### PR TITLE
Verify an image exists before running terraform apply

### DIFF
--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -3,6 +3,7 @@ package tarmak
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -18,6 +19,10 @@ func (t *Tarmak) Terraform() interfaces.Terraform {
 }
 
 func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
+	if err := t.verifyImageExists(); err != nil {
+		return err
+	}
+
 	if !t.flags.Cluster.Apply.ConfigurationOnly {
 		selectStacks := t.flags.Cluster.Apply.InfrastructureStacks
 
@@ -123,4 +128,17 @@ func (t *Tarmak) CmdTerraformShell(args []string) error {
 	}
 
 	return fmt.Errorf("you have to provide exactly one parameter that contains one of the stack names %s", strings.Join(stackNames, ", "))
+}
+
+func (t *Tarmak) verifyImageExists() error {
+	images, err := t.Packer().List()
+	if err != nil {
+		return err
+	}
+
+	if len(images) == 0 {
+		return errors.New("no images found")
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Verifies an image exists before running terraform apply. Exits with an error earlier.

**Which issue this PR fixes** 
fixes #19 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Verify at least one image exists before running terraform apply
```
