### PR TITLE
Disable insecure apiserver port

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -63,6 +63,10 @@ class kubernetes::apiserver(
     $_admission_control = $admission_control
   }
 
+  # Do not insecure bind the API server on kubernetes 1.6+
+  $insecure_port = $::kubernetes::_apiserver_insecure_port
+  $secure_port = $::kubernetes::apiserver_secure_port
+
   # Default to etcd3 for versions bigger than 1.5
   if $storage_backend == undef and versioncmp($::kubernetes::version, '1.5.0') >= 0 {
     $_storage_backend = 'etcd3'

--- a/puppet/modules/kubernetes/manifests/params.pp
+++ b/puppet/modules/kubernetes/manifests/params.pp
@@ -14,7 +14,6 @@ class kubernetes::params {
   $gid = 873
   $user = 'kubernetes'
   $group = 'kubernetes'
-  $master_url = 'http://127.0.0.1:8080'
   $curl_path = $::osfamily ? {
     'RedHat' => '/bin/curl',
     'Debian' => '/usr/bin/curl',

--- a/puppet/modules/kubernetes/spec/acceptance/single_node_spec.rb
+++ b/puppet/modules/kubernetes/spec/acceptance/single_node_spec.rb
@@ -12,12 +12,22 @@ describe '::kubernetes' do
     "test-#{SecureRandom.hex}"
   end
 
+  let :kubernetes_version do
+    if not ENV['KUBERNETES_VERSION'].nil?
+      "version => '#{ENV['KUBERNETES_VERSION']}',"
+    else
+      ''
+    end
+  end
+
   context 'test master and worker on a single node, no tls' do
     let :pp do
       "
 class{'kubernetes':
   cluster_name                 => '#{cluster_name}',
   service_account_key_generate => true,
+  apiserver_insecure_port => 8080,
+  #{kubernetes_version}
 }
 class{'kubernetes::master':
   disable_kubelet => true,

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -16,6 +16,12 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% else -%>
   --allow-privileged=false \
 <% end -%>
+<% if @secure_port -%>
+  --secure-port=<%= @secure_port %> \
+<% end -%>
+<% if @insecure_port -%>
+  --insecure-port=<%= @insecure_port %> \
+<% end -%>
 <% if @insecure_bind_address -%>
   --insecure-bind-address=<%= @insecure_bind_address %> \
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kubeconfig.erb
+++ b/puppet/modules/kubernetes/templates/kubeconfig.erb
@@ -5,7 +5,7 @@ current-context: default
 
 clusters:
 - cluster:
-    server: <%= scope['kubernetes::master_url'] %>
+    server: <%= scope['kubernetes::_master_url'] %>
 <% if @_ca_file or @ca_file  -%>
     certificate-authority: <%= @_ca_file || @ca_file %>
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kubectl-apply.service.erb
+++ b/puppet/modules/kubernetes/templates/kubectl-apply.service.erb
@@ -11,7 +11,11 @@ TimeoutStartSec=600
 Environment=KUBECONFIG=<%= scope['kubernetes::kubectl::kubeconfig_path'] %>
 RemainAfterExit=yes
 # Wait for API server to be healthy
-ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/healthz); if [ $STATUS -eq 200 ]; then break; fi; done"
+<%- if scope['kubernetes::_apiserver_insecure_port'] == 0 %>
+ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -k -w '%{http_code}' https://localhost:<%= scope['kubernetes::apiserver_secure_port'] %>/healthz); if [ $STATUS -eq 200 ]; then break; fi; done"
+<%- else -%>
+ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:<%= scope['kubernetes::_apiserver_insecure_port'] %>/healthz); if [ $STATUS -eq 200 ]; then break; fi; done"
+<%- end -%>
 # Apply template
 ExecStart=<%= @kubectl_path %> apply -f <%= @apply_file %>
 

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -34,7 +34,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --require-kubeconfig \
 <% end -%>
 <% else -%>
-  --api-servers=<%= scope['kubernetes::master_url'] %> \
+  --api-servers=<%= scope['kubernetes::_master_url'] %> \
 <% end -%>
 <% end -%>
 <% if @_node_labels_string and @_node_labels_string.length > 0 -%>


### PR DESCRIPTION
This pulls in the updates to the puppet modules to run the apiserver without an API server insecure port open.

Fixes #43 


```release-note
Disable apiserver binding insecure-port on the master
```
