### PR TITLE
Fix kubelet kube proxy systemd order

### DIFF
--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -1,17 +1,17 @@
 # class kubernetes::kubelet
 class kubernetes::kubelet(
-  $role = 'worker',
-  $container_runtime = 'docker',
-  $kubelet_dir = '/var/lib/kubelet',
-  $network_plugin = undef,
-  $network_plugin_mtu = 1460,
-  $allow_privileged = true,
-  $register_node = true,
-  $register_schedulable = undef,
-  $ca_file = undef,
-  $cert_file = undef,
-  $key_file = undef,
-  $client_ca_file = undef,
+  String $role = 'worker',
+  String $container_runtime = 'docker',
+  String $kubelet_dir = '/var/lib/kubelet',
+  Optional[String] $network_plugin = undef,
+  Integer $network_plugin_mtu = 1460,
+  Boolean $allow_privileged = true,
+  Boolean $register_node = true,
+  Optional[Boolean] $register_schedulable = undef,
+  Optional[String] $ca_file = undef,
+  Optional[String] $cert_file = undef,
+  Optional[String] $key_file = undef,
+  Optional[String] $client_ca_file = undef,
   $node_labels = undef,
   $node_taints = undef,
   $pod_cidr = undef,
@@ -20,8 +20,22 @@ class kubernetes::kubelet(
     'RedHat' => 'systemd',
     default  => 'cgroupfs',
   },
+  Array[String] $systemd_wants = [],
+  Array[String] $systemd_requires = [],
+  Array[String] $systemd_after = [],
+  Array[String] $systemd_before = [],
 ){
   require ::kubernetes
+
+  $_systemd_wants = $systemd_wants
+  if $container_runtime == 'docker' {
+    $_systemd_after = ['docker.service'] + $systemd_after
+    $_systemd_requires = ['docker.service'] + $systemd_after
+  } else {
+    $_systemd_after = $systemd_after
+    $_systemd_requires = $systemd_after
+  }
+  $_systemd_before = $systemd_before
 
   if $register_schedulable == undef {
     if $role == 'master' {

--- a/puppet/modules/kubernetes/manifests/proxy.pp
+++ b/puppet/modules/kubernetes/manifests/proxy.pp
@@ -1,12 +1,21 @@
 # class kubernetes::kubelet
 class kubernetes::proxy(
-  $ca_file = undef,
-  $cert_file = undef,
-  $key_file = undef,
+  Optional[String] $ca_file = undef,
+  Optional[String] $cert_file = undef,
+  Optional[String] $key_file = undef,
+  Array[String] $systemd_wants = [],
+  Array[String] $systemd_requires = [],
+  Array[String] $systemd_after = [],
+  Array[String] $systemd_before = [],
 ){
   require ::kubernetes
 
   $service_name = 'kube-proxy'
+
+  $_systemd_wants = $systemd_wants
+  $_systemd_after = $systemd_after
+  $_systemd_requires = $systemd_after
+  $_systemd_before = $systemd_before
 
   $kubeconfig_path = "${::kubernetes::config_dir}/kubeconfig-proxy"
   file{$kubeconfig_path:

--- a/puppet/modules/kubernetes/templates/kube-proxy.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy.service.erb
@@ -2,6 +2,7 @@
 Description=Kubernetes Kube-Proxy Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 After=network.target
+<%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -1,10 +1,7 @@
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-<% if $container_engine == 'docker' %>
-After=docker.service
-Requires=docker.service
-<% end -%>
+<%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
 WorkingDirectory=<%= @kubelet_dir %>

--- a/puppet/modules/tarmak/manifests/worker.pp
+++ b/puppet/modules/tarmak/manifests/worker.pp
@@ -33,16 +33,20 @@ class tarmak::worker {
   }
 
   class { 'kubernetes::kubelet':
-      ca_file        => "${kubelet_base_path}-ca.pem",
-      key_file       => "${kubelet_base_path}-key.pem",
-      cert_file      => "${kubelet_base_path}.pem",
-      client_ca_file => "${kubelet_base_path}-ca.pem",
+      ca_file          => "${kubelet_base_path}-ca.pem",
+      key_file         => "${kubelet_base_path}-key.pem",
+      cert_file        => "${kubelet_base_path}.pem",
+      client_ca_file   => "${kubelet_base_path}-ca.pem",
+      systemd_after    => ['kubelet-cert.service'],
+      systemd_requires => ['kubelet-cert.service'],
   }
 
   class { 'kubernetes::proxy':
-      ca_file   => "${proxy_base_path}-ca.pem",
-      key_file  => "${proxy_base_path}-key.pem",
-      cert_file => "${proxy_base_path}.pem",
+      ca_file          => "${proxy_base_path}-ca.pem",
+      key_file         => "${proxy_base_path}-key.pem",
+      cert_file        => "${proxy_base_path}.pem",
+      systemd_after    => ['kube-proxy-cert.service'],
+      systemd_requires => ['kube-proxy-cert.service'],
   }
 
   class { 'kubernetes::worker':


### PR DESCRIPTION
**What this PR does / why we need it**:

This make sure that kubelet and kube-proxy are started in the correct order when they are run without puppet

```release-note
Ensure systemd unit order for kubelet and kube-proxy
```

Subtree pull update, so self-lgtming that