### PR TITLE
vault helper docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,3 +49,4 @@ build and deploy Kubernetes in production at scale.
    known-issues
    existing-vpc
    vault-setup-config
+   vault-helper-guide

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -29,8 +29,13 @@ stdin
 init
 Golang
 refactoring
-kube
-ttl
+backends
+oneshot
 apiserver
+kube
 api
+ttl
+hostname
+configmap
 kubelet
+rolename

--- a/docs/vault-helper-guide.rst
+++ b/docs/vault-helper-guide.rst
@@ -11,7 +11,7 @@ cluster is in need of signed certificates from Vault to operate. These
 certificates need to be stored locally and regularly renewed.
 
 It is essential for the Vault stack to be executed and completed before the
-Kuebrnetes stacks as they rely on communication from Vault. With the Vault
+Kubernetes stacks as they rely on communication from Vault. With the Vault
 stack completed and the connection to the Vault server established, the
 vault-helper package is used to mount all backends (Etcd, Etcd overlay, K8s,
 K8s proxy and secrets generic) to Vault if they have not already. Mounts with

--- a/docs/vault-helper-guide.rst
+++ b/docs/vault-helper-guide.rst
@@ -25,13 +25,14 @@ idempotent.
 
 Vault is now set up correctly for each CA, tokens, roles and policies.
 
-The vault-helper binary is stored on all Kubernetes instances. Two cron jobs
-are run on every Kubernetes instance type in order to renew both tokens and
-certificates every day. These will trigger oneshot services
-(token-renewal.service, cert.service) to be fired, executing the locally stored
-vault-helper binary to renew certificates and tokens. When executing either
-renew-token or cert, vault-helper will recognise if an init-token is present in
-local file, generating a new unique token to be stored, deleting the
-init-token. The cert subcommand will ensure a private key is generated, if one
-does not exist, before sending a CSR to the Vault server. The returned signed
-certificate it then stored locally, replacing any previous certificates.
+The vault-helper binary is stored on all cluster instances (etcd, worker and
+master). Two Systemd timers are run on every cluster instance in order to
+renew both tokens and certificates every day. These will trigger oneshot
+services (token-renewal.service, cert.service) to be fired, executing the
+locally stored vault-helper binary to renew certificates and tokens. When
+executing either renew-token or cert, vault-helper will recognise if an
+init-token is present in local file, generating a new unique token to be
+stored, deleting the init-token. The cert subcommand will ensure a private key
+is generated, if one does not exist, before sending a CSR to the Vault server.
+The returned signed certificate it then stored locally, replacing any previous
+certificates.

--- a/docs/vault-helper-guide.rst
+++ b/docs/vault-helper-guide.rst
@@ -1,0 +1,37 @@
+.. _vault-helper-guide:
+
+Vault Helper In Tarmak
+======================
+
+`Vault <https://www.vaultproject.io>`_ is used in Tarmak to `provide a PKI
+(private key infrastructure) <vault-setup-config.html>`_. `vault-helper
+<https://github.com/jetstack/vault-helper>`_ is a tool designed to facilitate
+and automate the PKI tasks required. Each Kubernetes instance type in a Tarmak
+cluster is in need of signed certificates from Vault to operate. These
+certificates need to be stored locally and regularly renewed.
+
+It is essential for the Vault stack to be executed and completed before the
+Kuebrnetes stacks as they rely on communication from Vault. With the Vault
+stack completed and the connection to the Vault server established, the
+vault-helper package is used to mount all backends (Etcd, Etcd overlay, K8s,
+K8s proxy and secrets generic) to Vault if they have not already. Mounts with
+incorrect default or max lease TTLs will be re-tuned accordingly.
+
+These backends serve as the CAs for the Kubernetes components. Roles and then
+polices to these roles are written to each CA as described `here
+<vault-setup-config.html#certificate-roles-on-kubernetes-ca>`_.  The init-token
+polices and roles are then written to Vault also. This whole process is
+idempotent.
+
+Vault is now set up correctly for each CA, tokens, roles and policies.
+
+The vault-helper binary is stored on all Kubernetes instances. Two cron jobs
+are run on every Kubernetes instance type in order to renew both tokens and
+certificates every day. These will trigger oneshot services
+(token-renewal.service, cert.service) to be fired, executing the locally stored
+vault-helper binary to renew certificates and tokens. When executing either
+renew-token or cert, vault-helper will recognise if an init-token is present in
+local file, generating a new unique token to be stored, deleting the
+init-token. The cert subcommand will ensure a private key is generated, if one
+does not exist, before sending a CSR to the Vault server. The returned signed
+certificate it then stored locally, replacing any previous certificates.

--- a/docs/vault-setup-config.rst
+++ b/docs/vault-setup-config.rst
@@ -35,6 +35,9 @@ Three CA's are needed to provide multiple roles for each cluster as follows:
 
 * Verifying aggregated API calls (k8s-api-proxy)
     * single role for Kubernetes components (kube-apiserver-proxy)
+    * verified through a custom API server
+    * CA stored in the configmap extension-apiserver-authentication in the
+      kube-system namespace
 
 
 Init Tokens
@@ -66,15 +69,16 @@ restart all services which are dependant.
 Expiration of Tokens and Certificates
 -------------------------------------
 Both signed certificates and tokens issued to each instance are short lived
-meaning they need to be renewed regularly. A systemd timer is run on each
-instance that will periodically renew its certificate and token in time before
-expiry, ensuring all instances always have valid certificates. If an instance
-were to become offline or the Vault server became unreachable for a sufficient
-amount of time, certificates and tokens will no longer be renewable. If a
-certificate expires it will become invalid and will cause the relevant
-operation to be halted until its certificates are renewed. If an instance's
-unique token is not renewed, it will no longer be able to ever authenticate
-itself against Vault and so will need to be replaced.
+meaning they need to be renewed regularly. Two Systemd timers `cert.timer` and
+`token-renewal.timer` are run on each instance that will renew its
+certificate and token at a default value of 24 hours. This ensures all
+instances always have valid certificates. If an instance were to become offline
+or the Vault server became unreachable for a sufficient amount of time,
+certificates and tokens will no longer be renewable. If a certificate expires
+it will become invalid and will cause the relevant operation to be halted until
+its certificates are renewed. If an instance's unique token is not renewed, it
+will no longer be able to ever authenticate itself against Vault and so will
+need to be replaced.
 
 Certificate Roles on Kubernetes CA
 ----------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds vault-helper documentation to Tarmak

== Rebased on top of vault helper/setup docs https://github.com/jetstack/tarmak/pull/51 due to link dependency ==

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #57 

```release-note
`NONE`
```
