### PR TITLE
Retry verify ssh connection to bastion

### DIFF
--- a/pkg/tarmak/stack/tools_stack.go
+++ b/pkg/tarmak/stack/tools_stack.go
@@ -2,7 +2,15 @@
 package stack
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/cenkalti/backoff"
 
 	clusterv1alpha1 "github.com/jetstack/tarmak/pkg/apis/cluster/v1alpha1"
 	tarmakv1alpha1 "github.com/jetstack/tarmak/pkg/apis/tarmak/v1alpha1"
@@ -42,20 +50,60 @@ func (s *ToolsStack) verifyBastionAvailable() error {
 		return err
 	}
 
-	retCode, err := ssh.Execute(
-		"bastion",
-		"/bin/true",
-		[]string{},
-	)
+	//Ensure go routine exits before returning
+	finished := make(chan struct{})
+	var wg sync.WaitGroup
+	defer wg.Wait()
 
-	msg := "error while connectioning to bastion host"
-	if err != nil {
-		return fmt.Errorf("%s: %s", msg, err)
+	//Capture signals to cancel ssh retry
+	ctx, cancelRetries := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+
+	wg.Add(1)
+	go func() {
+		select {
+		case <-ch:
+			cancelRetries()
+		case <-finished:
+		}
+		signal.Stop(ch)
+		wg.Done()
+		return
+	}()
+
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = time.Second
+	expBackoff.MaxElapsedTime = time.Minute * 1
+	b := backoff.WithContext(expBackoff, ctx)
+
+	executeSSH := func() error {
+		retCode, err := ssh.Execute(
+			"bastion",
+			"/bin/true",
+			[]string{},
+		)
+
+		msg := "error while connecting to bastion host"
+		if err != nil {
+			err = fmt.Errorf("%s: %v", msg, err)
+			s.log.Warnf(err.Error())
+			return err
+		}
+		if retCode != 0 {
+			err = fmt.Errorf("%s unexpected return code: %d", msg, retCode)
+			s.log.Warn(err.Error())
+			return err
+		}
+
+		return nil
 	}
-	if retCode != 0 {
-		return fmt.Errorf("%s unexpected return code: %d", msg, retCode)
+
+	err := backoff.Retry(executeSSH, b)
+	close(finished)
+	if err != nil {
+		return fmt.Errorf("failed to connect to bastion host: %v", err)
 	}
 
 	return nil
-
 }


### PR DESCRIPTION
* Adds exponential backoff to verify bastion ssh connection
* Quits after 1 min / SIGTERM/INT
* Fixes #56

**What this PR does / why we need it**:
Tarmak apply sometimes returns error when verifying bastion connection before bastion is finished spinning up

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #56 

```release-note
Retry SSH connection to bastion during tools stack
```
/assign @simonswine 