### PR TITLE
Look for SSH config correctly in multi cluster environments

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -338,13 +338,9 @@ func (c *Cluster) ConfigPath() string {
 	return filepath.Join(c.Environment().Tarmak().ConfigPath(), c.ClusterName())
 }
 
-func (c *Cluster) HubName() string {
-	return fmt.Sprintf("%s-%s", c.environment.Name(), clusterv1alpha1.ClusterTypeHub)
-}
-
 func (c *Cluster) SSHConfigPath() string {
 	if c.Type() == clusterv1alpha1.ClusterTypeClusterMulti {
-		return filepath.Join(c.Environment().Tarmak().ConfigPath(), c.HubName(), "ssh_config")
+		return filepath.Join(c.Environment().Tarmak().ConfigPath(), c.Environment().HubName(), "ssh_config")
 	}
 	return filepath.Join(c.ConfigPath(), "ssh_config")
 }

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -338,7 +338,14 @@ func (c *Cluster) ConfigPath() string {
 	return filepath.Join(c.Environment().Tarmak().ConfigPath(), c.ClusterName())
 }
 
+func (c *Cluster) HubName() string {
+	return fmt.Sprintf("%s-%s", c.environment.Name(), clusterv1alpha1.ClusterTypeHub)
+}
+
 func (c *Cluster) SSHConfigPath() string {
+	if c.Type() == clusterv1alpha1.ClusterTypeClusterMulti {
+		return filepath.Join(c.Environment().Tarmak().ConfigPath(), c.HubName(), "ssh_config")
+	}
 	return filepath.Join(c.ConfigPath(), "ssh_config")
 }
 

--- a/pkg/tarmak/environment/environment.go
+++ b/pkg/tarmak/environment/environment.go
@@ -91,6 +91,10 @@ func (e *Environment) Name() string {
 	return e.conf.Name
 }
 
+func (c *Environment) HubName() string {
+	return fmt.Sprintf("%s-%s", c.Name(), clusterv1alpha1.ClusterTypeHub)
+}
+
 func (e *Environment) Config() *tarmakv1alpha1.Environment {
 	return e.conf.DeepCopy()
 }

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -58,6 +58,7 @@ type Environment interface {
 	Provider() Provider
 	Validate() error
 	Name() string
+	HubName() string
 	BucketPrefix() string
 	Clusters() []Cluster
 	Cluster(name string) (cluster Cluster, err error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: In multi-cluster environments, tarmak k8s clusters should look for vault cluster ssh credentials in the hub's folder rather than look in the cluster's folder

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
