### PR TITLE
Update terraform to 0.11 and update plugins to latest releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+### Versions
+
+| Application | Supported versions | Default  |
+|-------------|-------------------:|---------:|
+| Packer      |                    | `1.0.2`  |
+| Terraform   |                    | `0.10.8` |
+| Consul      |                    | `1.0.2`  |
+| Vault       |                    | `0.9.1`  |
+| Kubernetes  | `>= 1.6 && < 1.10` | `1.7.10` |
+
 ## [0.2.1]: 0.2.1 - 2017-12-05
 
 ### Fixed

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -4,8 +4,8 @@ FROM alpine:3.6
 RUN apk add --no-cache unzip curl
 
 # install terraform
-ENV TERRAFORM_VERSION 0.10.8
-ENV TERRAFORM_HASH b786c0cf936e24145fad632efd0fe48c831558cc9e43c071fffd93f35e3150db
+ENV TERRAFORM_VERSION 0.11.2
+ENV TERRAFORM_HASH f728fa73ff2a4c4235a28de4019802531758c7c090b6ca4c024d48063ab8537b
 RUN curl -sL  https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > /tmp/terraform.zip && \
     echo "${TERRAFORM_HASH}  /tmp/terraform.zip" | sha256sum  -c && \
     unzip /tmp/terraform.zip && \

--- a/terraform/amazon/kubernetes/iam_policies.tf
+++ b/terraform/amazon/kubernetes/iam_policies.tf
@@ -2,7 +2,7 @@ data "template_file" "iam_tarmak_bucket_read" {
   template = "${file("${path.module}/templates/iam_tarmak_bucket_read.json")}"
 
   vars {
-    puppet_tar_gz_bucket_path = "${data.terraform_remote_state.hub_state.secrets_bucket}/${aws_s3_bucket_object.puppet-tar-gz.key}"
+    puppet_tar_gz_bucket_path = "${data.terraform_remote_state.hub_state.secrets_bucket.0}/${aws_s3_bucket_object.puppet-tar-gz.key}"
   }
 }
 

--- a/terraform/amazon/kubernetes/providers.tf
+++ b/terraform/amazon/kubernetes/providers.tf
@@ -1,14 +1,10 @@
 provider "aws" {
   region              = "${var.region}"
   allowed_account_ids = ["${var.allowed_account_ids}"]
-  version             = "~> 1.0"
+  version             = "~> 1.7.1"
 }
 
 provider "template" {
-  version = "~> 1.0"
-}
-
-provider "terraform" {
   version = "~> 1.0"
 }
 

--- a/terraform/amazon/kubernetes/puppet_s3.tf
+++ b/terraform/amazon/kubernetes/puppet_s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket_object" "puppet-tar-gz" {
   key          = "${data.template_file.stack_name.rendered}/puppet.tar.gz"
-  bucket       = "${data.terraform_remote_state.hub_state.secrets_bucket}"
+  bucket       = "${data.terraform_remote_state.hub_state.secrets_bucket.0}"
   content_type = "application/tar+gzip"
   source       = "puppet.tar.gz"
   etag         = "${md5(file("puppet.tar.gz"))}"

--- a/terraform/amazon/network-existing-vpc/aws.tf
+++ b/terraform/amazon/network-existing-vpc/aws.tf
@@ -1,13 +1,9 @@
 provider "aws" {
   region              = "${var.region}"
   allowed_account_ids = ["${var.allowed_account_ids}"]
-  version             = "~> 1.0"
+  version             = "~> 1.7.1"
 }
 
 provider "template" {
-  version = "~> 1.0"
-}
-
-provider "terraform" {
   version = "~> 1.0"
 }

--- a/terraform/amazon/network-existing-vpc/vpc.tf
+++ b/terraform/amazon/network-existing-vpc/vpc.tf
@@ -1,3 +1,3 @@
 data "aws_vpc" "main" {
-    id = "${var.vpc_id}"
+  id = "${var.vpc_id}"
 }

--- a/terraform/amazon/network/aws.tf
+++ b/terraform/amazon/network/aws.tf
@@ -1,13 +1,9 @@
 provider "aws" {
   region              = "${var.region}"
   allowed_account_ids = ["${var.allowed_account_ids}"]
-  version             = "~> 1.0"
+  version             = "~> 1.7.1"
 }
 
 provider "template" {
-  version = "~> 1.0"
-}
-
-provider "terraform" {
   version = "~> 1.0"
 }

--- a/terraform/amazon/network/outputs.tf
+++ b/terraform/amazon/network/outputs.tf
@@ -39,11 +39,11 @@ output "route_table_private_ids" {
 }
 
 output "private_zone_id" {
-  value = "${aws_route53_zone.private.id}"
+  value = ["${aws_route53_zone.private.*.id}"]
 }
 
 output "private_zone" {
-  value = "${aws_route53_zone.private.name}"
+  value = ["${aws_route53_zone.private.*.name}"]
 }
 
 output "environment" {

--- a/terraform/amazon/state/aws.tf
+++ b/terraform/amazon/state/aws.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region              = "${var.region}"
   allowed_account_ids = ["${var.allowed_account_ids}"]
-  version             = "~> 1.0"
+  version             = "~> 1.7.1"
 }
 
 provider "template" {

--- a/terraform/amazon/state/backup.tf
+++ b/terraform/amazon/state/backup.tf
@@ -44,9 +44,9 @@ resource "aws_kms_alias" "backups" {
 }
 
 output "backups_bucket" {
-  value = "${aws_s3_bucket.backups.bucket}"
+  value = "${aws_s3_bucket.backups.*.bucket}"
 }
 
 output "backups_kms_arn" {
-  value = "${aws_kms_key.backups.arn}"
+  value = "${aws_kms_key.backups.*.arn}"
 }

--- a/terraform/amazon/state/outputs.tf
+++ b/terraform/amazon/state/outputs.tf
@@ -15,7 +15,7 @@ output "public_zone" {
 }
 
 output "jenkins_data_volume_id" {
-  value = "${aws_ebs_volume.jenkins.id}"
+  value = "${aws_ebs_volume.jenkins.*.id}"
 }
 
 output "bucket_prefix" {

--- a/terraform/amazon/state/secrets.tf
+++ b/terraform/amazon/state/secrets.tf
@@ -24,9 +24,9 @@ resource "aws_kms_alias" "secrets" {
 }
 
 output "secrets_bucket" {
-  value = "${aws_s3_bucket.secrets.bucket}"
+  value = "${aws_s3_bucket.secrets.*.bucket}"
 }
 
 output "secrets_kms_arn" {
-  value = "${aws_kms_key.secrets.arn}"
+  value = "${aws_kms_key.secrets.*.arn}"
 }

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -10,13 +10,13 @@ data "template_file" "{{.TFName}}_user_data" {
   vars {
     region = "${var.region}"
 
-    puppet_tar_gz_bucket_path = "${data.terraform_remote_state.hub_state.secrets_bucket}/${aws_s3_bucket_object.puppet-tar-gz.key}"
+    puppet_tar_gz_bucket_path = "${data.terraform_remote_state.hub_state.secrets_bucket.0}/${aws_s3_bucket_object.puppet-tar-gz.key}"
 
     vault_token = "${var.vault_init_token_{{.Role.Name}}}"
     vault_ca    = "${base64encode(data.terraform_remote_state.hub_vault.vault_ca)}"
     vault_url   = "${data.terraform_remote_state.hub_vault.vault_url}"
 
-    tarmak_dns_root      = "${data.terraform_remote_state.hub_network.private_zone}"
+    tarmak_dns_root      = "${data.terraform_remote_state.hub_network.private_zone.0}"
     tarmak_role          = "{{.Role.Name}}"
     tarmak_instance_pool = "{{.Name}}"
     tarmak_cluster       = "${data.template_file.stack_name.rendered}"
@@ -206,7 +206,7 @@ resource "aws_ebs_volume" "{{$instancePool.TFName}}_{{.Name}}" {
 
 {{ end -}}
 resource "aws_route53_record" "{{.TFName}}" {
-  zone_id = "${data.terraform_remote_state.hub_network.private_zone_id}"
+  zone_id = "${data.terraform_remote_state.hub_network.private_zone_id.0}"
   name    = "etcd-${count.index+1}.${data.template_file.stack_name.rendered}"
   type    = "A"
   ttl     = "300"

--- a/terraform/amazon/templates/instance_pools/role_elb.tf.template
+++ b/terraform/amazon/templates/instance_pools/role_elb.tf.template
@@ -34,7 +34,7 @@ resource "aws_elb" "{{.TFName}}" {
 }
 
 resource "aws_route53_record" "{{.TFName}}_api" {
-  zone_id = "${data.terraform_remote_state.hub_network.private_zone_id}"
+  zone_id = "${data.terraform_remote_state.hub_network.private_zone_id.0}"
   name    = "api.${data.template_file.stack_name.rendered}"
   type    = "A"
 

--- a/terraform/amazon/tools/aws.tf
+++ b/terraform/amazon/tools/aws.tf
@@ -1,14 +1,10 @@
 provider "aws" {
   region              = "${var.region}"
   allowed_account_ids = ["${var.allowed_account_ids}"]
-  version             = "~> 1.0"
+  version             = "~> 1.7.1"
 }
 
 provider "template" {
-  version = "~> 1.0"
-}
-
-provider "terraform" {
   version = "~> 1.0"
 }
 

--- a/terraform/amazon/tools/bastion.tf
+++ b/terraform/amazon/tools/bastion.tf
@@ -84,7 +84,7 @@ resource "aws_route53_record" "bastion" {
 }
 
 resource "aws_route53_record" "bastion_private" {
-  zone_id = "${data.terraform_remote_state.network.private_zone_id}"
+  zone_id = "${data.terraform_remote_state.network.private_zone_id.0}"
   name    = "bastion.${var.environment}"
   type    = "A"
   ttl     = "60"

--- a/terraform/amazon/vault/aws.tf
+++ b/terraform/amazon/vault/aws.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region              = "${var.region}"
   allowed_account_ids = ["${var.allowed_account_ids}"]
-  version             = "~> 1.0"
+  version             = "~> 1.7.1"
 }
 
 data "aws_caller_identity" "current" {
@@ -12,14 +12,10 @@ provider "template" {
   version = "~> 1.0"
 }
 
-provider "terraform" {
-  version = "~> 1.0"
-}
-
 provider "random" {
-  version = "~> 1.0"
+  version = "~> 1.1"
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 1.0.1"
 }

--- a/terraform/amazon/vault/tls.tf
+++ b/terraform/amazon/vault/tls.tf
@@ -42,8 +42,8 @@ resource "tls_cert_request" "vault" {
   }
 
   dns_names = [
-    "vault.${data.terraform_remote_state.network.private_zone}",
-    "vault-${count.index + 1}.${data.terraform_remote_state.network.private_zone}",
+    "vault.${data.terraform_remote_state.network.private_zone.0}",
+    "vault-${count.index + 1}.${data.terraform_remote_state.network.private_zone.0}",
     "localhost",
   ]
 

--- a/terraform/amazon/vault/tls_s3.tf
+++ b/terraform/amazon/vault/tls_s3.tf
@@ -1,25 +1,25 @@
 resource "aws_s3_bucket_object" "node-certs" {
   count        = "${var.instance_count}"
   key          = "vault/vault-${count.index+1}.pem-${md5(element(tls_locally_signed_cert.vault.*.cert_pem, count.index))}"
-  bucket       = "${data.terraform_remote_state.state.secrets_bucket}"
+  bucket       = "${data.terraform_remote_state.state.secrets_bucket.0}"
   content      = "${element(tls_locally_signed_cert.vault.*.cert_pem, count.index)}"
   content_type = "text/plain"
-  kms_key_id   = "${data.terraform_remote_state.state.secrets_kms_arn}"
+  kms_key_id   = "${data.terraform_remote_state.state.secrets_kms_arn.0}"
 }
 
 resource "aws_s3_bucket_object" "node-keys" {
   count        = "${var.instance_count}"
   key          = "vault/vault-${count.index+1}-key.pem-${md5(element(tls_private_key.vault.*.private_key_pem, count.index))}"
-  bucket       = "${data.terraform_remote_state.state.secrets_bucket}"
+  bucket       = "${data.terraform_remote_state.state.secrets_bucket.0}"
   content      = "${element(tls_private_key.vault.*.private_key_pem, count.index)}"
   content_type = "text/plain"
-  kms_key_id   = "${data.terraform_remote_state.state.secrets_kms_arn}"
+  kms_key_id   = "${data.terraform_remote_state.state.secrets_kms_arn.0}"
 }
 
 resource "aws_s3_bucket_object" "ca-cert" {
   key          = "vault/ca.pem-${md5(tls_self_signed_cert.ca.cert_pem)}"
-  bucket       = "${data.terraform_remote_state.state.secrets_bucket}"
-  kms_key_id   = "${data.terraform_remote_state.state.secrets_kms_arn}"
+  bucket       = "${data.terraform_remote_state.state.secrets_bucket.0}"
+  kms_key_id   = "${data.terraform_remote_state.state.secrets_kms_arn.0}"
   content      = "${tls_self_signed_cert.ca.cert_pem}"
   content_type = "text/plain"
 }

--- a/terraform/amazon/vault/variables.tf
+++ b/terraform/amazon/vault/variables.tf
@@ -72,7 +72,7 @@ output "vault_url" {
 }
 
 output "vault_kms_key_id" {
-  value = "${element(split("/", data.terraform_remote_state.network.secrets_kms_arn), 1)}"
+  value = "${element(split("/", data.terraform_remote_state.state.secrets_kms_arn.0), 1)}"
 }
 
 output "vault_unseal_key_name" {

--- a/terraform/amazon/vault/vault_dns.tf
+++ b/terraform/amazon/vault/vault_dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "per-instance" {
   count   = "${var.instance_count}"
-  zone_id = "${data.terraform_remote_state.network.private_zone_id}"
+  zone_id = "${data.terraform_remote_state.network.private_zone_id.0}"
   name    = "vault-${count.index + 1}"
   type    = "A"
   ttl     = "180"
@@ -8,7 +8,7 @@ resource "aws_route53_record" "per-instance" {
 }
 
 resource "aws_route53_record" "endpoint" {
-  zone_id = "${data.terraform_remote_state.network.private_zone_id}"
+  zone_id = "${data.terraform_remote_state.network.private_zone_id.0}"
   name    = "vault"
   type    = "A"
   ttl     = "180"

--- a/terraform/amazon/vault/vault_iam.tf
+++ b/terraform/amazon/vault/vault_iam.tf
@@ -28,14 +28,14 @@ data "template_file" "vault_policy" {
     volume_id   = "${element(aws_ebs_volume.vault.*.id, count.index)}"
     instance_id = "${element(aws_instance.vault.*.id, count.index)}"
 
-    backup_bucket_prefix = "${data.terraform_remote_state.state.backups_bucket}/${data.template_file.stack_name.rendered}-vault-${count.index+1}"
-    backup_bucket        = "${data.terraform_remote_state.state.backups_bucket}"
+    backup_bucket_prefix = "${data.terraform_remote_state.state.backups_bucket.0}/${data.template_file.stack_name.rendered}-vault-${count.index+1}"
+    backup_bucket        = "${data.terraform_remote_state.state.backups_bucket.0}"
 
-    secrets_bucket                = "${data.terraform_remote_state.state.secrets_bucket}"
+    secrets_bucket                = "${data.terraform_remote_state.state.secrets_bucket.0}"
     vault_tls_cert_path           = "${element(aws_s3_bucket_object.node-certs.*.key, count.index)}"
     vault_tls_key_path            = "${element(aws_s3_bucket_object.node-keys.*.key, count.index)}"
     vault_tls_ca_path             = "${aws_s3_bucket_object.ca-cert.key}"
-    vault_unsealer_kms_key_id     = "${data.terraform_remote_state.state.secrets_kms_arn}"
+    vault_unsealer_kms_key_id     = "${data.terraform_remote_state.state.secrets_kms_arn.0}"
     vault_unsealer_ssm_key_prefix = "${data.template_file.vault_unseal_key_name.rendered}"
   }
 }

--- a/terraform/amazon/vault/vault_instances.tf
+++ b/terraform/amazon/vault/vault_instances.tf
@@ -3,7 +3,7 @@ data "template_file" "vault" {
   count    = "${var.instance_count}"
 
   vars {
-    fqdn           = "vault-${count.index + 1}.${data.terraform_remote_state.network.private_zone}"
+    fqdn           = "vault-${count.index + 1}.${data.terraform_remote_state.network.private_zone.0}"
     environment    = "${var.environment}"
     region         = "${var.region}"
     instance_count = "${var.instance_count}"
@@ -17,14 +17,14 @@ data "template_file" "vault" {
     consul_encrypt = "${replace(replace(random_id.consul_encrypt.b64,"-","+"),"_","/")}=="
 
     vault_version       = "${var.vault_version}"
-    vault_tls_cert_path = "s3://${data.terraform_remote_state.state.secrets_bucket}/${element(aws_s3_bucket_object.node-certs.*.key, count.index)}"
-    vault_tls_key_path  = "s3://${data.terraform_remote_state.state.secrets_bucket}/${element(aws_s3_bucket_object.node-keys.*.key, count.index)}"
-    vault_tls_ca_path   = "s3://${data.terraform_remote_state.state.secrets_bucket}/${aws_s3_bucket_object.ca-cert.key}"
+    vault_tls_cert_path = "s3://${data.terraform_remote_state.state.secrets_bucket.0}/${element(aws_s3_bucket_object.node-certs.*.key, count.index)}"
+    vault_tls_key_path  = "s3://${data.terraform_remote_state.state.secrets_bucket.0}/${element(aws_s3_bucket_object.node-keys.*.key, count.index)}"
+    vault_tls_ca_path   = "s3://${data.terraform_remote_state.state.secrets_bucket.0}/${aws_s3_bucket_object.ca-cert.key}"
 
-    vault_unsealer_kms_key_id     = "${data.terraform_remote_state.state.secrets_kms_arn}"
+    vault_unsealer_kms_key_id     = "${data.terraform_remote_state.state.secrets_kms_arn.0}"
     vault_unsealer_ssm_key_prefix = "${data.template_file.vault_unseal_key_name.rendered}"
 
-    backup_bucket_prefix = "${data.terraform_remote_state.state.backups_bucket}/${data.template_file.stack_name.rendered}-vault-${count.index+1}"
+    backup_bucket_prefix = "${data.terraform_remote_state.state.backups_bucket.0}/${data.template_file.stack_name.rendered}-vault-${count.index+1}"
 
     # run backup once per instance spread throughout the day
     backup_schedule = "*-*-* ${format("%02d",count.index * (24/var.instance_count))}:00:00"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,19 +1,15 @@
 provider "aws" {
-  version = "~> 1.0"
+  version = "~> 1.7.1"
 }
 
 provider "template" {
   version = "~> 1.0"
 }
 
-provider "terraform" {
-  version = "~> 1.0"
-}
-
 provider "random" {
-  version = "~> 1.0"
+  version = "~> 1.1"
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 1.0.1"
 }


### PR DESCRIPTION
Terraform 0.11 requires dynamic resource outputs to be lists the required
quite a bit of refactoring.

```release-note
Update terraform to 0.11
```

fixes #84 