### PR TITLE
Fix existing VPC docs

### DIFF
--- a/docs/existing-vpc.rst
+++ b/docs/existing-vpc.rst
@@ -62,9 +62,10 @@ For example, if we have the following infrastructure (notation in terraform)::
 		}
 
 		resource "aws_nat_gateway" "main" {
+		  count         = "${length(aws_subnet.public)}"
 		  depends_on    = ["aws_internet_gateway.main"]
 		  allocation_id = "${aws_eip.nat.id}"
-		  subnet_id     = "${aws_subnet.public.1.id}"
+		  subnet_id     = "${aws_subnet.public.*.id[count.index]}"
 		}
 
 		resource "aws_route_table" "public" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: The docs for deploying tarmak into an existing VPC used an incorrect index for accessing the names of the public subnet resource. This PR fixes that


```release-note
NONE
```

