### PR TITLE
Implement flag to keep terraform containers around

### DIFF
--- a/cmd/tarmak/cmd/root.go
+++ b/cmd/tarmak/cmd/root.go
@@ -43,4 +43,11 @@ func init() {
 		false,
 		"enable verbose logging",
 	)
+
+	RootCmd.PersistentFlags().BoolVar(
+		&globalFlags.KeepContainers,
+		"keep-containers",
+		false,
+		"do not clean-up terraform/packer containers after running them",
+	)
 }

--- a/pkg/apis/tarmak/v1alpha1/types.go
+++ b/pkg/apis/tarmak/v1alpha1/types.go
@@ -116,6 +116,7 @@ type Image struct {
 type Flags struct {
 	Verbose         bool   // logrus log level to run with
 	ConfigDirectory string // path to config directory
+	KeepContainers  bool   // do not clean-up terraform/packer containers after running them
 
 	Initialize bool // run tarmak in initialize mode, don't parse config before rnning init
 

--- a/pkg/docker/app_container.go
+++ b/pkg/docker/app_container.go
@@ -18,9 +18,11 @@ type AppContainer struct {
 
 	dockerContainer *docker.Container
 
-	WorkingDir string
-	Env        []string
-	Cmd        []string
+	WorkingDir string   // working dir inside the container
+	Env        []string // environment variables
+	Cmd        []string // command to run in the container
+	Keep       bool     // don't cleanup containers
+
 }
 
 func (ac *AppContainer) SetLog(log *logrus.Entry) {
@@ -84,6 +86,11 @@ func (ac *AppContainer) CleanUp() error {
 		if err != nil {
 			return fmt.Errorf("error sending KILL signal to container %s: %s", ac.dockerContainer.ID, err)
 		}
+	}
+
+	if ac.Keep {
+		ac.log.Debug("keep container as requested")
+		return nil
 	}
 
 	return ac.app.dockerClient.RemoveContainer(docker.RemoveContainerOptions{ID: ac.dockerContainer.ID})

--- a/pkg/packer/image.go
+++ b/pkg/packer/image.go
@@ -60,6 +60,7 @@ func (i *image) Build(ctx context.Context) (amiID string, err error) {
 
 	c.WorkingDir = "/packer"
 	c.Cmd = []string{"sleep", "3600"}
+	c.Keep = i.packer.tarmak.KeepContainers()
 
 	err = c.Prepare()
 	if err != nil {

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -135,6 +135,7 @@ type Tarmak interface {
 	SSH() SSH
 	HomeDirExpand(in string) (string, error)
 	HomeDir() string
+	KeepContainers() bool
 }
 
 type Config interface {

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -227,6 +227,10 @@ func (t *Tarmak) HomeDirExpand(in string) (string, error) {
 	return homedir.Expand(in)
 }
 
+func (t *Tarmak) KeepContainers() bool {
+	return t.flags.KeepContainers
+}
+
 func (t *Tarmak) ConfigPath() string {
 	return t.configDirectory
 }

--- a/pkg/terraform/container.go
+++ b/pkg/terraform/container.go
@@ -248,6 +248,7 @@ func (tc *TerraformContainer) prepare() error {
 	// set default commandpfals
 	tc.Cmd = []string{"sleep", "3600"}
 	tc.WorkingDir = "/terraform"
+	tc.Keep = tc.t.tarmak.KeepContainers()
 
 	// build terraform image if needed
 	tc.log.Debug("prepare container")


### PR DESCRIPTION

**What this PR does / why we need it**:

Allows to keep terraform containers around instead of being cleaned up. Help with debugging issues

```release-note
Add `--keep-containers` flag to preserve container environment launched by tarmak
```
