### PR TITLE
Use same local IP as tunnel binds to

### DIFF
--- a/pkg/tarmak/kubectl/kubectl.go
+++ b/pkg/tarmak/kubectl/kubectl.go
@@ -140,7 +140,7 @@ func (k *Kubectl) ensureConfig() error {
 	c := api.NewConfig()
 	configPath := k.ConfigPath()
 
-	// cluster name in tamrak is cluster name in kubeconfig
+	// cluster name in tarmak is cluster name in kubeconfig
 	key := k.tarmak.Cluster().ClusterName()
 
 	// load an existing config
@@ -206,8 +206,10 @@ func (k *Kubectl) ensureConfig() error {
 			if err != nil {
 				return err
 			}
-			cluster.Server = fmt.Sprintf("https://localhost:%d", tunnel.Port())
+			cluster.Server = fmt.Sprintf("https://%s:%d", tunnel.BindAddress(), tunnel.Port())
 		}
+
+		k.log.Debugf("trying to connect to %+v", cluster.Server)
 
 		version, err := k.verifyAPIVersion(*c)
 		if err == nil {
@@ -219,7 +221,7 @@ func (k *Kubectl) ensureConfig() error {
 				return err
 			}
 		} else {
-			k.log.Debugf("error connecting to cluster: %s", err)
+			k.log.Warnf("error connecting to cluster: %s", err)
 		}
 
 		retries -= 1


### PR DESCRIPTION
This fixes issues with machines that can't resolve localhost to
127.0.0.1

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use same tunnel address as specified for SSH, fixes tunnels on hosts that can't resolve localhost
```
