### PR TITLE
Clean up tarmak after execution

### DIFF
--- a/cmd/tarmak/cmd/cluster_apply.go
+++ b/cmd/tarmak/cmd/cluster_apply.go
@@ -36,6 +36,7 @@ var clusterApplyCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
 				return t.CmdTerraformApply(args, ctx)

--- a/cmd/tarmak/cmd/cluster_debug_puppet_build-tar.go
+++ b/cmd/tarmak/cmd/cluster_debug_puppet_build-tar.go
@@ -16,6 +16,7 @@ var clusterDebugPuppetBuildTarCmd = &cobra.Command{
 	Short: "Build a puppet.tar.gz in the current working directory",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 
 		path := "puppet.tar.gz"
 

--- a/cmd/tarmak/cmd/cluster_debug_terraform_shell.go
+++ b/cmd/tarmak/cmd/cluster_debug_terraform_shell.go
@@ -12,6 +12,7 @@ var clusterDebugTerraformShellCmd = &cobra.Command{
 	Short: "Prepares a Terraform container and executes a shell in this container",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.CmdTerraformShell(args))
 	},
 }

--- a/cmd/tarmak/cmd/cluster_destroy.go
+++ b/cmd/tarmak/cmd/cluster_destroy.go
@@ -24,6 +24,7 @@ var clusterDestroyCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
 				return t.CmdTerraformDestroy(args, ctx)

--- a/cmd/tarmak/cmd/cluster_images_build.go
+++ b/cmd/tarmak/cmd/cluster_images_build.go
@@ -15,6 +15,7 @@ var clusterImagesBuildCmd = &cobra.Command{
 	Short: "build images",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
 				return t.Packer().Build(ctx)

--- a/cmd/tarmak/cmd/cluster_images_list.go
+++ b/cmd/tarmak/cmd/cluster_images_list.go
@@ -17,6 +17,7 @@ var clusterImagesListCmd = &cobra.Command{
 	Short: "list images",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 0, 8, 0, '\t', 0)

--- a/cmd/tarmak/cmd/cluster_init.go
+++ b/cmd/tarmak/cmd/cluster_init.go
@@ -14,6 +14,7 @@ var clusterInitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		globalFlags.Initialize = true
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.CmdClusterInit())
 	},
 }

--- a/cmd/tarmak/cmd/cluster_instances_list.go
+++ b/cmd/tarmak/cmd/cluster_instances_list.go
@@ -16,6 +16,7 @@ var clusterInstancesListCmd = &cobra.Command{
 	Short: "Print a list of instances in the cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		hosts, err := t.Cluster().ListHosts()
 		if err != nil {
 			logrus.Fatal(err)

--- a/cmd/tarmak/cmd/cluster_instances_ssh.go
+++ b/cmd/tarmak/cmd/cluster_instances_ssh.go
@@ -12,6 +12,7 @@ var clusterInstancesSshCmd = &cobra.Command{
 	Short: "Log into an instance with SSH",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.SSHPassThrough(args)
 	},
 }

--- a/cmd/tarmak/cmd/cluster_kubectl.go
+++ b/cmd/tarmak/cmd/cluster_kubectl.go
@@ -12,6 +12,7 @@ var clusterKubectlCmd = &cobra.Command{
 	Short: "Run kubectl on the current cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.CmdKubectl(args))
 	},
 	DisableFlagParsing: true,

--- a/cmd/tarmak/cmd/cluster_list.go
+++ b/cmd/tarmak/cmd/cluster_list.go
@@ -15,6 +15,7 @@ var clusterListCmd = &cobra.Command{
 	Short: "Print a list of clusters",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 
 		varMaps := make([]map[string]string, 0)
 		for _, env := range t.Environments() {

--- a/cmd/tarmak/cmd/cluster_ssh.go
+++ b/cmd/tarmak/cmd/cluster_ssh.go
@@ -12,6 +12,7 @@ var clusterSshCmd = &cobra.Command{
 	Short: "Log into an instance with SSH",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.SSHPassThrough(args)
 	},
 }

--- a/cmd/tarmak/cmd/environment_init.go
+++ b/cmd/tarmak/cmd/environment_init.go
@@ -14,6 +14,7 @@ var environmentInitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		globalFlags.Initialize = true
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.CmdEnvironmentInit())
 	},
 }

--- a/cmd/tarmak/cmd/environment_list.go
+++ b/cmd/tarmak/cmd/environment_list.go
@@ -15,6 +15,7 @@ var environmentListCmd = &cobra.Command{
 	Short: "Print a list of environments",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		varMaps := make([]map[string]string, 0)
 		for _, env := range t.Environments() {
 			varMaps = append(varMaps, env.Parameters())

--- a/cmd/tarmak/cmd/kubectl.go
+++ b/cmd/tarmak/cmd/kubectl.go
@@ -12,6 +12,7 @@ var kubectlCmd = &cobra.Command{
 	Short: "Run kubectl on the current cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.CmdKubectl(args))
 	},
 	DisableFlagParsing: true,

--- a/cmd/tarmak/cmd/provider_init.go
+++ b/cmd/tarmak/cmd/provider_init.go
@@ -14,6 +14,7 @@ var providerInitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		globalFlags.Initialize = true
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.CmdProviderInit())
 	},
 }

--- a/cmd/tarmak/cmd/provider_list.go
+++ b/cmd/tarmak/cmd/provider_list.go
@@ -15,6 +15,7 @@ var providerListCmd = &cobra.Command{
 	Short: "Print a list of providers",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		varMaps := make([]map[string]string, 0)
 		for _, prov := range t.Providers() {
 			varMaps = append(varMaps, prov.Parameters())

--- a/cmd/tarmak/cmd/provider_validate.go
+++ b/cmd/tarmak/cmd/provider_validate.go
@@ -12,6 +12,7 @@ var providerValidateCmd = &cobra.Command{
 	Short: "Validate provider(s) used by current cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
 		t.Must(t.Environment().Provider().Validate())
 	},
 }

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -252,6 +252,16 @@ func (t *Tarmak) Validate() error {
 	return result
 }
 
+func (t *Tarmak) Cleanup() {
+	// clean up assets directory
+	if t.rootPath != nil {
+		if err := os.RemoveAll(*t.rootPath); err != nil {
+			t.log.Warnf("error cleaning up assets directory: %s", err)
+		}
+		t.rootPath = nil
+	}
+}
+
 func (t *Tarmak) Variables() map[string]interface{} {
 	output := map[string]interface{}{}
 	output["contact"] = t.config.Contact()


### PR DESCRIPTION
This cleans up the asset directory in /tmp containing puppet and terraform files 

```release-note
NONE
```