### PR TITLE
Ensure tools has been deployed before checking wing status

### DIFF
--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -69,10 +69,17 @@ func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
 		}
 	}
 
-	// wait for convergance in every mode
-	err := t.Cluster().WaitForConvergance()
-	if err != nil {
-		return err
+	// only check converged against wing if tools is deployed
+	for _, stack := range t.flags.Cluster.Apply.InfrastructureStacks {
+		if stack == tarmakv1alpha1.StackNameTools {
+			// wait for convergance in every mode
+			err := t.Cluster().WaitForConvergance()
+			if err != nil {
+				return err
+			}
+
+			break
+		}
 	}
 
 	return nil


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fixes bug where running only the network stack would check wing status

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #55

```release-note
NONE
```
