### PR TITLE
Fix argument parsing for pass through commands

### DIFF
--- a/cmd/tarmak/cmd/cluster_kubectl.go
+++ b/cmd/tarmak/cmd/cluster_kubectl.go
@@ -15,7 +15,6 @@ var clusterKubectlCmd = &cobra.Command{
 		defer t.Cleanup()
 		t.Must(t.CmdKubectl(args))
 	},
-	DisableFlagParsing: true,
 }
 
 func init() {

--- a/cmd/tarmak/cmd/kubectl.go
+++ b/cmd/tarmak/cmd/kubectl.go
@@ -1,23 +1,8 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
 package cmd
 
-import (
-	"github.com/spf13/cobra"
-
-	"github.com/jetstack/tarmak/pkg/tarmak"
-)
-
-var kubectlCmd = &cobra.Command{
-	Use:   "kubectl",
-	Short: "Run kubectl on the current cluster",
-	Run: func(cmd *cobra.Command, args []string) {
-		t := tarmak.New(globalFlags)
-		defer t.Cleanup()
-		t.Must(t.CmdKubectl(args))
-	},
-	DisableFlagParsing: true,
-}
+import ()
 
 func init() {
-	RootCmd.AddCommand(kubectlCmd)
+	RootCmd.AddCommand(clusterKubectlCmd)
 }

--- a/cmd/tarmak/main.go
+++ b/cmd/tarmak/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/jetstack/tarmak/cmd/tarmak/cmd"
 )
 
@@ -15,5 +17,5 @@ func main() {
 	cmd.Version.Version = version
 	cmd.Version.Commit = commit
 	cmd.Version.BuildDate = date
-	cmd.Execute()
+	cmd.Execute(os.Args[1:])
 }


### PR DESCRIPTION
`cluster ssh|kubectl` now escape every flags coming after its mention
and pass the through to the consecutive subcommand. Fixes #5

```release-note
Fix argument parsing for pass through commands `kubectl` and `ssh`
```
