### PR TITLE
Configure docker to use the json log format

### DIFF
--- a/puppet/modules/site_module/templates/docker.erb
+++ b/puppet/modules/site_module/templates/docker.erb
@@ -1,7 +1,7 @@
 # /etc/sysconfig/docker
 
 # Modify these options if you want to change the way the docker daemon runs
-OPTIONS='--selinux-enabled'
+OPTIONS='--selinux-enabled --log-driver=json-file --log-opt max-size=64m'
 if [ -z "${DOCKER_CERT_PATH}" ]; then
     DOCKER_CERT_PATH=/etc/docker
 fi


### PR DESCRIPTION
Fixes #72 

```release-note
Store docker logs in JSON format, with storage size quota
```
