### PR TITLE
Put container runtime resources into a separate slice

### DIFF
--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -1,4 +1,11 @@
 # class kubernetes::kubelet
+
+# @param cgroup_kubernetes_name name of cgroup slice for kubernetes related processes
+# @param cgroup_kubernetes_reserved_memory memory reserved for kubernetes related processes
+# @param cgroup_kubernetes_reserved_cpu CPU reserved for kubernetes related processes
+# @param cgroup_system_name name of cgroup slice for system processes
+# @param cgroup_system_reserved_memory memory reserved for system processes
+# @param cgroup_system_reserved_cpu CPU reserved for system processes
 class kubernetes::kubelet(
   String $role = 'worker',
   String $container_runtime = 'docker',
@@ -20,6 +27,13 @@ class kubernetes::kubelet(
     'RedHat' => 'systemd',
     default  => 'cgroupfs',
   },
+  String $cgroup_root = '/',
+  Optional[String] $cgroup_kube_name = '/podruntime.slice',
+  Optional[String] $cgroup_kube_reserved_memory = '256Mi',
+  Optional[String] $cgroup_kube_reserved_cpu = '10m',
+  Optional[String] $cgroup_system_name = '/system.slice',
+  Optional[String] $cgroup_system_reserved_memory = '128Mi',
+  Optional[String] $cgroup_system_reserved_cpu = '10m',
   Array[String] $systemd_wants = [],
   Array[String] $systemd_requires = [],
   Array[String] $systemd_after = [],

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -4,6 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
+Slice=podruntime.slice
 User=<%= scope['kubernetes::user'] %>
 Group=<%= scope['kubernetes::group'] %>
 <%- if scope['kubernetes::_service_account_key_file'] and scope['kubernetes::service_account_key_generate'] -%>

--- a/puppet/modules/kubernetes/templates/kube-controller-manager.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-controller-manager.service.erb
@@ -4,6 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
+Slice=podruntime.slice
 User=<%= scope['kubernetes::user'] %>
 Group=<%= scope['kubernetes::group'] %>
 <%- if scope['kubernetes::_service_account_key_file'] and scope['kubernetes::service_account_key_generate'] -%>

--- a/puppet/modules/kubernetes/templates/kube-proxy.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy.service.erb
@@ -7,6 +7,7 @@ After=network.target
 [Service]
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \
   --v=<%= scope['kubernetes::log_level'] %> \
+  --resource-container=podruntime.slice \
 <% if @kubeconfig_path -%>
   --kubeconfig=<%= @kubeconfig_path %> \
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kube-scheduler.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-scheduler.service.erb
@@ -4,6 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
+Slice=podruntime.slice
 User=<%= scope['kubernetes::user'] %>
 Group=<%= scope['kubernetes::group'] %>
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/scheduler \

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -4,6 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
+Slice=podruntime.slice
 WorkingDirectory=<%= @kubelet_dir %>
 <% if @cloud_provider == 'aws' -%>
 # prevent metadata service access on AWS
@@ -70,9 +71,32 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% end -%>
 <% if scope.function_versioncmp([scope['kubernetes::version'], '1.6.0']) >= 0 -%>
   --cgroup-driver=<%= @cgroup_driver %> \
-<% if not @osfamily.nil? and @osfamily == 'RedHat' -%>
-  --runtime-cgroups=/systemd/system.slice \
-  --kubelet-cgroups=/systemd/system.slice \
+  --cgroup-root=<%= @cgroup_root %> \
+<% if @cgroup_kube_name -%>
+  --kube-reserved-cgroup=<%= @cgroup_kube_name %> \
+  --runtime-cgroups=<%= @cgroup_kube_name %> \
+  --kubelet-cgroups=<%= @cgroup_kube_name %> \
+<%
+    # build kube reserved command line
+    @cgroup_kube_reserved = []
+    @cgroup_kube_reserved << "cpu=#{@cgroup_kube_reserved_cpu}" unless @cgroup_kube_reserved_cpu.nil? or @cgroup_kube_reserved_cpu == 'nil'
+    @cgroup_kube_reserved << "memory=#{@cgroup_kube_reserved_memory}" unless @cgroup_kube_reserved_memory.nil? or @cgroup_kube_reserved_memory == 'nil'
+    if @cgroup_kube_reserved.length > 0
+-%>
+  "--kube-reserved=<%= @cgroup_kube_reserved.join(',') %>" \
+<% end -%>
+<% end -%>
+<% if @cgroup_system_name -%>
+  --system-reserved-cgroup=<%= @cgroup_system_name %> \
+<%
+    # build system reserved command line
+    @cgroup_system_reserved = []
+    @cgroup_system_reserved << "cpu=#{@cgroup_system_reserved_cpu}" unless @cgroup_system_reserved_cpu.nil? or @cgroup_system_reserved_cpu == 'nil'
+    @cgroup_system_reserved << "memory=#{@cgroup_system_reserved_memory}" unless @cgroup_system_reserved_memory.nil? or @cgroup_system_reserved_memory == 'nil'
+    if @cgroup_system_reserved.length > 0
+-%>
+  "--system-reserved=<%= @cgroup_system_reserved.join(',') %>" \
+<% end -%>
 <% end -%>
 <% end -%>
 <% if @cert_file and @key_file -%>

--- a/puppet/modules/site_module/manifests/docker_config.pp
+++ b/puppet/modules/site_module/manifests/docker_config.pp
@@ -3,4 +3,10 @@ class site_module::docker_config {
     ensure  => file,
     content => template('site_module/docker.erb'),
   }
+  file { '/etc/systemd/system/docker.service.d':
+    ensure  => directory,
+  } -> file { '/etc/systemd/system/docker.service.d/10-slice.conf':
+    ensure  => directory,
+    content => '[Service]\nSlice=podruntime.slice\n',
+  }
 }


### PR DESCRIPTION
This ensures we can reserve CPU and memory resources for the system and
the runtime properly in a follow-up PR

```release-note
Setup kubernetes runtime components under cgroup podruntime.slice
```
