### PR TITLE
Remove myself from the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ approvers:
 - simonswine
 - mattbates
 reviewers:
-- munnerz
 - simonswine
 - dippynark
 - mattbates


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes me from the OWNERS file - feel free to assign specific issues/PRs to me with `/cc`, but I'd rather reduce the number of assignments I get from the bot for now 😄 

**Release note**:
```release-note
NONE
```

/cc @simonswine 
