### PR TITLE
Add task to build docs using docker

### DIFF
--- a/docs/.dockerignore
+++ b/docs/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+.venv
+Dockerfile
+_build/
+_static/
+venv/

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,15 @@
+FROM jfloff/alpine-python:3.4-slim
+
+WORKDIR /site
+
+RUN apk update && apk add enchant make
+
+RUN pip install --upgrade pip virtualenv
+RUN virtualenv venv
+RUN source venv/bin/activate
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["make"]
+CMD ["html"]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,3 +1,4 @@
+# Copyright Jetstack Ltd. See LICENSE for details.
 FROM jfloff/alpine-python:3.4-slim
 
 WORKDIR /site

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,9 +27,12 @@ help:
 
 # Make the site's html in docker
 docker_html:
-	mkdir -p _build
-	docker build -t tarmakdocs:latest .
-	docker run -it -v "$$(pwd):/site" -u `stat -c "%u:%g" _build` -w /site tarmakdocs:latest
+	set -x; mkdir -p _build; \
+	docker build -t tarmakdocs:latest .; \
+	container=$$(docker create tarmakdocs:latest); \
+	docker cp . $$container:/site; \
+	docker start -a $$container; \
+	docker cp $$container:/site/_build .
 
 .venv:
 	virtualenv -p $(shell which python3) $(VENV_PATH)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,7 +32,8 @@ docker_html:
 	container=$$(docker create tarmakdocs:latest); \
 	docker cp . $$container:/site; \
 	docker start -a $$container; \
-	docker cp $$container:/site/_build .
+	docker cp $$container:/site/_build .; \
+	docker rm $$container
 
 .venv:
 	virtualenv -p $(shell which python3) $(VENV_PATH)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,6 +25,12 @@ help:
 %: Makefile .venv
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+# Make the site's html in docker
+docker_html:
+	mkdir -p _build
+	docker build -t tarmakdocs:latest .
+	docker run -it -v "$$(pwd):/site" -u `stat -c "%u:%g" _build` -w /site tarmakdocs:latest
+
 .venv:
 	virtualenv -p $(shell which python3) $(VENV_PATH)
 	$(VENV_PATH)/bin/pip install -r requirements.txt

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -65,7 +65,16 @@ To build the documentation run the following.
   cd $GOPATH/src/github.com/jetstack/tarmak/docs
   make html
 
-You can now open `_build/html/index.html` in a browser.
+
+Or using docker:
+
+::
+
+  cd $GOPATH/src/github.com/jetstack/tarmak/docs
+  make docker_html
+
+You can now open ``_build/html/index.html`` in a browser or serve the site with
+a `web server of your choice <https://gist.github.com/willurd/5720255>`_.
 
 
 Updating puppet subtrees


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting up the python environment for the docs is harder than just building the site in docker - which tarmak users will likely have installed.

This is just another option. It's still possible to run create the docs the usual way.

**Release note**:
```release-note
It is now possible to build the docs in a container with `make docker_html`
```
