### PR TITLE
Set kubelet eviction-hard based on total memory

### DIFF
--- a/puppet/modules/kubernetes/lib/puppet/functions/five_percent_of_total_ram.rb
+++ b/puppet/modules/kubernetes/lib/puppet/functions/five_percent_of_total_ram.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:five_percent_of_total_ram) do
   end
 
   def five_percent_of_total_ram(total_bytes)
-    five_percent = (total_bytes * 0.05 / 1_000_000).round
+    five_percent = (total_bytes * 0.05 / 1024**2).round
     default = 100
 
     if five_percent < default

--- a/puppet/modules/kubernetes/lib/puppet/functions/five_percent_of_total_ram.rb
+++ b/puppet/modules/kubernetes/lib/puppet/functions/five_percent_of_total_ram.rb
@@ -1,0 +1,16 @@
+Puppet::Functions.create_function(:five_percent_of_total_ram) do
+  dispatch :five_percent_of_total_ram do
+    param 'Integer', :total_bytes
+  end
+
+  def five_percent_of_total_ram(total_bytes)
+    five_percent = (total_bytes * 0.05 / 1_000_000).round
+    default = 100
+
+    if five_percent < default
+      '100Mi'
+    else
+      five_percent.to_s + 'Mi'
+    end
+  end
+end

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -10,6 +10,8 @@ class kubernetes::kubelet(
   String $role = 'worker',
   String $container_runtime = 'docker',
   String $kubelet_dir = '/var/lib/kubelet',
+  String $hard_eviction_memory_threshold =
+    five_percent_of_total_ram(dig44($facts, ['memory', 'system', 'total_bytes'], 1)),
   Optional[String] $network_plugin = undef,
   Integer $network_plugin_mtu = 1460,
   Boolean $allow_privileged = true,

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -20,7 +20,7 @@ describe 'kubernetes::kubelet' do
       should_not contain_file(service_file).with_content(/--network-plugin/)
       should contain_file(service_file).with_content(/--container-runtime=docker/)
       should contain_file(service_file).with_content(%r{--kubeconfig=/etc/kubernetes/kubeconfig-kubelet})
-      should contain_file(service_file).with_content(%r{--eviction-hard=memory.available<200Mi})
+      should contain_file(service_file).with_content(%r{--eviction-hard="memory.available<191Mi"})
     end
   end
 

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -20,7 +20,7 @@ describe 'kubernetes::kubelet' do
       should_not contain_file(service_file).with_content(/--network-plugin/)
       should contain_file(service_file).with_content(/--container-runtime=docker/)
       should contain_file(service_file).with_content(%r{--kubeconfig=/etc/kubernetes/kubeconfig-kubelet})
-      should contain_file(service_file).with_content(%r{--eviction-hard="memory.available<191Mi"})
+      should contain_file(service_file).with_content(%r{--eviction-hard=memory.available<191Mi})
     end
   end
 

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -20,6 +20,7 @@ describe 'kubernetes::kubelet' do
       should_not contain_file(service_file).with_content(/--network-plugin/)
       should contain_file(service_file).with_content(/--container-runtime=docker/)
       should contain_file(service_file).with_content(%r{--kubeconfig=/etc/kubernetes/kubeconfig-kubelet})
+      should contain_file(service_file).with_content(%r{--eviction-hard=memory.available<200Mi})
     end
   end
 

--- a/puppet/modules/kubernetes/spec/spec_helper.rb
+++ b/puppet/modules/kubernetes/spec/spec_helper.rb
@@ -5,5 +5,10 @@ RSpec.configure do |config|
     :path => '/bin:/sbin:/usr/bin:/usr/sbin:/opt/bin',
     :osfamily => 'RedHat',
     :kernelversion => '3.11.1',
+    :memory => {
+      :system => {
+        :total_bytes => 4_000_000_000,
+      }
+    }
   }
 end

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -103,7 +103,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   "--tls-cert-file=<%= @cert_file %>" \
   "--tls-private-key-file=<%= @key_file %>" \
 <% end -%>
-  --eviction-hard=memory.available<<%= @hard_eviction_memory_threshold %>
+  --eviction-hard="memory.available<<%= @hard_eviction_memory_threshold %>"
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -103,7 +103,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   "--tls-cert-file=<%= @cert_file %>" \
   "--tls-private-key-file=<%= @key_file %>" \
 <% end -%>
-  --eviction-hard="memory.available<<%= @hard_eviction_memory_threshold %>" \
+  "--eviction-hard=memory.available<<%= @hard_eviction_memory_threshold %>" \
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -103,6 +103,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   "--tls-cert-file=<%= @cert_file %>" \
   "--tls-private-key-file=<%= @key_file %>" \
 <% end -%>
+  --eviction-hard=memory.available<<%= @hard_eviction_memory_threshold %>
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -103,7 +103,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   "--tls-cert-file=<%= @cert_file %>" \
   "--tls-private-key-file=<%= @key_file %>" \
 <% end -%>
-  --eviction-hard="memory.available<<%= @hard_eviction_memory_threshold %>"
+  --eviction-hard="memory.available<<%= @hard_eviction_memory_threshold %>" \
   --logtostderr=true
 
 Restart=on-failure


### PR DESCRIPTION
The kubelet will default to memory.available<100Mi as the hard eviction
threshold. This makes that figure 5% of the total memory or 100Mi.
Whichever is greater.

Read from the default memory facts to set the kubelet `eviction-hard`
parameter.

Default facts:
https://puppet.com/docs/facter/3.10/core_facts.html#memory

Implements https://github.com/jetstack/tarmak/issues/149

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Sets a kubelet hard eviction target to 5% of the node's total memory.
```
