### PR TITLE
Kube-apiserver should use endpoint reconciler in 1.9+

### DIFF
--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -75,7 +75,11 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <%- if scope['kubernetes::_service_account_key_file'] -%>
   --service-account-key-file=<%= scope['kubernetes::_service_account_key_file'] %> \
 <% end -%>
+<%- if scope.function_versioncmp([scope['kubernetes::version'], '1.9.0']) >= 0 -%>
+  --endpoint-reconciler-type=lease \
+<%- else -%>
   --apiserver-count=<%= @count %> \
+<%- end -%>
 <% if @_storage_backend -%>
   --storage-backend=<%= @_storage_backend %> \
 <% end -%>


### PR DESCRIPTION
```release-note
Enable endpoint reconciler for kubernetes API server 1.9+
```