### PR TITLE
Make sha256 check command working on both Linux and Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,14 @@ GOPATH ?= /tmp/go
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
+	SHASUM := "sha256sum -c"
 	DEP_URL := https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64
 	DEP_HASH := 31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315
 	GORELEASER_URL := https://github.com/goreleaser/goreleaser/releases/download/v0.54.0/goreleaser_Linux_x86_64.tar.gz
 	GORELEASER_HASH := 895df4293580dd8f9b0daf0ef5456f2238a2fbfc51d9f75dde6e2c63ca4fccc2
 endif
 ifeq ($(UNAME_S),Darwin)
+	SHASUM := "shasum -a 256 -c"
 	DEP_URL := https://github.com/golang/dep/releases/download/v0.4.1/dep-darwin-amd64
 	DEP_HASH := f170008e2bf8b196779c361a4eaece1b03450d23bbf32d1a0beaa9b00b6a5ab4
 	GORELEASER_URL := https://github.com/goreleaser/goreleaser/releases/download/v0.54.0/goreleaser_Darwin_x86_64.tar.gz
@@ -111,12 +113,12 @@ $(BINDIR)/informer-gen:
 
 $(BINDIR)/dep:
 	curl -sL -o $@ $(DEP_URL)
-	echo "$(DEP_HASH)  $@" | sha256sum -c
+	echo "$(DEP_HASH)  $@" | $$SHASUM
 	chmod +x $@
 
 $(BINDIR)/goreleaser:
 	curl -sL -o $@.tar.gz $(GORELEASER_URL)
-	echo "$(GORELEASER_HASH) $@.tar.gz" | sha256sum -c
+	echo "$(GORELEASER_HASH) $@.tar.gz" | $$SHASUM
 	cd $(BINDIR) && tar xzvf $(shell basename $@).tar.gz goreleaser
 
 depend: $(BINDIR)/go-bindata $(BINDIR)/mockgen $(BINDIR)/defaulter-gen $(BINDIR)/defaulter-gen $(BINDIR)/deepcopy-gen $(BINDIR)/conversion-gen $(BINDIR)/client-gen $(BINDIR)/lister-gen $(BINDIR)/informer-gen $(BINDIR)/dep $(BINDIR)/goreleaser


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Gets `make build` actually working on `macOS` platforms o_O

**Which issue this PR fixes**: 
no issue has been opened for this, but it's kinda weird you never tested building the project on `macOS` ¯\_(ツ)_/¯

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Makefile uses sha256sum command on both Linux and Darwin platforms to
check the integrity of the build. The problem is macOS does not ship the
sha sum utility with the same name. This commit uses the right utility
name for macOS platforms whilst preserving the original command for
usage on Linux OS.
```
