### PR TITLE
Update vault-helper to 0.9.9

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -930,8 +930,8 @@
 [[projects]]
   name = "github.com/jetstack/vault-helper"
   packages = ["pkg/kubernetes"]
-  revision = "9ef86ddaab8853e14ee1461d632403199f56ef2c"
-  version = "0.9.7"
+  revision = "f309627094849a76622dfeb49da4ff44a335a559"
+  version = "0.9.9"
 
 [[projects]]
   name = "github.com/jetstack/vault-unsealer"
@@ -2035,6 +2035,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "942a69e8f8bd3b3b71423ae5cead730bac3313bb1d43c923535d6a23137bd063"
+  inputs-digest = "0c932c65202ef877b7fca57c597265adf7dbbccd3d9daedfedc8ec6db15e4213"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@ required = [
 
 [[constraint]]
   name = "github.com/jetstack/vault-helper"
-  version = "0.9.7"
+  version = "0.9.9"
 
 [[constraint]]
   name = "github.com/cenkalti/backoff"

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/generic.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/generic.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/init_token.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/init_token.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/kubernetes.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/kubernetes.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (
@@ -144,9 +145,7 @@ func isValidClusterID(clusterID string) error {
 		return errors.New("Invalid cluster ID - contains uppercase")
 	}
 
-	f = func(r rune) bool {
-		return ((r < 'a' || r > 'z') && (r < '0' || r > '9')) && r != '-'
-	}
+	f = func(r rune) bool { return ((r < 'a' || r > 'z') && (r < '0' || r > '9')) && r != '-' }
 
 	if strings.IndexFunc(clusterID, f) != -1 {
 		return errors.New("Not a valid cluster ID name")

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/kubernetes_pki_roles.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/kubernetes_pki_roles.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (
@@ -92,7 +93,7 @@ func (k *Kubernetes) k8sAPIServerRole() *pkiRole {
 			"allow_bare_domains":  true,
 			"allow_ip_sans":       true,
 			"server_flag":         true,
-			"client_flag":         false,
+			"client_flag":         true,
 			"max_ttl":             fmt.Sprintf("%ds", int(k.MaxValidityComponents.Seconds())),
 			"ttl":                 fmt.Sprintf("%ds", int(k.MaxValidityComponents.Seconds())),
 		},
@@ -127,7 +128,7 @@ func (k *Kubernetes) k8sKubeletRole() *pkiRole {
 			"use_csr_sans":        false,
 			"enforce_hostnames":   false,
 			"organization":        "system:nodes",
-			"allowed_domains":     strings.Join([]string{"kubelet", "system:node", "system:node:*", "*.compute.internal"}, ","),
+			"allowed_domains":     strings.Join([]string{"kubelet", "system:node", "system:node:*", "*.compute.internal", "*.ec2.internal"}, ","),
 			"allow_bare_domains":  true,
 			"allow_glob_domains":  true,
 			"allow_any_name":      false,

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/kubernetes_policies.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/kubernetes_policies.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/pki.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/pki.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (

--- a/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/policy.go
+++ b/vendor/github.com/jetstack/vault-helper/pkg/kubernetes/policy.go
@@ -1,3 +1,4 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
 package kubernetes
 
 import (


### PR DESCRIPTION
This allows kubelets to get the interal FQDN from *.ec2.internal, which
is used withing us-east-1 of AWS.

```release-note
Fix for clusters in us-east-1 allows kubelets to get the interal FQDN from *.ec2.internal, which
is used only within us-east-1 of AWS
```
