### PR TITLE
Fix kubectl

### DIFF
--- a/cmd/tarmak/cmd/kubectl.go
+++ b/cmd/tarmak/cmd/kubectl.go
@@ -1,8 +1,6 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
 package cmd
 
-import ()
-
 func init() {
 	RootCmd.AddCommand(clusterKubectlCmd)
 }

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -185,6 +185,7 @@ type Packer interface {
 
 type Terraform interface {
 	Output(cluster Cluster) (map[string]interface{}, error)
+	Prepare(cluster Cluster) error
 }
 
 type SSH interface {

--- a/pkg/tarmak/kubectl/kubectl.go
+++ b/pkg/tarmak/kubectl/kubectl.go
@@ -190,6 +190,11 @@ func (k *Kubectl) ensureWorkingKubeconfig() (interfaces.Tunnel, error) {
 
 	// check if certificates are set
 	if len(authInfo.ClientCertificateData) == 0 || len(authInfo.ClientKeyData) == 0 || len(cluster.CertificateAuthorityData) == 0 {
+
+		if err := k.tarmak.Terraform().Prepare(k.tarmak.Environment().Hub()); err != nil {
+			return nil, fmt.Errorf("failed to prepare terraform: %s", err)
+		}
+
 		if err := k.requestNewAdminCert(cluster, authInfo); err != nil {
 			return nil, err
 		}

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -107,16 +107,41 @@ func (t *Terraform) socketPath(c interfaces.Cluster) string {
 	return tarmakSocketPath(c.ConfigPath())
 }
 
-func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string, args []string) error {
+func (t *Terraform) Prepare(cluster interfaces.Cluster) error {
 
 	// generate tf code
 	if err := t.GenerateCode(cluster); err != nil {
-		return err
+		return fmt.Errorf("failed to generate code: %s", err)
 	}
 
 	// symlink tarmak plugins into folder
 	if err := t.preparePlugins(cluster); err != nil {
-		return err
+		return fmt.Errorf("failed to prepare plugins: %s", err)
+	}
+
+	// run init
+	if err := t.command(
+		cluster,
+		[]string{
+			"terraform",
+			"init",
+			"-get-plugins=false",
+			"-input=false",
+		},
+		nil,
+		nil,
+		nil,
+	); err != nil {
+		return fmt.Errorf("failed to run terraform init: %s", err)
+	}
+
+	return nil
+}
+
+func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string, args []string) error {
+
+	if err := t.Prepare(cluster); err != nil {
+		return fmt.Errorf("failed to prepare terraform: %s", err)
 	}
 
 	// listen to rpc
@@ -133,22 +158,6 @@ func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string,
 			t.log.Fatalf("error listening to unix socket: %s", err)
 		}
 	}()
-
-	// run init
-	if err := t.command(
-		cluster,
-		[]string{
-			"terraform",
-			"init",
-			"-get-plugins=false",
-			"-input=false",
-		},
-		nil,
-		nil,
-		nil,
-	); err != nil {
-		return err
-	}
 
 	// command
 	if command == debugShell {


### PR DESCRIPTION
Fixes #184 

```release-note
Allow `tarmak kubectl` to be run from a different location to where the cluster was created
```