### PR TITLE
Write ssh config at tarmak initialisation to ensue present

### DIFF
--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -140,6 +140,10 @@ func (t *Tarmak) initializeConfig() error {
 		return fmt.Errorf("error finding current cluster '%s': %s", clusterName, err)
 	}
 
+	if err := t.ssh.WriteConfig(); err != nil {
+		return fmt.Errorf("failed to write ssh config for current cluster '%s': %v", clusterName, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Ensure ssh config is written at the point of tarmak config initialisation

 fixes #174 

```release-note
NONE
```
