### PR TITLE
Expand relative config directory arguments

### DIFF
--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -75,6 +76,12 @@ func New(flags *tarmakv1alpha1.Flags) *Tarmak {
 	t.configDirectory, err = homedir.Expand(flags.ConfigDirectory)
 	if err != nil {
 		t.log.Fatalf("unable to expand config directory ('%s'): %s", flags.ConfigDirectory, err)
+	}
+
+	// expand relative config path
+	t.configDirectory, err = filepath.Abs(flags.ConfigDirectory)
+	if err != nil {
+		t.log.Fatalf("unable to expand relative config directory ('%s'): %s", flags.ConfigDirectory, err)
 	}
 
 	t.log.Level = logrus.DebugLevel


### PR DESCRIPTION
**What this PR does / why we need it**:
When passed a relative config directory e.g. `tarmak -c ./my_dir clusters list` it is not expanded. This meant that an incomplete path was being passed down to terraform runs which now (not running in docker) were failing.

**Special notes for your reviewer**:
Happy to add try and add a test case for this. Perhaps in `pkg/tarmak/tarmak_test.go`?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Always expand relative config path arguments to ensure correct values in generated Terraform config.
```
