### PR TITLE
Update calico manifests to v3.1.1

### DIFF
--- a/puppet/modules/calico/manifests/node.pp
+++ b/puppet/modules/calico/manifests/node.pp
@@ -5,9 +5,9 @@
 # @param metrics_port Port for felix metrics endpoint, 0 disables metrics collection
 class calico::node (
   String $node_image = 'quay.io/calico/node',
-  String $node_version = '2.6.6',
+  String $node_version = '3.1.1',
   String $cni_image = 'quay.io/calico/cni',
-  String $cni_version = '1.11.2',
+  String $cni_version = '3.1.1',
   String $ipv4_pool_cidr = '10.231.0.0/16',
   Enum['always', 'cross-subnet', 'off'] $ipv4_pool_ipip_mode = 'always',
   Integer[0,65535] $metrics_port = 9091,

--- a/puppet/modules/calico/manifests/policy_controller.pp
+++ b/puppet/modules/calico/manifests/policy_controller.pp
@@ -1,6 +1,6 @@
 class calico::policy_controller (
   String $image = 'quay.io/calico/kube-controllers',
-  String $version = '1.0.3',
+  String $version = '3.1.1',
 )
 {
   include ::kubernetes

--- a/puppet/modules/calico/spec/classes/config_spec.rb
+++ b/puppet/modules/calico/spec/classes/config_spec.rb
@@ -43,7 +43,7 @@ describe 'calico::config' do
 
     it 'has valid cni_network_config json' do
       cni = JSON.load(cni_network_config)
-      expect(cni['mtu']).to eq(1480)
+      expect(cni['plugins'].first['mtu']).to eq(1480)
     end
   end
 
@@ -57,7 +57,7 @@ describe 'calico::config' do
 
     it 'has valid cni_network_config json' do
       cni = JSON.load(cni_network_config)
-      expect(cni['mtu']).to eq(8981)
+      expect(cni['plugins'].first['mtu']).to eq(8981)
     end
   end
 

--- a/puppet/modules/calico/templates/configmap.yaml.erb
+++ b/puppet/modules/calico/templates/configmap.yaml.erb
@@ -14,26 +14,33 @@ data:
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-        "name": "k8s-pod-network",
-        "cniVersion": "0.1.0",
-        "type": "calico",
-        "etcd_endpoints": "__ETCD_ENDPOINTS__",
-        "etcd_key_file": "<%= @etcd_key_file %>",
-        "etcd_cert_file": "<%= @etcd_cert_file %>",
-        "etcd_ca_cert_file": "<%= @etcd_ca_file %>",
-        "log_level": "info",
-        "mtu": <%= @mtu %>,
-        "ipam": {
-            "type": "calico-ipam"
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          "etcd_key_file": "<%= @etcd_key_file %>",
+          "etcd_cert_file": "<%= @etcd_cert_file %>",
+          "etcd_ca_cert_file": "<%= @etcd_ca_file %>",
+          "log_level": "info",
+          "mtu": <%= @mtu %>,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
         },
-        "policy": {
-            "type": "k8s",
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
         }
+      ]
     }
 <% if @etcd_proto == 'https' -%>
 

--- a/puppet/modules/calico/templates/node-daemonset.yaml.erb
+++ b/puppet/modules/calico/templates/node-daemonset.yaml.erb
@@ -154,6 +154,9 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
 <% if @etcd_proto == 'https' -%>
             - mountPath: <%= @etcd_cert_path %>
               name: etcd-certs

--- a/puppet/modules/calico/templates/node-daemonset.yaml.erb
+++ b/puppet/modules/calico/templates/node-daemonset.yaml.erb
@@ -69,9 +69,17 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
@@ -112,6 +120,8 @@ spec:
             # Setup a custom MTU value
             - name: FELIX_IPINIPMTU
               value: "<%= @mtu %>"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
 <%- if @metrics_port > 0 -%>
             # Enable metrics collection
             - name: FELIX_PROMETHEUSMETRICSENABLED
@@ -125,6 +135,18 @@ spec:
           resources:
             requests:
               cpu: 250m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
@@ -133,7 +155,7 @@ spec:
               name: var-run-calico
               readOnly: false
 <% if @etcd_proto == 'https' -%>
-            - mountPath: <%= @etcd_cert_path%>
+            - mountPath: <%= @etcd_cert_path %>
               name: etcd-certs
 <% end -%>
         # This container installs the Calico CNI binaries
@@ -142,6 +164,9 @@ spec:
           image: <%= @cni_image %>:v<%= @cni_version %>
           command: ["/install-cni.sh"]
           env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
@@ -174,6 +199,9 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -181,8 +209,8 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
-        # Mount in the etcd TLS secrets.
 <% if @etcd_proto == 'https' -%>
+        # Mount in the etcd TLS secrets.
         - name: etcd-certs
           hostPath:
             path: <%= @etcd_cert_path%>

--- a/puppet/modules/calico/templates/node-rbac.yaml.erb
+++ b/puppet/modules/calico/templates/node-rbac.yaml.erb
@@ -50,16 +50,24 @@ metadata:
   name: calico-policy-controller
   namespace: <%= @namespace %>
 rules:
-- apiGroups:
-  - ""
-  - extensions
-  resources:
-    - pods
-    - namespaces
-    - networkpolicies
-  verbs:
-    - watch
-    - list
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+      - nodes
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
 ---
 <%- if @version_before_1_6 -%>
 apiVersion: rbac.authorization.k8s.io/v1alpha1

--- a/puppet/modules/calico/templates/policy-controller-deployment.yaml.erb
+++ b/puppet/modules/calico/templates/policy-controller-deployment.yaml.erb
@@ -54,6 +54,9 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
 <% if @tls -%>
             # Location of the CA certificate for etcd.
             - name: ETCD_CA_CERT_FILE


### PR DESCRIPTION
Following the guide here:
https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/calico

I made the changes to the calico yaml templates required for 3.1.1

Making sure to continue to mount in the etcd tls files as before.

**What this PR does / why we need it**:
Updates tarmak's calico deployment to 3.1.1.

We need this so that calico uses etcd 3 as etcd 3 is easier to backup.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade calico cni plugin to from v2.6 to 3.1.1
```
