### PR TITLE
Install the aws-cli from pip

### DIFF
--- a/packer/amazon/centos-puppet-agent-latest-kernel.json
+++ b/packer/amazon/centos-puppet-agent-latest-kernel.json
@@ -13,21 +13,21 @@
       "secret_key": "{{user `aws_secret_key`}}",
       "region": "{{user `region`}}",
       "source_ami_filter": {
-          "filters": {
-              "owner-alias": "aws-marketplace",
-              "product-code": "aw0evgkw8e5c1q413zgy5pjce",
-              "virtualization-type": "hvm"
-          },
-          "most_recent": true
+        "filters": {
+          "owner-alias": "aws-marketplace",
+          "product-code": "aw0evgkw8e5c1q413zgy5pjce",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true
       },
       "instance_type": "c4.xlarge",
       "ssh_username": "centos",
       "ssh_pty": "true",
       "ami_name": "Tarmak CentOS 7 x86_64 with puppet-agent and latest upstream kernel{{isotime \"2006-01-02_030405\"}}",
       "tags": {
-          "Name": "tarmak_{{user `tarmak_environment`}}_{{user `tarmak_base_image_name`}}",
-          "tarmak_environment": "{{user `tarmak_environment`}}",
-          "tarmak_base_image_name": "{{user `tarmak_base_image_name`}}"
+        "Name": "tarmak_{{user `tarmak_environment`}}_{{user `tarmak_base_image_name`}}",
+        "tarmak_environment": "{{user `tarmak_environment`}}",
+        "tarmak_base_image_name": "{{user `tarmak_base_image_name`}}"
       },
       "associate_public_ip_address": true
     }
@@ -42,7 +42,7 @@
         "yum update -y",
         "yum install -y epel-release",
         "yum install -y git puppet-agent vim tmux socat python-pip at jq unzip",
-        "pip install awscli",
+        "pip install awscli==1.15.17 --ignore-installed",
         "rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org",
         "rpm -ivh http://www.elrepo.org/elrepo-release-7.0-2.el7.elrepo.noarch.rpm",
         "yum --enablerepo=elrepo-kernel install -y kernel-ml",

--- a/packer/amazon/centos-puppet-agent.json
+++ b/packer/amazon/centos-puppet-agent.json
@@ -13,21 +13,21 @@
       "secret_key": "{{user `aws_secret_key`}}",
       "region": "{{user `region`}}",
       "source_ami_filter": {
-          "filters": {
-              "owner-alias": "aws-marketplace",
-              "product-code": "aw0evgkw8e5c1q413zgy5pjce",
-              "virtualization-type": "hvm"
-          },
-          "most_recent": true
+        "filters": {
+          "owner-alias": "aws-marketplace",
+          "product-code": "aw0evgkw8e5c1q413zgy5pjce",
+          "virtualization-type": "hvm"
+        },
+        "most_recent": true
       },
       "instance_type": "c4.xlarge",
       "ssh_username": "centos",
       "ssh_pty": "true",
       "ami_name": "Tarmak CentOS 7 x86_64 with puppet-agent {{isotime \"2006-01-02_030405\"}}",
       "tags": {
-          "Name": "tarmak_{{user `tarmak_environment`}}_{{user `tarmak_base_image_name`}}",
-          "tarmak_environment": "{{user `tarmak_environment`}}",
-          "tarmak_base_image_name": "{{user `tarmak_base_image_name`}}"
+        "Name": "tarmak_{{user `tarmak_environment`}}_{{user `tarmak_base_image_name`}}",
+        "tarmak_environment": "{{user `tarmak_environment`}}",
+        "tarmak_base_image_name": "{{user `tarmak_base_image_name`}}"
       },
       "associate_public_ip_address": true
     }
@@ -42,7 +42,7 @@
         "yum update -y",
         "yum install -y epel-release",
         "yum install -y git puppet-agent vim tmux socat python-pip at jq unzip",
-        "pip install awscli"
+        "pip install awscli==1.15.17 --ignore-installed"
       ]
     }
   ]

--- a/puppet/modules/aws_ebs/manifests/init.pp
+++ b/puppet/modules/aws_ebs/manifests/init.pp
@@ -27,7 +27,7 @@ class aws_ebs(
     mode =>  '0755',
   })
 
-  ensure_resource('package', ['curl', 'gawk', 'util-linux', 'awscli', 'xfsprogs'],{
+  ensure_resource('package', ['curl', 'gawk', 'util-linux', 'xfsprogs'],{
     ensure => present
   })
 

--- a/terraform/amazon/modules/vault/templates/vault_user_data.yaml
+++ b/terraform/amazon/modules/vault/templates/vault_user_data.yaml
@@ -373,7 +373,7 @@ runcmd:
 - chown vault:vault /etc/vault/vault.hcl
 - hostnamectl set-hostname "${fqdn}"
 - yum -y install epel-release
-- yum -y install unzip jq curl gpg awscli
+- yum -y install unzip jq curl gpg
 - /usr/local/bin/download-vault-consul.sh
 - /usr/local/bin/download-vault-unsealer.sh
 - /usr/local/bin/download-consul-backinator.sh


### PR DESCRIPTION
The package from yum install is currently broken and it means we can't bring up new clusters

**What this PR does / why we need it**:
The aws-cli we're getting from yum is broken at the moment, installing this version with pip seems to work.

Without it we can't bring up vault etc etc

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Install awscli in base images using pip to avoid getting broken versions from yum.
```
