### PR TITLE
Show zone info from config when doing `cluster list`

### DIFF
--- a/cmd/tarmak/cmd/cluster_list.go
+++ b/cmd/tarmak/cmd/cluster_list.go
@@ -36,7 +36,7 @@ var clusterListCmd = &cobra.Command{
 					"environment": cluster.Environment().Name(),
 					"version":     kubernetesVersion,
 					"type":        cluster.Type(),
-					"zone":        cluster.Variables()["public_zone"].(string),
+					"zone":        env.Provider().PublicZone(),
 					"current":     current,
 				})
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
`cluster list` was making cloud provider calls making it slow. This has been removed, in favour of using the local config

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #199 

```release-note
NONE
```

/assign @simonswine 