### PR TITLE
Fix default file path expansion

### DIFF
--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -73,15 +73,17 @@ func New(flags *tarmakv1alpha1.Flags) *Tarmak {
 	t.homeDir = homeDir
 
 	// set config directory
+
+	// expand home directory
 	t.configDirectory, err = homedir.Expand(flags.ConfigDirectory)
 	if err != nil {
 		t.log.Fatalf("unable to expand config directory ('%s'): %s", flags.ConfigDirectory, err)
 	}
 
 	// expand relative config path
-	t.configDirectory, err = filepath.Abs(flags.ConfigDirectory)
+	t.configDirectory, err = filepath.Abs(t.configDirectory)
 	if err != nil {
-		t.log.Fatalf("unable to expand relative config directory ('%s'): %s", flags.ConfigDirectory, err)
+		t.log.Fatalf("unable to expand relative config directory ('%s'): %s", t.configDirectory, err)
 	}
 
 	t.log.Level = logrus.DebugLevel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
With the introduction of https://github.com/jetstack/tarmak/pull/194 the default file path didn't work correctly anymore. The filepath was changed to `/~/.tarmak` because of that function. This change fixes that by expanding it before we feed it to the filepath absolute function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #203 

**Special notes for your reviewer**:
I am not really sure we need to keep the changes of #194. Normally the shell expands an relative directory to a full directory before it gives that to the program. IMO this change was introduced because because one type of shell doesn't do it properly. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix incorrect path for default path of the config file
```
