### PR TITLE
Toggle SELinux volume label based on OS version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /bin/
 .DS_Store
 /.kube/
+.bundle

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -107,11 +107,10 @@ class kubernetes::kubelet(
     $_ca_file = $ca_file
   }
 
-  $os_version = 0 + $facts["operatingsystemrelease"]
-  if $os_version < 7.5 {
-    $seltype = 'svirt_sandbox_file_t'
-  } else {
+  if versioncmp($facts["operatingsystemrelease"], '7.5') >= 0 {
     $seltype = 'container_file_t'
+  } else {
+    $seltype = 'svirt_sandbox_file_t'
   }
 
   file{$kubelet_dir:

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -107,8 +107,13 @@ class kubernetes::kubelet(
     $_ca_file = $ca_file
   }
 
+  $os_version = 0 + $facts["operatingsystemrelease"]
+  if $os_version < 7.5 {
+    $seltype = 'svirt_sandbox_file_t'
+  } else {
+    $seltype = 'container_file_t'
+  }
 
-  $seltype = 'svirt_sandbox_file_t'
   file{$kubelet_dir:
     ensure  => 'directory',
     mode    => '0750',

--- a/puppet/modules/kubernetes/spec/spec_helper.rb
+++ b/puppet/modules/kubernetes/spec/spec_helper.rb
@@ -9,6 +9,11 @@ RSpec.configure do |config|
       :system => {
         :total_bytes => 4_000_000_000,
       }
-    }
+    },
+    :operatingsystemrelease => "7.5"
   }
+
+  config.before(:each) do
+    Puppet::Util::Log.newdestination(:console) if ENV.fetch("PUPPET_DEBUG", false)
+  end
 end

--- a/puppet/modules/tarmak/spec/spec_helper.rb
+++ b/puppet/modules/tarmak/spec/spec_helper.rb
@@ -5,5 +5,6 @@ RSpec.configure do |config|
     :path => '/bin:/sbin:/usr/bin:/usr/sbin:/opt/bin',
     :ipaddress => '10.10.10.10',
     :osfamily => 'RedHat',
+    :operatingsystemrelease => "7.5",
   }
 end


### PR DESCRIPTION
**What this PR does / why we need it**:
We've been having an issue using the old label on the latest versions.

Source: https://docs.openshift.com/container-platform/3.6/install_config/persistent_storage/pod_security_context.html

> The volume will be given a type which is accessible by unprivileged containers. This type is usually container_file_t, which treats volumes as container content. Previously, the label specified was svirt_sandbox_file_t. This label is no longer used due to security concerns.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use the container_file_t volume label on newer os versions.
```
