### PR TITLE
Toggle SELinux volume label based on OS version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /bin/
 .DS_Store
 /.kube/
+.bundle

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -107,8 +107,8 @@ class kubernetes::kubelet(
     $_ca_file = $ca_file
   }
 
-
-  $seltype = 'svirt_sandbox_file_t'
+  $seltype = 'container_file_t'
+  $seltype_old = 'svirt_sandbox_file_t'
   file{$kubelet_dir:
     ensure  => 'directory',
     mode    => '0750',
@@ -119,7 +119,8 @@ class kubernetes::kubelet(
 
   if dig44($facts, ['os', 'selinux', 'enabled'], false) {
     exec { 'semanage_fcontext_kubelet_dir':
-      command => "semanage fcontext -a -t ${seltype} \"${kubelet_dir}(/.*)?\"",
+      # fall back to old seltype, if command fails
+      command => "semanage fcontext -a -t ${seltype} \"${kubelet_dir}(/.*)?\" || semanage fcontext -a -t ${seltype_old} \"${kubelet_dir}(/.*)?\"",
       unless  => "semanage fcontext -l | grep \"${kubelet_dir}(/.*).*:${seltype}\"",
       require => File[$kubelet_dir],
       path    => $::kubernetes::path

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -62,7 +62,7 @@ describe 'kubernetes::kubelet' do
 
     it 'should have seltype set on parent dir' do
       should contain_file(parent_dir).with_ensure('directory')
-      should contain_file(parent_dir).with_seltype('svirt_sandbox_file_t')
+      should contain_file(parent_dir).with_seltype('container_file_t')
     end
   end
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We've been having an issue using the old label on the latest versions.

Source: https://docs.openshift.com/container-platform/3.6/install_config/persistent_storage/pod_security_context.html

> The volume will be given a type which is accessible by unprivileged containers. This type is usually container_file_t, which treats volumes as container content. Previously, the label specified was svirt_sandbox_file_t. This label is no longer used due to security concerns.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use the container_file_t volume label on newer os versions.
```
