### PR TITLE
Enable iptables processing for bridges

### DIFF
--- a/puppet/modules/kubernetes/templates/kube-proxy.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy.service.erb
@@ -5,6 +5,8 @@ After=network.target
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
+ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-ip6tables=1
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \
   --v=<%= scope['kubernetes::log_level'] %> \
   --resource-container=podruntime.slice \


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable iptables processing for bridges. Important for non-calico CNI's that use bridges. Otherwise bridge
traffic is not put through iptables

```release-note
Enable iptables processing for bridged traffic
```
