### PR TITLE
Use centos with rhel kernel as default image

### DIFF
--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -92,7 +92,7 @@ func SetDefaults_InstancePool(obj *InstancePool) {
 
 	// set image to default image
 	if obj.Image == "" {
-		obj.Image = "centos-puppet-agent-latest-kernel"
+		obj.Image = "centos-puppet-agent"
 	}
 
 	// set a default size for volumes


### PR DESCRIPTION
Upstream kernel is quite risky and can't be maintained in the long term.

```release-note
NONE
```
