### PR TITLE
Fetch latest selinux package for kubelet config

### DIFF
--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -117,7 +117,7 @@ class kubernetes::kubelet(
     seltype => $seltype,
   }
 
-  if dig44($facts, ['os', 'selinux', 'enabled'], false) and $::osfamily == "Redhat" {
+  if dig44($facts, ['os', 'selinux', 'enabled'], false) and $::osfamily == 'Redhat' {
     $policy_package = 'selinux-policy-targeted'
     ensure_resource('package', $policy_package, {
       ensure => 'latest',

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -46,6 +46,11 @@ describe 'kubernetes::kubelet' do
           'placement' => {
             'availability-zone' => 'my-zone-1z',
           },
+        },
+        'os' => {
+          'selinux' => {
+            'enabled' => true
+          }
         }
       }
     end
@@ -209,7 +214,7 @@ describe 'kubernetes::kubelet' do
           "cgroup_#{cgroup_type}_reserved_cpu"    => '100m',
           "cgroup_#{cgroup_type}_reserved_memory" => '128Mi',
         }}
-        it do 
+        it do
           should contain_file(service_file).with_content(%r{--#{cgroup_type}-reserved=cpu=100m,memory=128Mi})
         end
       end


### PR DESCRIPTION
Before configuring the kubelet directory, fetch the latest selinx policy so that the latest labels are available.

```release-note
Running puppet will now always fetch the latest selinux policy package
```
