### PR TITLE
Ignore .kube directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 /.kube/
 .bundle
+.kube


### PR DESCRIPTION
**What this PR does / why we need it**:
Integration tests can leave .kube directories behind - which show in git if not ignored.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ignoore .kube directories from puppet modules
```
