### PR TITLE
Relax tarmak puppet module dependency versions

### DIFF
--- a/puppet/modules/tarmak/metadata.json
+++ b/puppet/modules/tarmak/metadata.json
@@ -7,32 +7,32 @@
   "source": "https://github.com/jetstack/puppet-module-tarmak",
   "project_page": "https://github.com/jetstack/puppet-module-tarmak",
   "issues_url": "https://github.com/jetstack/puppet-module-tarmak/issues",
-  "dependencies" : [
+  "dependencies": [
     {
-       "name": "puppetlabs-stdlib",
-       "version_requirement" : ">= 4.2.0 < 5.0.0"
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.2.0 < 5.0.0"
     },
     {
-       "name": "jetstack/kubernetes",
-       "version_requirement": ">= 0.1.2-rc3 < 1.0.0"
+      "name": "jetstack/kubernetes",
+      "version_requirement": ">= 0.1.0 < 1.0.0"
     },
     {
-       "name": "jetstack/calico",
-       "version_requirement": ">= 0.1.2-rc3 < 1.0.0"
+      "name": "jetstack/calico",
+      "version_requirement": ">= 0.1.0 < 1.0.0"
     },
     {
-       "name": "jetstack/etcd",
-       "version_requirement": ">= 0.2.0-rc1 < 1.0.0"
+      "name": "jetstack/etcd",
+      "version_requirement": ">= 0.1.0 < 1.0.0"
     },
     {
-       "name": "jetstack/aws_ebs",
-       "version_requirement": ">= 0.1.2-rc3 < 1.0.0"
+      "name": "jetstack/aws_ebs",
+      "version_requirement": ">= 0.1.0 < 1.0.0"
     },
     {
-       "name": "jetstack/vault_client",
-       "version_requirement": ">= 0.1.2-rc3 < 1.0.0"
+      "name": "jetstack/vault_client",
+      "version_requirement": ">= 0.1.0 < 1.0.0"
     }
   ],
   "data_provider": null,
-  "long_description" : "This module is part of [Tarmak](http://docs.tarmak.io) and should currently be considered alpha.\n\n[![Travis](https://img.shields.io/travis/jetstack/puppet-module-tarmak.svg)](https://travis-ci.org/jetstack/puppet-module-tarmak/)"
+  "long_description": "This module is part of [Tarmak](http://docs.tarmak.io) and should currently be considered alpha.\n\n[![Travis](https://img.shields.io/travis/jetstack/puppet-module-tarmak.svg)](https://travis-ci.org/jetstack/puppet-module-tarmak/)"
 }


### PR DESCRIPTION
We were seeing this misleading error on the wing servers:
```
msg="Warning: ModuleLoader: module 'tarmak' has unresolved dependencies - it will only see those that are resolved. Use 'puppet module list --tree' to see information about modules" app=wing cmd=puppet
```
It's not as serious as it since the node can still converge.

This commit relaxes the minimum version requirement.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Relax tarmak puppet module dependencies
```
