### PR TITLE
Restart the wing agent service on-failure

### DIFF
--- a/terraform/amazon/modules/kubernetes/templates/puppet_agent_user_data.yaml
+++ b/terraform/amazon/modules/kubernetes/templates/puppet_agent_user_data.yaml
@@ -19,6 +19,8 @@ write_files:
     Environment=AIRWORTHY_HASH=2d69cfe0b92f86481805c28d0b8ae47a8ffa6bb2373217e7c5215d61fc9efa1d
     Environment=WING_VERSION=0.3.0
     PermissionsStartOnly=true
+    Restart=on-failure
+    RestartSec=3
     ExecStartPre=/bin/sh -c '\
       set -e ;\
       test -x /opt/wing-$${WING_VERSION}/wing && exit 0 ;\
@@ -29,7 +31,7 @@ write_files:
         chmod 755 /opt/airworthy-$${AIRWORTHY_VERSION}/airworthy ;\
       fi ;\
       /opt/airworthy-$${AIRWORTHY_VERSION}/airworthy download --output /opt/wing-$${WING_VERSION}/wing --sha256sums https://github.com/jetstack/tarmak/releases/download/$${WING_VERSION}/tarmak_$${WING_VERSION}_checksums.txt  --signature-armored https://github.com/jetstack/tarmak/releases/download/$${WING_VERSION}/tarmak_$${WING_VERSION}_checksums.txt.asc https://github.com/jetstack/tarmak/releases/download/$${WING_VERSION}/wing_$${WING_VERSION}_linux_amd64'
-      ExecStart=/bin/sh -c 'exec /opt/wing-$${WING_VERSION}/wing agent --manifest-url "s3://${puppet_tar_gz_bucket_path}" --cluster-name "${tarmak_cluster}" --instance-name "$$(curl --silent --retry 5 http://169.254.169.254/latest/meta-data/instance-id || echo "unknown")" --server-url "https://bastion.${tarmak_environment}.${tarmak_dns_root}:9443"'
+    ExecStart=/bin/sh -c 'exec /opt/wing-$${WING_VERSION}/wing agent --manifest-url "s3://${puppet_tar_gz_bucket_path}" --cluster-name "${tarmak_cluster}" --instance-name "$$(curl --silent --retry 5 http://169.254.169.254/latest/meta-data/instance-id || echo "unknown")" --server-url "https://bastion.${tarmak_environment}.${tarmak_dns_root}:9443"'
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
**What this PR does / why we need it**:
If the wing fails to start we should restart it because otherwise it's a manual task to ssh in and restart it.

This will attempt a restart if the service fails in anyway - this included the ExecStartPre commands. Restarts will be attempted every 3 seconds.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #230

**Special notes for your reviewer**:
I've only tested this with a local unit - haven't actually run it in a real cluster.

```release-note
Restart the wing agent service on-failure
```
