### PR TITLE
vault-helper dry run and delete

### DIFF
--- a/pkg/tarmak/environment/environment.go
+++ b/pkg/tarmak/environment/environment.go
@@ -159,6 +159,7 @@ func (e *Environment) Variables() map[string]interface{} {
 	output["state_cluster_name"] = e.HubCluster.Name()
 	output["tools_cluster_name"] = e.HubCluster.Name()
 	output["vault_cluster_name"] = e.HubCluster.Name()
+	output["tarmak_version"] = e.tarmak.Version()
 	return output
 }
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -105,10 +105,11 @@ func (a *Amazon) Reset() {
 // This parameters should include non sensitive information to identify a provider
 func (a *Amazon) Parameters() map[string]string {
 	p := map[string]string{
-		"name":          a.Name(),
-		"cloud":         a.Cloud(),
-		"public_zone":   a.conf.Amazon.PublicZone,
-		"bucket_prefix": a.conf.Amazon.BucketPrefix,
+		"name":           a.Name(),
+		"cloud":          a.Cloud(),
+		"public_zone":    a.conf.Amazon.PublicZone,
+		"bucket_prefix":  a.conf.Amazon.BucketPrefix,
+		"tarmak_version": a.tarmak.Version(),
 	}
 	if a.conf.Amazon.VaultPath != "" {
 		p["vault_path"] = a.conf.Amazon.VaultPath
@@ -278,6 +279,7 @@ func (a *Amazon) Variables() map[string]interface{} {
 	output["public_zone"] = a.conf.Amazon.PublicZone
 	output["public_zone_id"] = a.conf.Amazon.PublicHostedZoneID
 	output["bucket_prefix"] = a.conf.Amazon.BucketPrefix
+	output["tarmak_version"] = a.tarmak.Version()
 
 	return output
 }

--- a/pkg/terraform/providers/tarmak/resource_vault_cluster.go
+++ b/pkg/terraform/providers/tarmak/resource_vault_cluster.go
@@ -70,6 +70,7 @@ func resourceTarmakVaultClusterCreate(d *schema.ResourceData, meta interface{}) 
 		VaultCA:            vaultCA,
 		VaultKMSKeyID:      vaultKMSKeyID,
 		VaultUnsealKeyName: vaultUnsealKeyName,
+		Create:             true,
 	}
 
 	log.Print("[DEBUG] calling rpc vault cluster status")
@@ -105,11 +106,11 @@ func resourceTarmakVaultClusterRead(d *schema.ResourceData, meta interface{}) (e
 	args := &tarmakRPC.VaultClusterStatusArgs{
 		VaultInternalFQDNs: vaultInternalFQDNs,
 		VaultCA:            vaultCA,
+		Create:             false,
 	}
 
 	log.Print("[DEBUG] calling rpc vault cluster init status")
 	var reply tarmakRPC.VaultClusterStatusReply
-	// TODO: verify that all Ensure operations have succeeded, not just initialisation
 	err = client.Call(tarmakRPC.VaultClusterInitStatusCall, args, &reply)
 	if err != nil {
 		d.SetId("")
@@ -121,6 +122,29 @@ func resourceTarmakVaultClusterRead(d *schema.ResourceData, meta interface{}) (e
 }
 
 func resourceTarmakVaultClusterDelete(d *schema.ResourceData, meta interface{}) (err error) {
+	client := meta.(*rpc.Client)
+
+	vaultInternalFQDNs := []string{}
+	for _, internalFQDN := range d.Get("internal_fqdns").([]interface{}) {
+		vaultInternalFQDNs = append(vaultInternalFQDNs, internalFQDN.(string))
+	}
+	vaultCA := d.Get("vault_ca").(string)
+
+	args := &tarmakRPC.VaultClusterStatusArgs{
+		VaultInternalFQDNs: vaultInternalFQDNs,
+		VaultCA:            vaultCA,
+		Create:             false,
+	}
+
+	log.Print("[DEBUG] calling rpc vault cluster delete")
+	var reply tarmakRPC.VaultClusterStatusReply
+	err = client.Call(tarmakRPC.VaultClusterDeleteCall, args, &reply)
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("status", reply.Status)
 	d.SetId("")
 	return nil
 }

--- a/pkg/terraform/providers/tarmak/resource_vault_instance_role.go
+++ b/pkg/terraform/providers/tarmak/resource_vault_instance_role.go
@@ -45,6 +45,11 @@ func resourceTarmakVaultInstanceRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tarmak_version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -60,12 +65,20 @@ func resourceTarmakVaultInstanceRoleCreate(d *schema.ResourceData, meta interfac
 	}
 	vaultCA := d.Get("vault_ca").(string)
 
+	old, new := d.GetChange("tarmak_version")
+
+	force := false
+	if old.(string) != new.(string) {
+		force = true
+	}
+
 	args := &tarmakRPC.VaultInstanceRoleArgs{
 		VaultClusterName:   clusterName,
 		RoleName:           roleName,
 		VaultInternalFQDNs: vaultInternalFQDNs,
 		VaultCA:            vaultCA,
 		Create:             true,
+		Force:              force,
 	}
 
 	log.Printf("[DEBUG] calling rpc vault instance role for role %s", roleName)
@@ -101,7 +114,7 @@ func resourceTarmakVaultInstanceRoleRead(d *schema.ResourceData, meta interface{
 		RoleName:           roleName,
 		VaultInternalFQDNs: vaultInternalFQDNs,
 		VaultCA:            vaultCA,
-		Create:             true,
+		Create:             false,
 	}
 
 	log.Printf("[DEBUG] calling rpc vault instance role for role %s", roleName)

--- a/pkg/terraform/providers/tarmak/rpc/rpc.go
+++ b/pkg/terraform/providers/tarmak/rpc/rpc.go
@@ -6,6 +6,7 @@ import (
 	"net/rpc"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 
@@ -21,6 +22,7 @@ const (
 type tarmakRPC struct {
 	cluster interfaces.Cluster
 	tarmak  interfaces.Tarmak
+	mu      sync.Mutex
 }
 
 func (r *tarmakRPC) log() *logrus.Entry {
@@ -31,6 +33,7 @@ func New(cluster interfaces.Cluster) Tarmak {
 	return &tarmakRPC{
 		tarmak:  cluster.Environment().Tarmak(),
 		cluster: cluster,
+		mu:      sync.Mutex{},
 	}
 }
 

--- a/pkg/terraform/providers/tarmak/rpc/vault_instance_role.go
+++ b/pkg/terraform/providers/tarmak/rpc/vault_instance_role.go
@@ -2,6 +2,7 @@
 package rpc
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/jetstack/vault-helper/pkg/kubernetes"
@@ -19,6 +20,7 @@ type VaultInstanceRoleArgs struct {
 	VaultInternalFQDNs []string
 	VaultCA            string
 	Create             bool
+	Force              bool
 }
 
 type VaultInstanceRoleReply struct {
@@ -58,10 +60,29 @@ func (r *tarmakRPC) VaultInstanceRole(args *VaultInstanceRoleArgs, result *Vault
 	k := kubernetes.New(vaultClient, r.tarmak.Log())
 	k.SetClusterID(r.tarmak.Cluster().ClusterName())
 
-	if err := k.Ensure(); err != nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	changesNeeded, err := k.EnsureDryRun()
+	if err != nil {
 		err = fmt.Errorf("vault cluster is not ready: %s", err)
 		r.tarmak.Log().Error(err)
 		return err
+	}
+
+	if changesNeeded || args.Force {
+		if args.Create {
+			if err := k.Ensure(); err != nil {
+				err = fmt.Errorf("vault cluster is not ready: %s", err)
+				r.tarmak.Log().Error(err)
+				return err
+			}
+
+		} else {
+			err = errors.New("changes needed to vault")
+			r.tarmak.Log().Error(err)
+			return err
+		}
 	}
 
 	initTokens := k.InitTokens()

--- a/terraform/amazon/modules/kubernetes/inputs.tf
+++ b/terraform/amazon/modules/kubernetes/inputs.tf
@@ -77,3 +77,5 @@ variable "public_zone_id" {}
 variable "vault_security_group_id" {}
 
 variable "bastion_security_group_id" {}
+
+variable "tarmak_version" {}

--- a/terraform/amazon/modules/kubernetes/vault.tf
+++ b/terraform/amazon/modules/kubernetes/vault.tf
@@ -5,11 +5,12 @@ resource "tarmak_vault_cluster" "vault" {
   vault_unseal_key_name = "${var.vault_unseal_key_name}"
 }
 
-resource "tarmak_vault_instance_role" "master" {  
+resource "tarmak_vault_instance_role" "master" {
   role_name = "master"
   vault_cluster_name = "${var.vault_cluster_name}"
   internal_fqdns = ["${var.internal_fqdns}"]
   vault_ca = "${var.vault_ca}"
+  tarmak_version = "${var.tarmak_version}"
 
   depends_on = ["tarmak_vault_cluster.vault"]
 }
@@ -19,6 +20,7 @@ resource "tarmak_vault_instance_role" "worker" {
   vault_cluster_name = "${var.vault_cluster_name}"
   internal_fqdns = ["${var.internal_fqdns}"]
   vault_ca = "${var.vault_ca}"
+  tarmak_version = "${var.tarmak_version}"
 
   depends_on = ["tarmak_vault_cluster.vault"]
 }
@@ -28,6 +30,7 @@ resource "tarmak_vault_instance_role" "etcd" {
   vault_cluster_name = "${var.vault_cluster_name}"
   internal_fqdns = ["${var.internal_fqdns}"]
   vault_ca = "${var.vault_ca}"
+  tarmak_version = "${var.tarmak_version}"
 
   depends_on = ["tarmak_vault_cluster.vault"]
 }

--- a/terraform/amazon/modules/vault/inputs.tf
+++ b/terraform/amazon/modules/vault/inputs.tf
@@ -83,5 +83,3 @@ data "template_file" "stack_name" {
 data "template_file" "vault_unseal_key_name" {
   template = "vault-${var.environment}-"
 }
-
-

--- a/terraform/amazon/modules/vault/vault_instances.tf
+++ b/terraform/amazon/modules/vault/vault_instances.tf
@@ -106,3 +106,12 @@ resource "aws_ebs_volume" "vault" {
     #prevent_destroy = true
   }
 }
+
+resource "tarmak_vault_cluster" "vault" {
+  internal_fqdns = ["${aws_route53_record.per-instance.*.fqdn}"]
+  vault_ca = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"
+  vault_kms_key_id = "${element(split("/", var.secrets_kms_arn), 1)}"
+  vault_unseal_key_name = "${data.template_file.vault_unseal_key_name.rendered}"
+
+  depends_on = ["aws_instance.vault","tls_locally_signed_cert.vault","aws_route53_record.per-instance"]
+}

--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -42,6 +42,8 @@ variable "secrets_bucket" {
   default = ""
 }
 
+variable "tarmak_version" {}
+
 {{ if or (eq .ClusterType .ClusterTypeClusterSingle) (eq .ClusterType .ClusterTypeHub)}}
 
 

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -171,6 +171,7 @@ module "kubernetes" {
   public_zone_id = "${module.state.public_zone_id}"
   vault_security_group_id = "${module.vault.vault_security_group_id}"
   bastion_security_group_id = "${module.bastion.bastion_security_group_id}"
+  tarmak_version = "${var.tarmak_version}"
 }
 {{end}}
 
@@ -222,5 +223,6 @@ module "kubernetes" {
   vault_ca = "${data.terraform_remote_state.hub_state.vault_vault_ca}"
   vault_url = "${data.terraform_remote_state.hub_state.vault_vault_url}"
   vault_security_group_id = "${data.terraform_remote_state.hub_state.vault_vault_security_group_id}"
+  tarmak_version = "${var.tarmak_version}"
 }
 {{end}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use new vault-helper api to use a dry run on ensure. This means nothing is changed if not needed & a terraform plan will return if changes are needed. Also uses delete on terraform destroy. 

A vault-helper ensure will happen with a hub apply.

**Which issue this PR fixes** 
fixes #180
fixes #168 

**Special notes for your reviewer**:
Uses vault-helper 0.9.12

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
vault-helper initialises PKI during cluster hub apply
```
