### PR TITLE
Ensure templated files are truncated

### DIFF
--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -58,7 +58,11 @@ func (t *Terraform) GenerateCode(c interfaces.Cluster) (err error) {
 			"puppet.tar.gz",
 		),
 	)
-	file, err := os.OpenFile(puppetTarGzFilename, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := os.OpenFile(
+		puppetTarGzFilename,
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		0600,
+	)
 	if err != nil {
 		return fmt.Errorf("error creating %s: %s", puppetTarGzFilename, err)
 	}
@@ -163,7 +167,7 @@ func (t *terraformTemplate) generateTemplate(name string) error {
 			t.destDir,
 			fmt.Sprintf("%s.tf", name),
 		),
-		os.O_RDWR|os.O_CREATE,
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
 		0644,
 	)
 	if err != nil {
@@ -214,7 +218,7 @@ func (t *terraformTemplate) generateInstanceTemplates() error {
 			t.destDir,
 			fmt.Sprintf("modules/kubernetes/%s.tf", name),
 		),
-		os.O_RDWR|os.O_CREATE,
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
 		0644,
 	)
 	if err != nil {
@@ -271,7 +275,7 @@ func (t *terraformTemplate) generateTerraformVariables() error {
 			t.destDir,
 			"terraform.tfvars",
 		),
-		os.O_RDWR|os.O_CREATE,
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
 		0644,
 	)
 	if err != nil {
@@ -293,7 +297,7 @@ func (t *terraformTemplate) generateRemoteStateConfig() error {
 			t.destDir,
 			"terraform_remote_state.tf",
 		),
-		os.O_RDWR|os.O_CREATE,
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
 		0644,
 	)
 	if err != nil {


### PR DESCRIPTION
Currently we don't truncate the files before writing to it. That creates
problems once the file gets shorter than the existing one, as it will
contain extra characters.

```release-note
Ensure templated files are truncated
```
