### PR TITLE
Suppress provider log output

### DIFF
--- a/pkg/terraform/passthrough.go
+++ b/pkg/terraform/passthrough.go
@@ -60,6 +60,7 @@ func newErrUI(out io.Writer, errOut io.Writer) cli.Ui {
 func newMeta(ui cli.Ui) command.Meta {
 	if os.Getenv("TF_LOG") == "" {
 		log.SetOutput(ioutil.Discard)
+		os.Stderr = nil
 	}
 
 	var inAutomation bool

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -167,7 +167,7 @@ func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string,
 
 		cmd := exec.Command(shell)
 		cmd.Dir = dir
-		// envVars variables will override any shell envs will equal key
+		// envVars variables will override any shell envs with equal key
 		cmd.Env = append(os.Environ(), envVars...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
@@ -209,6 +209,8 @@ func (t *Terraform) envVars(cluster interfaces.Cluster) ([]string, error) {
 	} else {
 		envVars = append(envVars, environmentProvider...)
 	}
+
+	envVars = append(envVars, fmt.Sprintf("TF_LOG=%s", os.Getenv("TF_LOG")))
 
 	return envVars, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Suppress terraform providers stderr when "TF_LOG="

fixes #246 

```release-note
NONE
```
