### PR TITLE
OIDC documentation

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -62,3 +62,5 @@ calicoctl
 Elasticsearch
 Logstash
 Jenkins
+prepended
+username

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -215,6 +215,28 @@ A full list of the configuration parameters are shown below:
         * ``port`` - Port to listen on (a free port will be chosen for you if
           omitted)
 
+OIDC Authentication
+~~~~~~~~~~~~~~~~~~~
+
+Tarmak supports authentication using OIDC. The following snippet demonstrates how you would configure OIDC authentication in `tarmak.yaml`. For details on the configuration options, visit the Kubernetes documentation `here <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens>`_. Note that if the version of your cluster is less than 1.10.0, the `signingAlgs` parameter is ignored.
+
+.. code-block:: yaml
+
+    kubernetes:
+        apiServer:
+            oidc:
+                clientID: 1a2b3c4d5e6f7g8h
+                groupsClaim: groups
+                groupsPrefix: "oidc:"
+                issuerURL: https://domain/application-server
+                signingAlgs:
+                - RS256
+                usernameClaim: preferred_username
+                usernamePrefix: "oidc:"
+    ...
+
+For the above setup, ID tokens presented to the apiserver will need to contain claims called `preferred_username` and `groups` representing the username and groups associated with the client. These values will then be prepended with `oidc:` before authorisation rules are applied, so it is important that this is taken into account when configuring cluster authorisation.
+
 Jenkins
 ~~~~~~~
 
@@ -246,28 +268,6 @@ When you set this annotation, your Jenkins will be secured with HTTPS. You need 
       size: 16Gi
       type: ssd
   ...
-
-OIDC Authentication
-~~~~~~~~~~~~~~~~~~~
-
-Tarmak supports authentication using OIDC. The following snippet demonstrates how you would configure OIDC authenication in `tarmak.yaml`. For details on the configuration options, visit the Kubernetes documentation [here](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens). Note that if the version of your cluster is less than 1.10.0, the `signingAlgs` parameter is ignored.
-
-.. code-block:: yaml
-
-    kubernetes:
-        apiServer:
-            oidc:
-                clientID: 0oaf5lzw2vmWkNeST0h7
-                groupsClaim: groups
-                groupsPrefix: "okta:"
-                issuerURL: https://dev-932361.oktapreview.com/oauth2/ausf5nwi4pzMmSdvh0h7
-                signingAlgs:
-                - RS256
-                usernameClaim: preferred_username
-                usernamePrefix: "okta:"
-    ...
-
-For the above setup, ID tokens presented to the apiserver will need to contain claims called `preferred_username` and `groups` representing the username and groups associated with the client. These values will then be prepended with `okta:` before authorisation rules are applied, so it is important that this is taken into account when configuring cluster authorisation.
 
 Setting up an AWS hosted Elasticsearch Cluster
 ++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -247,6 +247,28 @@ When you set this annotation, your Jenkins will be secured with HTTPS. You need 
       type: ssd
   ...
 
+OIDC Authentication
+~~~~~~~~~~~~~~~~~~~
+
+Tarmak supports authentication using OIDC. The following snippet demonstrates how you would configure OIDC authenication in `tarmak.yaml`. For details on the configuration options, visit the Kubernetes documentation [here](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens). Note that if the version of your cluster is less than 1.10.0, the `signingAlgs` parameter is ignored.
+
+.. code-block:: yaml
+
+    kubernetes:
+        apiServer:
+            oidc:
+                clientID: 0oaf5lzw2vmWkNeST0h7
+                groupsClaim: groups
+                groupsPrefix: "okta:"
+                issuerURL: https://dev-932361.oktapreview.com/oauth2/ausf5nwi4pzMmSdvh0h7
+                signingAlgs:
+                - RS256
+                usernameClaim: preferred_username
+                usernamePrefix: "okta:"
+    ...
+
+For the above setup, ID tokens presented to the apiserver will need to contain claims called `preferred_username` and `groups` representing the username and groups associated with the client. These values will then be prepended with `okta:` before authorisation rules are applied, so it is important that this is taken into account when configuring cluster authorisation.
+
 Setting up an AWS hosted Elasticsearch Cluster
 ++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -82,6 +82,11 @@ class kubernetes::apiserver(
     $_admission_control = $admission_control
   }
 
+  # check OIDC configuration parameters
+  if $oidc_signing_algs.length > 0 and versioncmp($::kubernetes::version, '1.10.0') < 0   {
+    $_oidc_signing_algs = []
+  }
+
   # Do not insecure bind the API server on kubernetes 1.6+
   $insecure_port = $::kubernetes::_apiserver_insecure_port
   $secure_port = $::kubernetes::apiserver_secure_port

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -83,7 +83,9 @@ class kubernetes::apiserver(
   }
 
   # check OIDC configuration parameters
-  if $oidc_signing_algs.length > 0 and versioncmp($::kubernetes::version, '1.10.0') < 0   {
+  if $oidc_signing_algs.length > 0 and versioncmp($::kubernetes::version, '1.10.0') >= 0 {
+    $_oidc_signing_algs = $oidc_signing_algs
+  } else {
     $_oidc_signing_algs = []
   }
 

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -114,7 +114,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @oidc_issuer_url -%>
   "--oidc-issuer-url=<%= @oidc_issuer_url %>" \
 <% end -%>
-<% if @_oidc_signing_algs.length > 0 -%>
+<% if @_oidc_signing_algs != [] -%>
   "--oidc-signing-algs=<%= @_oidc_signing_algs.join(',') %>" \
 <% end -%>
 <% if @oidc_username_claim -%>

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -114,8 +114,8 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @oidc_issuer_url -%>
   "--oidc-issuer-url=<%= @oidc_issuer_url %>" \
 <% end -%>
-<% if @oidc_signing_algs.length > 0 -%>
-  "--oidc-signing-algs=<%= @oidc_signing_algs.join(',') %>" \
+<% if @_oidc_signing_algs.length > 0 -%>
+  "--oidc-signing-algs=<%= @_oidc_signing_algs.join(',') %>" \
 <% end -%>
 <% if @oidc_username_claim -%>
   "--oidc-username-claim=<%= @oidc_username_claim %>" \


### PR DESCRIPTION
**What this PR does / why we need it**: This PR documents how to configure OIDC in tarmak and making sure the signingArgs parameter is only used when running Kubernetes version 1.10 or above.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #258 

```release-note
Add OIDC documentation
```
