### PR TITLE
Adds backoff to wing client set

### DIFF
--- a/pkg/tarmak/environment/bastion.go
+++ b/pkg/tarmak/environment/bastion.go
@@ -45,7 +45,7 @@ func (e *Environment) VerifyBastionAvailable() error {
 
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.InitialInterval = time.Second
-	expBackoff.MaxElapsedTime = time.Minute * 1
+	expBackoff.MaxElapsedTime = time.Minute * 2
 	b := backoff.WithContext(expBackoff, ctx)
 
 	executeSSH := func() error {

--- a/pkg/wing/puppet.go
+++ b/pkg/wing/puppet.go
@@ -17,15 +17,15 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cenkalti/backoff"
+	"github.com/docker/docker/pkg/archive"
+	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cenkalti/backoff"
-	"github.com/docker/docker/pkg/archive"
 	"github.com/jetstack/tarmak/pkg/apis/wing/v1alpha1"
 	"github.com/jetstack/tarmak/pkg/wing/provider/file"
 	"github.com/jetstack/tarmak/pkg/wing/provider/s3"
-	"golang.org/x/net/context"
 )
 
 // This make sure puppet is converged when neccessary


### PR DESCRIPTION
**What this PR does / why we need it**:
Use a backoff when connection to wing.

fixes #261

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
