### PR TITLE
Implement an external scrape mode for prometheus

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -80,6 +80,7 @@ type ClusterKubernetes struct {
 	Dashboard         *ClusterKubernetesDashboard         `json:"dashboard,omitempty"`
 	APIServer         *ClusterKubernetesAPIServer         `json:"apiServer,omitempty"`
 	PodSecurityPolicy *ClusterPodSecurityPolicy           `json:"podSecurityPolicy,omitempty"`
+	Prometheus        *ClusterKubernetesPrometheus        `json:"prometheus,omitempty"`
 }
 
 type ClusterKubernetesClusterAutoscaler struct {
@@ -145,6 +146,14 @@ type ClusterKubernetesAPIServerOIDC struct {
 
 type ClusterPodSecurityPolicy struct {
 	Enabled bool `json:"enabled,omitempty"`
+}
+
+// Configure the cluster internal deployment of prometheus
+type ClusterKubernetesPrometheus struct {
+	// Enable a cluster internal prometheus deployment, default: true
+	Enabled bool `json:"enabled,omitempty"`
+	// Only deploy/scrape Kubernetes external exporters, default: false
+	ExternalScrapeTargetsOnly bool `json:"externalScrapeTargetsOnly,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -143,6 +143,17 @@ func kubernetesClusterConfig(conf *clusterv1alpha1.ClusterKubernetes, hieraData 
 		}
 	}
 
+	// enabling prometheus if requested, default is to enable prometheus
+	if conf.Prometheus == nil || conf.Prometheus.Enabled {
+		// check if mode external scrape targets only is enabled
+		if conf.Prometheus != nil && conf.Prometheus.ExternalScrapeTargetsOnly {
+			hieraData.variables = append(hieraData.variables, "prometheus::external_scrape_targets_only: true")
+		} else {
+			hieraData.variables = append(hieraData.variables, "prometheus::external_scrape_targets_only: false")
+		}
+		hieraData.classes = append(hieraData.classes, `prometheus`)
+	}
+
 	return
 }
 

--- a/pkg/puppet/puppet_test.go
+++ b/pkg/puppet/puppet_test.go
@@ -2,6 +2,7 @@
 package puppet
 
 import (
+	"strings"
 	"testing"
 
 	clusterv1alpha1 "github.com/jetstack/tarmak/pkg/apis/cluster/v1alpha1"
@@ -26,8 +27,15 @@ func TestOIDCFields(t *testing.T) {
 
 	kubernetesClusterConfig(&c, &d)
 
-	if len(d.variables) != 7 {
-		t.Fatalf("unexpected number of variables: %d", len(d.variables))
+	count := 0
+	for _, v := range d.variables {
+		if strings.Contains(v, "oidc") {
+			count += 1
+		}
+	}
+
+	if act, exp := count, 7; act != exp {
+		t.Fatalf("unexpected number of variables: exp:%d act:%d", exp, act)
 	}
 
 }

--- a/puppet/hieradata/common.yaml
+++ b/puppet/hieradata/common.yaml
@@ -30,3 +30,6 @@ vault_client::init_role: "%{::tarmak_cluster}-%{::tarmak_role}"
 vault_client::ca_cert_path: /etc/vault/ca.pem
 vault_client::init_policies:
 - "%{::tarmak_cluster}/%{::tarmak_role}"
+
+prometheus::server::external_labels:
+  cluster: "%{::tarmak_cluster}"

--- a/puppet/hieradata/role/etcd.yaml
+++ b/puppet/hieradata/role/etcd.yaml
@@ -1,7 +1,6 @@
 ---
 classes:
 - tarmak::etcd
-- prometheus
 - airworthy::install
 
 tarmak::hostname: "%{::tarmak_hostname}"

--- a/puppet/hieradata/role/master.yaml
+++ b/puppet/hieradata/role/master.yaml
@@ -5,6 +5,5 @@ classes:
 - kubernetes_addons::heapster
 - kubernetes_addons::influxdb
 - kubernetes_addons::grafana
-- prometheus
 
 kubernetes::kubelet::role: master

--- a/puppet/hieradata/role/worker.yaml
+++ b/puppet/hieradata/role/worker.yaml
@@ -3,4 +3,3 @@ classes:
 - site_module::docker_storage
 - tarmak::worker
 - tarmak::overlay_calico
-- prometheus

--- a/puppet/modules/prometheus/manifests/init.pp
+++ b/puppet/modules/prometheus/manifests/init.pp
@@ -6,15 +6,18 @@ class prometheus(
   Integer[1025,65535] $etcd_k8s_main_port = $::prometheus::params::etcd_k8s_main_port,
   Integer[1025,65535] $etcd_k8s_events_port = $::prometheus::params::etcd_k8s_events_port,
   Integer[1024,65535] $etcd_overlay_port = $::prometheus::params::etcd_overlay_port,
+  Boolean $external_scrape_targets_only = false,
 ) inherits ::prometheus::params
 {
 
   if $role == 'master' {
     include ::prometheus::server
-    include ::prometheus::kube_state_metrics
-    include ::prometheus::node_exporter
-    include ::prometheus::blackbox_exporter
     include ::prometheus::blackbox_exporter_etcd
+    include ::prometheus::node_exporter
+    if ! $external_scrape_targets_only {
+      include ::prometheus::kube_state_metrics
+      include ::prometheus::blackbox_exporter
+    }
   }
 
   if $role == 'etcd' {

--- a/puppet/modules/prometheus/manifests/server.pp
+++ b/puppet/modules/prometheus/manifests/server.pp
@@ -10,6 +10,7 @@ class prometheus::server (
   Integer $persistent_volume_size = 15,
   String $kubernetes_token_file = '/var/run/secrets/kubernetes.io/serviceaccount/token',
   String $kubernetes_ca_file = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+  Hash[String,String] $external_labels = {},
 )
 {
   require ::kubernetes

--- a/puppet/modules/prometheus/manifests/server.pp
+++ b/puppet/modules/prometheus/manifests/server.pp
@@ -72,319 +72,321 @@ class prometheus::server (
       target  => 'prometheus-config',
   }
 
-
-  # Scrape config for API servers.
-  #
-  # Kubernetes exposes API servers as endpoints to the default/kubernetes
-  # service so this uses `endpoints` role and uses relabelling to only keep
-  # the endpoints associated with the default/kubernetes service using the
-  # default named port `https`. This works for single API server deployments as
-  # well as HA API server deployments.
-  prometheus::scrape_config { 'kubernetes-apiservers':
-    order  =>  100,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'endpoints',
-      }],
-      'tls_config'            => {
-        'ca_file' => $kubernetes_ca_file,
-      },
-      'bearer_token_file'     => $kubernetes_token_file,
-      'scheme'                => 'https',
-      'relabel_configs'       => [{
-        'source_labels' => ['__meta_kubernetes_namespace', '__meta_kubernetes_service_name', '__meta_kubernetes_endpoint_port_name'],
-        'action'        => 'keep',
-        'regex'         => 'default;kubernetes;https',
-      }],
-    }
-  }
-
-  # Scrape config for nodes (kubelet).
-  #
-  # Rather than connecting directly to the node, the scrape is proxied though the
-  # Kubernetes apiserver.  This means it will work if Prometheus is running out of
-  # cluster, or can't connect to nodes for some other reason (e.g. because of
-  # firewalling).
-  prometheus::scrape_config { 'kubernetes-nodes':
-    order  =>  110,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'node',
-      }],
-      'tls_config'            => {
-        'ca_file' => $kubernetes_ca_file,
-      },
-      'bearer_token_file'     => $kubernetes_token_file,
-      'scheme'                => 'https',
-      'relabel_configs'       => [{
-        'action' => 'labelmap',
-        'regex'  => '__meta_kubernetes_node_label_(.+)',
-      },{
-        'target_label' => '__address__',
-        'replacement'  => 'kubernetes.default.svc:443',
-      }, {
-        'source_labels' => ['__meta_kubernetes_node_name'],
-        'regex'         => '(.+)',
-        'target_label'  => '__metrics_path__',
-        'replacement'   => '/api/v1/nodes/${1}/proxy/metrics',
-      }],
-    }
-  }
-
-
-  # Scrape config for Kubelet cAdvisor.
-  #
-  # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
-  # (those whose names begin with 'container_') have been removed from the
-  # Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
-  # retrieve those metrics.
-  #
-  # In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
-  # HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
-  # in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
-  # the --cadvisor-port=0 Kubelet flag).
-  #
-  # This job is not necessary and should be removed in Kubernetes 1.6 and
-  # earlier versions, or it will cause the metrics to be scraped twice.
-  prometheus::scrape_config { 'kubernetes-nodes-cadvisor':
-    order  =>  120,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'node',
-      }],
-      'tls_config'            => {
-        'ca_file' => $kubernetes_ca_file,
-      },
-      'bearer_token_file'     => $kubernetes_token_file,
-      'scheme'                => 'https',
-      'relabel_configs'       => [{
-        'action' => 'labelmap',
-        'regex'  => '__meta_kubernetes_node_label_(.+)',
-      },{
-        'target_label' => '__address__',
-        'replacement'  => 'kubernetes.default.svc:443',
-      }, {
-        'source_labels' => ['__meta_kubernetes_node_name'],
-        'regex'         => '(.+)',
-        'target_label'  => '__metrics_path__',
-        'replacement'   => '/api/v1/nodes/${1}/proxy/metrics/cadvisor',
-      }],
-    }
-  }
-
-  # Scrape config for service endpoints.
-  #
-  # The relabeling allows the actual service scrape endpoint to be configured
-  # via the following annotations:
-  #
-  # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
-  # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
-  # to set this to `https` & most likely set the `tls_config` of the scrape config.
-  # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-  # * `prometheus.io/port`: If the metrics are exposed on a different port to the
-  # service then set this appropriately.
-  prometheus::scrape_config { 'kubernetes-service-endpoints':
-    order  =>  200,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'endpoints',
-      }],
-
-      'relabel_configs'       => [
-        {
-          'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_scrape'],
+  $external_scrape_targets_only = $::prometheus::external_scrape_targets_only
+  if ! $external_scrape_targets_only {
+    # Scrape config for API servers.
+    #
+    # Kubernetes exposes API servers as endpoints to the default/kubernetes
+    # service so this uses `endpoints` role and uses relabelling to only keep
+    # the endpoints associated with the default/kubernetes service using the
+    # default named port `https`. This works for single API server deployments as
+    # well as HA API server deployments.
+    prometheus::scrape_config { 'kubernetes-apiservers':
+      order  =>  100,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'endpoints',
+        }],
+        'tls_config'            => {
+          'ca_file' => $kubernetes_ca_file,
+        },
+        'bearer_token_file'     => $kubernetes_token_file,
+        'scheme'                => 'https',
+        'relabel_configs'       => [{
+          'source_labels' => ['__meta_kubernetes_namespace', '__meta_kubernetes_service_name', '__meta_kubernetes_endpoint_port_name'],
           'action'        => 'keep',
-          'regex'         => true,
+          'regex'         => 'default;kubernetes;https',
+        }],
+      }
+    }
+
+    # Scrape config for nodes (kubelet).
+    #
+    # Rather than connecting directly to the node, the scrape is proxied though the
+    # Kubernetes apiserver.  This means it will work if Prometheus is running out of
+    # cluster, or can't connect to nodes for some other reason (e.g. because of
+    # firewalling).
+    prometheus::scrape_config { 'kubernetes-nodes':
+      order  =>  110,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'node',
+        }],
+        'tls_config'            => {
+          'ca_file' => $kubernetes_ca_file,
         },
-        {
-          'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_scheme'],
-          'action'        => 'replace',
-          'target_label'  => '__scheme__',
-          'regex'         => '(https?)',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_path'],
-          'action'        => 'replace',
-          'target_label'  => '__metrics_path__',
-          'regex'         => '(.+)',
-        },
-        {
-          'source_labels' => ['__address__', '__meta_kubernetes_service_annotation_prometheus_io_port'],
-          'action'        => 'replace',
-          'target_label'  => '__address__',
-          'regex'         => '(.+)(?::\d+);(\d+)',
-          'replacement'   => '$1:$2',
-        },
-        {
+        'bearer_token_file'     => $kubernetes_token_file,
+        'scheme'                => 'https',
+        'relabel_configs'       => [{
           'action' => 'labelmap',
-          'regex'  => '__meta_kubernetes_service_label_(.+)',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_namespace'],
-          'action'        => 'replace',
-          'target_label'  => 'kubernetes_namespace',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_service_name'],
-          'action'        => 'replace',
-          'target_label'  => 'kubernetes_name',
-        }
-      ]
-    }
-  }
-
-  # Example scrape config for probing services via the Blackbox Exporter.
-  #
-  # The relabeling allows the actual service scrape endpoint to be configured
-  # via the following annotations:
-  #
-  # * `prometheus.io/probe`: Only probe services that have a value of `true`
-  prometheus::scrape_config { 'kubernetes-services':
-    order  =>  210,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'service'
-      }],
-      'metrics_path'          => '/probe',
-      'params'                => {
-        'module' => ['http_2xx'],
-      },
-      'relabel_configs'       => [
-        {
-          'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_probe'],
-          'action'        => 'keep',
-          'regex'         => true,
-        },
-        {
-          'source_labels' => ['__address__'],
-          'target_label'  => '__param_target',
-        },
-        {
+          'regex'  => '__meta_kubernetes_node_label_(.+)',
+        },{
           'target_label' => '__address__',
-          'replacement'  => 'blackbox-exporter',
-        },
-        {
-          'source_labels' => ['__param_target'],
-          'target_label'  => 'instance',
-        },
-        {
-          'action' => 'labelmap',
-          'regex'  => '__meta_kubernetes_service_label_(.+)',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_service_namespace'],
-          'target_label'  => 'kubernetes_namespace',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_service_name'],
-          'target_label'  => 'kubernetes_name',
-        },
-      ]
-    },
-  }
-
-
-  # Example scrape config for probing ingresses via the Blackbox Exporter.
-  #
-  # The relabeling allows the actual ingress scrape endpoint to be configured
-  # via the following annotations:
-  #
-  # * `prometheus.io/probe`: Only probe ingresses that have a value of `true`
-  prometheus::scrape_config { 'kubernetes-ingresses':
-    order  =>  220,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'ingress'
-      }],
-      'metrics_path'          => '/probe',
-      'params'                => {
-        'module' => ['http_2xx'],
-      },
-      'relabel_configs'       => [
-        {
-          'source_labels' => ['__meta_kubernetes_ingress_annotation_prometheus_io_probe'],
-          'action'        => 'keep',
-          'regex'         => true,
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_ingress_scheme','__address__','__meta_kubernetes_ingress_path'],
-          'target_label'  => '__param_target',
-          'regex'         => '(.+);(.+);(.+)',
-          'replacement'   => '${1}://${2}${3}',
-        },
-        {
-          'target_label' => '__address__',
-          'replacement'  => 'blackbox-exporter',
-        },
-        {
-          'source_labels' => ['__param_target'],
-          'target_label'  => 'instance',
-        },
-        {
-          'action' => 'labelmap',
-          'regex'  => '__meta_kubernetes_ingress_label_(.+)',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_ingress_namespace'],
-          'target_label'  => 'kubernetes_namespace',
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_ingress_name'],
-          'target_label'  => 'kubernetes_name',
-        },
-      ]
-    },
-  }
-
-  # Example scrape config for pods
-  #
-  # The relabeling allows the actual pod scrape endpoint to be configured via the
-  # following annotations:
-  #
-  # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
-  # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-  # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
-  # pod's declared ports (default is a port-free target if none are declared).
-  prometheus::scrape_config { 'kubernetes-pods':
-    order  =>  230,
-    config => {
-      'kubernetes_sd_configs' => [{
-        'role' => 'pod'
-      }],
-      'relabel_configs'       => [
-        {
-          'source_labels' => ['__meta_kubernetes_pod_annotation_prometheus_io_scrape'],
-          'action'        => 'keep',
-          'regex'         => true,
-        },
-        {
-          'source_labels' => ['__meta_kubernetes_pod_annotation_prometheus_io_path'],
-          'action'        => 'replace',
-          'target_label'  => '__metrics_path__',
+          'replacement'  => 'kubernetes.default.svc:443',
+        }, {
+          'source_labels' => ['__meta_kubernetes_node_name'],
           'regex'         => '(.+)',
+          'target_label'  => '__metrics_path__',
+          'replacement'   => '/api/v1/nodes/${1}/proxy/metrics',
+        }],
+      }
+    }
+
+
+    # Scrape config for Kubelet cAdvisor.
+    #
+    # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
+    # (those whose names begin with 'container_') have been removed from the
+    # Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
+    # retrieve those metrics.
+    #
+    # In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
+    # HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
+    # in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
+    # the --cadvisor-port=0 Kubelet flag).
+    #
+    # This job is not necessary and should be removed in Kubernetes 1.6 and
+    # earlier versions, or it will cause the metrics to be scraped twice.
+    prometheus::scrape_config { 'kubernetes-nodes-cadvisor':
+      order  =>  120,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'node',
+        }],
+        'tls_config'            => {
+          'ca_file' => $kubernetes_ca_file,
         },
-        {
-          'source_labels' => ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port'],
-          'action'        => 'replace',
-          'regex'         => '([^:]+)(?::\d+)?;(\d+)',
-          'replacement'   => '${1}:${2}',
-          'target_label'  => '__address__',
-        },
-        {
+        'bearer_token_file'     => $kubernetes_token_file,
+        'scheme'                => 'https',
+        'relabel_configs'       => [{
           'action' => 'labelmap',
-          'regex'  => '__meta_kubernetes_pod_label_(.+)',
+          'regex'  => '__meta_kubernetes_node_label_(.+)',
+        },{
+          'target_label' => '__address__',
+          'replacement'  => 'kubernetes.default.svc:443',
+        }, {
+          'source_labels' => ['__meta_kubernetes_node_name'],
+          'regex'         => '(.+)',
+          'target_label'  => '__metrics_path__',
+          'replacement'   => '/api/v1/nodes/${1}/proxy/metrics/cadvisor',
+        }],
+      }
+    }
+
+    # Scrape config for service endpoints.
+    #
+    # The relabeling allows the actual service scrape endpoint to be configured
+    # via the following annotations:
+    #
+    # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
+    # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
+    # to set this to `https` & most likely set the `tls_config` of the scrape config.
+    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+    # * `prometheus.io/port`: If the metrics are exposed on a different port to the
+    # service then set this appropriately.
+    prometheus::scrape_config { 'kubernetes-service-endpoints':
+      order  =>  200,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'endpoints',
+        }],
+
+        'relabel_configs'       => [
+          {
+            'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_scrape'],
+            'action'        => 'keep',
+            'regex'         => true,
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_scheme'],
+            'action'        => 'replace',
+            'target_label'  => '__scheme__',
+            'regex'         => '(https?)',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_path'],
+            'action'        => 'replace',
+            'target_label'  => '__metrics_path__',
+            'regex'         => '(.+)',
+          },
+          {
+            'source_labels' => ['__address__', '__meta_kubernetes_service_annotation_prometheus_io_port'],
+            'action'        => 'replace',
+            'target_label'  => '__address__',
+            'regex'         => '(.+)(?::\d+);(\d+)',
+            'replacement'   => '$1:$2',
+          },
+          {
+            'action' => 'labelmap',
+            'regex'  => '__meta_kubernetes_service_label_(.+)',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_namespace'],
+            'action'        => 'replace',
+            'target_label'  => 'kubernetes_namespace',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_service_name'],
+            'action'        => 'replace',
+            'target_label'  => 'kubernetes_name',
+          }
+        ]
+      }
+    }
+
+    # Example scrape config for probing services via the Blackbox Exporter.
+    #
+    # The relabeling allows the actual service scrape endpoint to be configured
+    # via the following annotations:
+    #
+    # * `prometheus.io/probe`: Only probe services that have a value of `true`
+    prometheus::scrape_config { 'kubernetes-services':
+      order  =>  210,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'service'
+        }],
+        'metrics_path'          => '/probe',
+        'params'                => {
+          'module' => ['http_2xx'],
         },
-        {
-          'source_labels' => ['__meta_kubernetes_namespace'],
-          'action'        => 'replace',
-          'target_label'  => 'kubernetes_namespace',
+        'relabel_configs'       => [
+          {
+            'source_labels' => ['__meta_kubernetes_service_annotation_prometheus_io_probe'],
+            'action'        => 'keep',
+            'regex'         => true,
+          },
+          {
+            'source_labels' => ['__address__'],
+            'target_label'  => '__param_target',
+          },
+          {
+            'target_label' => '__address__',
+            'replacement'  => 'blackbox-exporter',
+          },
+          {
+            'source_labels' => ['__param_target'],
+            'target_label'  => 'instance',
+          },
+          {
+            'action' => 'labelmap',
+            'regex'  => '__meta_kubernetes_service_label_(.+)',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_service_namespace'],
+            'target_label'  => 'kubernetes_namespace',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_service_name'],
+            'target_label'  => 'kubernetes_name',
+          },
+        ]
+      },
+    }
+
+
+    # Example scrape config for probing ingresses via the Blackbox Exporter.
+    #
+    # The relabeling allows the actual ingress scrape endpoint to be configured
+    # via the following annotations:
+    #
+    # * `prometheus.io/probe`: Only probe ingresses that have a value of `true`
+    prometheus::scrape_config { 'kubernetes-ingresses':
+      order  =>  220,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'ingress'
+        }],
+        'metrics_path'          => '/probe',
+        'params'                => {
+          'module' => ['http_2xx'],
         },
-        {
-          'source_labels' => ['__meta_kubernetes_pod_name'],
-          'action'        => 'replace',
-          'target_label'  => 'kubernetes_pod_name',
-        }
-      ]
+        'relabel_configs'       => [
+          {
+            'source_labels' => ['__meta_kubernetes_ingress_annotation_prometheus_io_probe'],
+            'action'        => 'keep',
+            'regex'         => true,
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_ingress_scheme','__address__','__meta_kubernetes_ingress_path'],
+            'target_label'  => '__param_target',
+            'regex'         => '(.+);(.+);(.+)',
+            'replacement'   => '${1}://${2}${3}',
+          },
+          {
+            'target_label' => '__address__',
+            'replacement'  => 'blackbox-exporter',
+          },
+          {
+            'source_labels' => ['__param_target'],
+            'target_label'  => 'instance',
+          },
+          {
+            'action' => 'labelmap',
+            'regex'  => '__meta_kubernetes_ingress_label_(.+)',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_ingress_namespace'],
+            'target_label'  => 'kubernetes_namespace',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_ingress_name'],
+            'target_label'  => 'kubernetes_name',
+          },
+        ]
+      },
+    }
+
+    # Example scrape config for pods
+    #
+    # The relabeling allows the actual pod scrape endpoint to be configured via the
+    # following annotations:
+    #
+    # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
+    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+    # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
+    # pod's declared ports (default is a port-free target if none are declared).
+    prometheus::scrape_config { 'kubernetes-pods':
+      order  =>  230,
+      config => {
+        'kubernetes_sd_configs' => [{
+          'role' => 'pod'
+        }],
+        'relabel_configs'       => [
+          {
+            'source_labels' => ['__meta_kubernetes_pod_annotation_prometheus_io_scrape'],
+            'action'        => 'keep',
+            'regex'         => true,
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_pod_annotation_prometheus_io_path'],
+            'action'        => 'replace',
+            'target_label'  => '__metrics_path__',
+            'regex'         => '(.+)',
+          },
+          {
+            'source_labels' => ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port'],
+            'action'        => 'replace',
+            'regex'         => '([^:]+)(?::\d+)?;(\d+)',
+            'replacement'   => '${1}:${2}',
+            'target_label'  => '__address__',
+          },
+          {
+            'action' => 'labelmap',
+            'regex'  => '__meta_kubernetes_pod_label_(.+)',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_namespace'],
+            'action'        => 'replace',
+            'target_label'  => 'kubernetes_namespace',
+          },
+          {
+            'source_labels' => ['__meta_kubernetes_pod_name'],
+            'action'        => 'replace',
+            'target_label'  => 'kubernetes_pod_name',
+          }
+        ]
+      }
     }
   }
 

--- a/puppet/modules/prometheus/templates/prometheus-config-global.yaml.erb
+++ b/puppet/modules/prometheus/templates/prometheus-config-global.yaml.erb
@@ -1,4 +1,5 @@
     global:
       scrape_interval:     15s
       evaluation_interval: 30s
-      # scrape_timeout is set to the global default (10s).
+      # scrape_timeout is set to the global default (10s)
+      external_labels: <%= @external_labels.to_json %>


### PR DESCRIPTION
This mode allows a tarmak prometheus deployment, which only contains
scrape_configs for nodes outside of the cluster

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Implement an external scrape mode for prometheus
```
