### PR TITLE
Add subnets/availability zones to the hub instance pools

### DIFF
--- a/pkg/tarmak/cluster/init.go
+++ b/pkg/tarmak/cluster/init.go
@@ -36,6 +36,8 @@ func Init(init interfaces.Initialize) (cluster *clusterv1alpha1.Cluster, err err
 		clusterType = tarmakv1alpha1.EnvironmentTypeMulti
 	}
 
+	availabilityZones, err := init.CurrentEnvironment().Provider().AskInstancePoolZones(init)
+
 	// add single cluster
 
 	if clusterType == tarmakv1alpha1.EnvironmentTypeMulti {
@@ -54,7 +56,9 @@ func Init(init interfaces.Initialize) (cluster *clusterv1alpha1.Cluster, err err
 			}
 		}
 		if !hubExists {
-			err := init.Config().AppendCluster(config.NewHub(environment.Name()))
+			clusterHub := config.NewHub(environment.Name())
+			addAvailabilityZones(clusterHub, availabilityZones)
+			err := init.Config().AppendCluster(clusterHub)
 			if err != nil {
 				return nil, err
 			}
@@ -65,7 +69,6 @@ func Init(init interfaces.Initialize) (cluster *clusterv1alpha1.Cluster, err err
 		cluster = config.NewClusterSingle(environment.Name(), "cluster")
 	}
 
-	availabilityZones, err := init.CurrentEnvironment().Provider().AskInstancePoolZones(init)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The instance pools of the hub didn't receive the assigned subnets/availability zones from tarmak init. This change fixes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #162 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add subnets/availability zones to the hub instance pools.
```
