### PR TITLE
Change resource so that we can run a clean terraform destroy

### DIFF
--- a/terraform/amazon/modules/bastion/outputs.tf
+++ b/terraform/amazon/modules/bastion/outputs.tf
@@ -1,6 +1,7 @@
 output "bastion_instance_id" {
-  value = "${aws_instance.bastion.id}"
+  value = "${element(concat(aws_instance.bastion.*.id, list("")), 0)}"
 }
+
 
 output "bastion_fqdn" {
   value = "${aws_route53_record.bastion.fqdn}"
@@ -15,7 +16,7 @@ output "bastion_ip" {
 }
 
 output "bastion_security_group_id" {
-  value = "${aws_security_group.bastion.id}"
+  value = "${element(concat(aws_security_group.bastion.*.id, list("")), 0)}"
 }
 
 output "remote_admin_security_group_id" {

--- a/terraform/amazon/modules/jenkins/outputs.tf
+++ b/terraform/amazon/modules/jenkins/outputs.tf
@@ -1,5 +1,5 @@
 output "jenkins_fqdn" {
-  value = "${aws_route53_record.jenkins_elb.fqdn}"
+  value = "${element(concat(aws_route53_record.jenkins_elb.*.fqdn, list("")), 0)}"
 }
 
 output "jenkins_security_group_id" {
@@ -11,5 +11,5 @@ output "jenkins_dns_name" {
 }
 
 output "jenkins_url" {
-  value = "https://${aws_route53_record.jenkins_elb.fqdn}"
+  value = "https://${element(concat(aws_route53_record.jenkins_elb.*.fqdn, list("")), 0)}"
 }

--- a/terraform/amazon/modules/network/igw.tf
+++ b/terraform/amazon/modules/network/igw.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "main" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = "${aws_vpc.main.0.id}"
 
   tags {
     Name        = "vpc.${data.template_file.stack_name.rendered}"

--- a/terraform/amazon/modules/network/outputs.tf
+++ b/terraform/amazon/modules/network/outputs.tf
@@ -1,9 +1,9 @@
 output "vpc_id" {
-  value = "${aws_vpc.main.id}"
+  value = "${element(concat(aws_vpc.main.*.id, list("")), 0)}"
 }
 
 output "vpc_net" {
-  value = "${aws_vpc.main.cidr_block}"
+  value = "${element(concat(aws_vpc.main.*.id, list("")), 0)}"
 }
 
 output "stack_name" {

--- a/terraform/amazon/modules/network/route53.tf
+++ b/terraform/amazon/modules/network/route53.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_zone" "private" {
   count         = "${signum(length(var.private_zone))}"
   name          = "${var.private_zone}"
-  vpc_id        = "${aws_vpc.main.id}"
+  vpc_id        = "${aws_vpc.main.0.id}"
   force_destroy = true
   comment       = "Hosted zone for private kubernetes in ${var.environment}"
 

--- a/terraform/amazon/modules/network/routes.tf
+++ b/terraform/amazon/modules/network/routes.tf
@@ -1,5 +1,5 @@
 resource "aws_route_table" "public" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = "${aws_vpc.main.0.id}"
 
   tags {
     Name        = "${data.template_file.stack_name.rendered}_public"
@@ -17,7 +17,7 @@ resource "aws_route" "public" {
 
 resource "aws_route_table" "private" {
   count  = "${length(var.availability_zones)}"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = "${aws_vpc.main.0.id}"
 
   tags {
     Name        = "${data.template_file.stack_name.rendered}_private_${var.availability_zones[count.index]}"

--- a/terraform/amazon/modules/network/subnets.tf
+++ b/terraform/amazon/modules/network/subnets.tf
@@ -1,6 +1,6 @@
 resource "aws_subnet" "public" {
   count                   = "${length(var.availability_zones)}"
-  vpc_id                  = "${aws_vpc.main.id}"
+  vpc_id                  = "${aws_vpc.main.0.id}"
   cidr_block              = "${cidrsubnet(cidrsubnet(aws_vpc.main.cidr_block, 3, 0), 3, count.index)}"
   availability_zone       = "${var.availability_zones[count.index]}"
   map_public_ip_on_launch = true
@@ -19,7 +19,7 @@ resource "aws_subnet" "public" {
 
 resource "aws_subnet" "private" {
   count             = "${length(var.availability_zones)}"
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = "${aws_vpc.main.0.id}"
   cidr_block        = "${cidrsubnet(aws_vpc.main.cidr_block, 3, count.index + 1)}"
   availability_zone = "${var.availability_zones[count.index]}"
 

--- a/terraform/amazon/modules/network/vpc.tf
+++ b/terraform/amazon/modules/network/vpc.tf
@@ -1,4 +1,5 @@
 resource "aws_vpc" "main" {
+  count                = 1
   cidr_block           = "${var.network}"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/terraform/amazon/modules/network/vpc_endpoints.tf
+++ b/terraform/amazon/modules/network/vpc_endpoints.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id          = "${aws_vpc.main.id}"
+  vpc_id          = "${aws_vpc.main.0.id}"
   service_name    = "com.amazonaws.${var.region}.s3"
   route_table_ids = ["${aws_route_table.private.*.id}"]
 }

--- a/terraform/amazon/modules/network/vpc_peering.tf
+++ b/terraform/amazon/modules/network/vpc_peering.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc_peering_connection" "peering" {
   count       = "${signum(length(var.vpc_peer_stack))}"
   peer_vpc_id = "${var.peer_vpc_id}"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = "${aws_vpc.main.0.id}"
   auto_accept = true
 
   accepter {
@@ -44,5 +44,5 @@ resource "aws_route" "them_peering_private" {
 resource "aws_route53_zone_association" "hub_zone" {
   count   = "${signum(length(var.vpc_peer_stack))}"
   zone_id = "${var.private_zone_id}"
-  vpc_id  = "${aws_vpc.main.id}"
+  vpc_id  = "${aws_vpc.main.0.id}"
 }

--- a/terraform/amazon/modules/vault/outputs.tf
+++ b/terraform/amazon/modules/vault/outputs.tf
@@ -1,9 +1,9 @@
 output "vault_ca" {
-  value = "${tls_self_signed_cert.ca.cert_pem}"
+  value = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"
 }
 
 output "vault_url" {
-  value = "https://${aws_route53_record.endpoint.fqdn}:8200"
+  value = "https://${element(concat(aws_route53_record.endpoint.*.fqdn, list("")), 0)}:8200"
 }
 
 output "vault_kms_key_id" {
@@ -19,7 +19,7 @@ output "instance_fqdns" {
 }
 
 output "vault_security_group_id" {
-  value = "${aws_security_group.vault.id}"
+  value = "${element(concat(aws_security_group.vault.*.id, list("")), 0)}"
 }
 
 output "vault_aws_caller_identity_current_account_id" {

--- a/terraform/amazon/modules/vault/tls.tf
+++ b/terraform/amazon/modules/vault/tls.tf
@@ -1,5 +1,6 @@
 # CA certificate
 resource "tls_private_key" "ca" {
+  count     = 1
   algorithm = "RSA"
   rsa_bits  = "4096"
 }
@@ -57,9 +58,9 @@ resource "tls_locally_signed_cert" "vault" {
 
   cert_request_pem = "${element(tls_cert_request.vault.*.cert_request_pem, count.index)}"
 
-  ca_key_algorithm   = "${tls_self_signed_cert.ca.key_algorithm}"
+  ca_key_algorithm   = "${tls_self_signed_cert.ca.0.key_algorithm}"
   ca_private_key_pem = "${tls_private_key.ca.private_key_pem}"
-  ca_cert_pem        = "${tls_self_signed_cert.ca.cert_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.ca.0.cert_pem}"
 
   # 1 year
   validity_period_hours = 8766

--- a/terraform/amazon/modules/vault/tls_s3.tf
+++ b/terraform/amazon/modules/vault/tls_s3.tf
@@ -17,9 +17,9 @@ resource "aws_s3_bucket_object" "node-keys" {
 }
 
 resource "aws_s3_bucket_object" "ca-cert" {
-  key          = "vault/ca.pem-${md5(tls_self_signed_cert.ca.cert_pem)}"
+  key          = "vault/ca.pem-${md5(tls_self_signed_cert.ca.0.cert_pem)}"
   bucket       = "${var.secrets_bucket}"
   kms_key_id   = "${var.secrets_kms_arn}"
-  content      = "${tls_self_signed_cert.ca.cert_pem}"
+  content      = "${tls_self_signed_cert.ca.0.cert_pem}"
   content_type = "text/plain"
 }

--- a/terraform/amazon/modules/vault/vault_dns.tf
+++ b/terraform/amazon/modules/vault/vault_dns.tf
@@ -8,6 +8,7 @@ resource "aws_route53_record" "per-instance" {
 }
 
 resource "aws_route53_record" "endpoint" {
+  count   = 1
   zone_id = "${var.private_zone_id}"
   name    = "vault"
   type    = "A"

--- a/terraform/amazon/modules/vault/vault_instances.tf
+++ b/terraform/amazon/modules/vault/vault_instances.tf
@@ -66,7 +66,7 @@ resource "aws_instance" "vault" {
   private_ip           = "${cidrhost(element(var.private_subnets, count.index % length(var.availability_zones)),(10 + (count.index/length(var.availability_zones))))}"
 
   vpc_security_group_ids = [
-    "${aws_security_group.vault.id}",
+    "${aws_security_group.vault.0.id}",
   ]
 
   root_block_device = {

--- a/terraform/amazon/modules/vault/vault_sg.tf
+++ b/terraform/amazon/modules/vault/vault_sg.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "vault" {
+  count  = 1
   name   = "${data.template_file.stack_name.rendered}-vault"
   vpc_id = "${var.vpc_id}"
 
@@ -16,7 +17,7 @@ resource "aws_security_group_rule" "vault_out_allow_all" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.vault.id}"
+  security_group_id = "${aws_security_group.vault.0.id}"
 }
 
 resource "aws_security_group_rule" "vault_in_allow_ssh_bastion" {
@@ -26,7 +27,7 @@ resource "aws_security_group_rule" "vault_in_allow_ssh_bastion" {
   protocol  = "tcp"
 
   source_security_group_id = "${var.bastion_security_group_id}"
-  security_group_id        = "${aws_security_group.vault.id}"
+  security_group_id        = "${aws_security_group.vault.0.id}"
 }
 
 resource "aws_security_group_rule" "vault_in_allow_vault_bastion" {
@@ -36,7 +37,7 @@ resource "aws_security_group_rule" "vault_in_allow_vault_bastion" {
   protocol  = "tcp"
 
   source_security_group_id = "${var.bastion_security_group_id}"
-  security_group_id        = "${aws_security_group.vault.id}"
+  security_group_id        = "${aws_security_group.vault.0.id}"
 }
 
 resource "aws_security_group_rule" "vault_in_allow_everything_inner_cluster" {
@@ -44,6 +45,6 @@ resource "aws_security_group_rule" "vault_in_allow_everything_inner_cluster" {
   from_port                = 0
   to_port                  = 0
   protocol                 = "-1"
-  security_group_id        = "${aws_security_group.vault.id}"
-  source_security_group_id = "${aws_security_group.vault.id}"
+  security_group_id        = "${aws_security_group.vault.0.id}"
+  source_security_group_id = "${aws_security_group.vault.0.id}"
 }

--- a/terraform/amazon/templates/instance_pools/role_elb.tf.template
+++ b/terraform/amazon/templates/instance_pools/role_elb.tf.template
@@ -105,6 +105,7 @@ output "ingress_wildcard_fqdn" {
 #}
 
 resource "aws_route53_record" "{{.Role.TFName}}_elb" {
+  count   = 1
   zone_id = "${var.public_zone_id}"
 {{ if eq .Role.Name "jenkins" -}}
   name    = "jenkins.${var.environment}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Some outputs were giving errors that it couldn't find an attribute of a resource when running terraform destroy. We had to implement a little hack/workaround to fix this. We add a count of 1 to the resource where the output gave an error. In the output we used the concat and element interpolation functions to fix the ouput. This is based on https://github.com/hashicorp/terraform/issues/16681#issuecomment-345105956 and we see this error since 0.11 (More information on that https://www.terraform.io/upgrade-guides/0-11.html#referencing-attributes-from-resources-with-count-0)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #257

**Special notes for your reviewer**: If you test this, you also need to incorporate PR #270 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix errors on clusters destroy command
```
