### PR TITLE
Ensure terraform destroy runs without refreshing data sources

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -308,7 +308,7 @@ func (t *Terraform) Destroy(cluster interfaces.Cluster) error {
 	return t.terraformWrapper(
 		cluster,
 		"destroy",
-		[]string{"-force"},
+		[]string{"-force", "-refresh=false"},
 	)
 }
 


### PR DESCRIPTION
This fixes a condition where you are not able to destroy because of an unreachable vault_cluster/bastion


```release-note
Run terraform destroy without refreshing data sources
```
