### PR TITLE
Improve vault tunnel creation

### DIFF
--- a/pkg/tarmak/ssh/tunnel.go
+++ b/pkg/tarmak/ssh/tunnel.go
@@ -47,7 +47,7 @@ func (t *Tunnel) Start() error {
 	var err error
 
 	// ensure there is connectivity to the bastion
-	args := append(t.sshCommand, "-N", "bastion", "/bin/true")
+	args := append(t.sshCommand, "bastion", "/bin/true")
 	cmd := exec.Command(args[0], args[1:len(args)]...)
 
 	t.log.Debugf("check SSH connection to bastion cmd=%s", cmd.Args)

--- a/pkg/tarmak/vault/vault.go
+++ b/pkg/tarmak/vault/vault.go
@@ -24,7 +24,7 @@ const (
 	VaultStateUnsealed
 	VaultStateUnintialised
 	VaultStateErr
-	vaultTunnelCreationTimeoutSeconds = 5
+	vaultTunnelCreationTimeoutSeconds = 100
 )
 
 const (
@@ -108,7 +108,7 @@ func (v *Vault) TunnelFromFQDNs(vaultInternalFQDNs []string, vaultCA string) (in
 				return
 			}
 
-			if health.Standby == false && health.Sealed == false {
+			if health.Standby == false && health.Sealed == false && health.Initialized == true {
 				activeNode <- pos
 			}
 

--- a/pkg/tarmak/vault/vault.go
+++ b/pkg/tarmak/vault/vault.go
@@ -24,6 +24,7 @@ const (
 	VaultStateUnsealed
 	VaultStateUnintialised
 	VaultStateErr
+	vaultTunnelCreationTimeoutSeconds = 5
 )
 
 const (
@@ -109,20 +110,25 @@ func (v *Vault) TunnelFromFQDNs(vaultInternalFQDNs []string, vaultCA string) (in
 
 			if health.Standby == false && health.Sealed == false {
 				activeNode <- pos
-
 			}
 
 		}(pos)
 	}
 
-	activePos := <-activeNode
+	var activePos int
+	select {
+	case activePos = <-activeNode:
+		v.log.Debug("active channel position recieved")
+	case <-time.After(vaultTunnelCreationTimeoutSeconds * time.Second):
+		return nil, fmt.Errorf("failed to retrieve active channel position")
+	}
 
 	go func(activePos int) {
 
 		// wait for all tunnel attempts
 		wg.Wait()
 
-		// stop tunnels
+		// stop non-active tunnels
 		for pos, _ := range tunnels {
 			if pos == activePos {
 				continue


### PR DESCRIPTION
This PR fixes the following:
- when testing connection to the bastion before creating vault tunnels, we use the `-N` flag, which shouldn't be used as we are running a remote command (`/bin/true`)
- when creating vault tunnels, if a problem occurs, there was a chance we could hang indefinitely - this change reduces the chance of a blocking channel so that this hanging doesn't occur

```release-note
Improve Vault tunnel creation preventing indefinite hanging in certain situations
```
