### PR TITLE
Run kube services under system slice

### DIFF
--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -30,7 +30,7 @@ class kubernetes::kubelet(
     default  => 'cgroupfs',
   },
   String $cgroup_root = '/',
-  Optional[String] $cgroup_kube_name = '/podruntime.slice',
+  Optional[String] $cgroup_kube_name = undef,
   Optional[String] $cgroup_kube_reserved_memory = '256Mi',
   Optional[String] $cgroup_kube_reserved_cpu = '10m',
   Optional[String] $cgroup_system_name = '/system.slice',

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -211,6 +211,7 @@ describe 'kubernetes::kubelet' do
 
       context 'with both cpu and memory a supplied' do
         let(:params) { {
+          "cgroup_kube_name" => "/podruntime.slice",
           "cgroup_#{cgroup_type}_reserved_cpu"    => '100m',
           "cgroup_#{cgroup_type}_reserved_memory" => '128Mi',
         }}
@@ -221,6 +222,7 @@ describe 'kubernetes::kubelet' do
 
       context 'with only cpu supplied' do
         let(:params) { {
+          "cgroup_kube_name" => "/podruntime.slice",
           "cgroup_#{cgroup_type}_reserved_cpu"    => '100m',
           "cgroup_#{cgroup_type}_reserved_memory" => nil,
         }}
@@ -231,6 +233,7 @@ describe 'kubernetes::kubelet' do
 
       context 'with only memory supplied' do
         let(:params) { {
+          "cgroup_kube_name" => "/podruntime.slice",
           "cgroup_#{cgroup_type}_reserved_cpu"    => nil,
           "cgroup_#{cgroup_type}_reserved_memory" => '128Mi',
         }}
@@ -241,6 +244,7 @@ describe 'kubernetes::kubelet' do
 
       context 'with nothing supplied' do
         let(:params) { {
+          "cgroup_kube_name" => "/podruntime.slice",
           "cgroup_#{cgroup_type}_reserved_cpu"    => nil,
           "cgroup_#{cgroup_type}_reserved_memory" => nil,
         }}

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -4,7 +4,12 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
-Slice=podruntime.slice
+<%
+  if scope['kubernetes::kubelet::cgroup_kube_name']
+  @cgroup_kube_basename = scope.call_function('regsubst', [scope['kubernetes::kubelet::cgroup_kube_name'], '^\/', ''])
+-%>
+  Slice=<%= @cgroup_kube_basename %>
+<% end -%>
 User=<%= scope['kubernetes::user'] %>
 Group=<%= scope['kubernetes::group'] %>
 <%- if scope['kubernetes::_service_account_key_file'] and scope['kubernetes::service_account_key_generate'] -%>

--- a/puppet/modules/kubernetes/templates/kube-controller-manager.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-controller-manager.service.erb
@@ -4,7 +4,12 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
-Slice=podruntime.slice
+<%
+  if scope['kubernetes::kubelet::cgroup_kube_name']
+  @cgroup_kube_basename = scope.call_function('regsubst', [scope['kubernetes::kubelet::cgroup_kube_name'], '^\/', ''])
+-%>
+  Slice=<%= @cgroup_kube_basename %>
+<% end -%>
 User=<%= scope['kubernetes::user'] %>
 Group=<%= scope['kubernetes::group'] %>
 <%- if scope['kubernetes::_service_account_key_file'] and scope['kubernetes::service_account_key_generate'] -%>

--- a/puppet/modules/kubernetes/templates/kube-proxy.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy.service.erb
@@ -10,7 +10,17 @@ ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-ip6tables=1
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \
   --v=<%= scope['kubernetes::log_level'] %> \
   --cluster-cidr=<%= scope['kubernetes::pod_network'] %> \
-  --resource-container=podruntime.slice \
+<%
+  if scope['kubernetes::kubelet::cgroup_kube_name']
+  @cgroup_kube_basename = scope.call_function('regsubst', [scope['kubernetes::kubelet::cgroup_kube_name'], '^\/', ''])
+-%>
+  --resource-container=<%= @cgroup_kube_basename %> \
+<%
+  elsif scope['kubernetes::kubelet::cgroup_system_name']
+  @cgroup_system_basename = scope.call_function('regsubst', [scope['kubernetes::kubelet::cgroup_system_name'], '^\/', ''])
+-%>
+  --resource-container=<%= @cgroup_system_basename %> \
+<% end -%>
 <% if @kubeconfig_path -%>
   --kubeconfig=<%= @kubeconfig_path %> \
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kube-scheduler.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-scheduler.service.erb
@@ -4,7 +4,12 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
-Slice=podruntime.slice
+<%
+  if scope['kubernetes::kubelet::cgroup_kube_name']
+  @cgroup_kube_basename = scope.call_function('regsubst', [scope['kubernetes::kubelet::cgroup_kube_name'], '^\/', ''])
+-%>
+  Slice=<%= @cgroup_kube_basename %>
+<% end -%>
 User=<%= scope['kubernetes::user'] %>
 Group=<%= scope['kubernetes::group'] %>
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/scheduler \

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -4,7 +4,12 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 
 [Service]
-Slice=podruntime.slice
+<%
+  if @cgroup_kube_name
+  @cgroup_kube_basename = scope.call_function('regsubst', [@cgroup_kube_name, '^\/', ''])
+-%>
+Slice=<%= @cgroup_kube_basename %>
+<% end -%>
 WorkingDirectory=<%= @kubelet_dir %>
 <% if @cloud_provider == 'aws' -%>
 # prevent metadata service access on AWS
@@ -73,9 +78,6 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --cgroup-driver=<%= @cgroup_driver %> \
   --cgroup-root=<%= @cgroup_root %> \
 <% if @cgroup_kube_name -%>
-  --kube-reserved-cgroup=<%= @cgroup_kube_name %> \
-  --runtime-cgroups=<%= @cgroup_kube_name %> \
-  --kubelet-cgroups=<%= @cgroup_kube_name %> \
 <%
     # build kube reserved command line
     @cgroup_kube_reserved = []
@@ -83,6 +85,9 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
     @cgroup_kube_reserved << "memory=#{@cgroup_kube_reserved_memory}" unless @cgroup_kube_reserved_memory.nil? or @cgroup_kube_reserved_memory == 'nil'
     if @cgroup_kube_reserved.length > 0
 -%>
+  --kube-reserved-cgroup=<%= @cgroup_kube_name %> \
+  --runtime-cgroups=<%= @cgroup_kube_name %> \
+  --kubelet-cgroups=<%= @cgroup_kube_name %> \
   "--kube-reserved=<%= @cgroup_kube_reserved.join(',') %>" \
 <% end -%>
 <% end -%>

--- a/puppet/modules/site_module/manifests/docker_config.pp
+++ b/puppet/modules/site_module/manifests/docker_config.pp
@@ -3,10 +3,17 @@ class site_module::docker_config {
     ensure  => file,
     content => template('site_module/docker.erb'),
   }
-  file { '/etc/systemd/system/docker.service.d':
-    ensure  => directory,
-  } -> file { '/etc/systemd/system/docker.service.d/10-slice.conf':
-    ensure  => directory,
-    content => '[Service]\nSlice=podruntime.slice\n',
+
+  if $kubernetes::kubelet::cgroup_kube_name {
+
+    $cgroup_kube_basename = regsubst( $kubernetes::kubelet::cgroup_kube_name, '^\/', '')
+
+    file { '/etc/systemd/system/docker.service.d':
+      ensure  => directory,
+    } -> file { '/etc/systemd/system/docker.service.d/10-slice.conf':
+      ensure  => directory,
+      content => "[Service]\nSlice=${cgroup_kube_basename}\n",
+    }
+
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: We want the option (enabled by default) to run the kube services under `/system.slice`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #297 

```release-note
Run kubelet under /system.slice so that system and kube services get priority over eachother's spare resource if there is resource contention
```
