### PR TITLE
Change cgroup driver from systemd to cgroupfs

### DIFF
--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -26,7 +26,6 @@ class kubernetes::kubelet(
   $pod_cidr = undef,
   $hostname_override = undef,
   Enum['systemd', 'cgroupfs'] $cgroup_driver =  $::osfamily ? {
-    'RedHat' => 'systemd',
     default  => 'cgroupfs',
   },
   String $cgroup_root = '/',

--- a/puppet/modules/kubernetes/spec/acceptance/single_node_spec.rb
+++ b/puppet/modules/kubernetes/spec/acceptance/single_node_spec.rb
@@ -66,6 +66,9 @@ class{'kubernetes::worker':
       # Ensure docker is setup
       hosts_as('master').each do |host|
         on host, 'yum install -y docker'
+        on host, 'cp -a /usr/lib/systemd/system/docker.service /etc/systemd/system/docker.service'
+        on host, 'sed -i -e \'s/systemd/cgroupfs/g\' /etc/systemd/system/docker.service'
+        on host, 'systemctl daemon-reload'
         on host, 'systemctl start docker.service'
       end
     end

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -190,7 +190,7 @@ describe 'kubernetes::kubelet' do
 
       context 'on redhat family os' do
         let(:facts) { {'osfamily' => 'RedHat' } }
-        it { should contain_file(service_file).with_content(%r{--cgroup-driver=systemd}) }
+        it { should contain_file(service_file).with_content(%r{--cgroup-driver=cgroupfs}) }
       end
 
       context 'on anything but redhat family os' do

--- a/puppet/modules/site_module/files/20-cgroupfs.conf
+++ b/puppet/modules/site_module/files/20-cgroupfs.conf
@@ -1,0 +1,16 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd-current \
+          --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current \
+          --default-runtime=docker-runc \
+          --exec-opt native.cgroupdriver=cgroupfs \
+          --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
+          --init-path=/usr/libexec/docker/docker-init-current \
+          --seccomp-profile=/etc/docker/seccomp.json \
+          $OPTIONS \
+          $DOCKER_STORAGE_OPTIONS \
+          $DOCKER_NETWORK_OPTIONS \
+          $ADD_REGISTRY \
+          $BLOCK_REGISTRY \
+          $INSECURE_REGISTRY \
+          $REGISTRIES

--- a/puppet/modules/site_module/manifests/docker.pp
+++ b/puppet/modules/site_module/manifests/docker.pp
@@ -1,12 +1,25 @@
 class site_module::docker{
 
+  $service_name = 'docker'
+  $path = defined('$::path') ? {
+      default => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+      true    => $::path
+  }
+
   package{'docker':
     ensure  => present,
   }
   -> class{'site_module::docker_config':}
-  -> service{'docker.service':
+  ~> exec { "${service_name}-daemon-reload":
+    command     => 'systemctl daemon-reload',
+    path        => $path,
+    refreshonly => true,
+  }
+  -> service{"${service_name}.service":
     ensure => running,
     enable => true,
+    hasstatus  => true,
+    hasrestart => true,
   }
 
   if defined(Class['kubernetes::kubelet']){

--- a/puppet/modules/site_module/manifests/docker_config.pp
+++ b/puppet/modules/site_module/manifests/docker_config.pp
@@ -3,10 +3,15 @@ class site_module::docker_config {
     ensure  => file,
     content => template('site_module/docker.erb'),
   }
-  file { '/etc/systemd/system/docker.service.d':
+  file { "/etc/systemd/system/${::site_module::docker::service_name}.service.d":
     ensure  => directory,
   } -> file { '/etc/systemd/system/docker.service.d/10-slice.conf':
     ensure  => file,
     content => "[Service]\nSlice=podruntime.slice\n",
+    notify  => Service["${::site_module::docker::service_name}.service"],
+  } -> file { '/etc/systemd/system/docker.service.d/20-cgroupfs.conf':
+    ensure  => file,
+    content => file('site_module/20-cgroupfs.conf'),
+    notify  => Service["${::site_module::docker::service_name}.service"],
   }
 }

--- a/puppet/modules/tarmak/spec/acceptance/single_node_spec.rb
+++ b/puppet/modules/tarmak/spec/acceptance/single_node_spec.rb
@@ -54,6 +54,9 @@ class{'tarmak::single_node':
         # make sure curl unzip vim is installed
         if fact_on(host, 'osfamily') == 'RedHat'
           on(host, 'yum install -y unzip docker')
+          on(host, 'cp -a /usr/lib/systemd/system/docker.service /etc/systemd/system/docker.service')
+          on(host, 'sed -i -e \'s/systemd/cgroupfs/g\' /etc/systemd/system/docker.service')
+          on(host, 'systemctl daemon-reload')
         elsif fact_on(host, 'osfamily') == 'Debian'
           on(host, 'apt-get install -y unzip apt-transport-https ca-certificates curl python-software-properties')
           on(host, 'apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D')


### PR DESCRIPTION
**What this PR does / why we need it**: When using the systemd driver, node allocatable limits are not being set properly by kubelet. Switching driver to cgroupfs fixes this issue.

```release-note
Change cgroup driver from systemd to cgroupfs for docker and kubelet
```
