### PR TITLE
Fix docker slice drop-in

### DIFF
--- a/puppet/modules/site_module/manifests/docker_config.pp
+++ b/puppet/modules/site_module/manifests/docker_config.pp
@@ -6,7 +6,7 @@ class site_module::docker_config {
   file { '/etc/systemd/system/docker.service.d':
     ensure  => directory,
   } -> file { '/etc/systemd/system/docker.service.d/10-slice.conf':
-    ensure  => directory,
-    content => '[Service]\nSlice=podruntime.slice\n',
+    ensure  => file,
+    content => "[Service]\nSlice=podruntime.slice\n",
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: The docker slice drop-in is currently creating a directory instead of a file. The quoting is also rendering the content incorrectly. This change fixes this so that docker actually runs under podruntime.slice.

```release-note
Run docker under podruntime.slice
```
