### PR TITLE
Fix stateful instance naming

### DIFF
--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -82,9 +82,6 @@ variable "bastion_root_size" {
 }
 {{ if .JenkinsInstall -}}
 variable "jenkins_ami" {}
-variable "jenkins_stack_name_prefix" {
-  default = "jenkins-"
-}
 variable "jenkins_instance_type" {
   default = "t2.large"
 }

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -168,13 +168,13 @@ resource "aws_instance" "{{.TFName}}" {
   }
 
   tags {
-    Name               = "${data.template_file.stack_name.rendered}-k8s-{{.TFName}}-${count.index+1}"
+    Name               = "${data.template_file.stack_name.rendered}-{{.DNSName}}-${count.index+1}"
     Environment        = "${var.environment}"
     Project            = "${var.project}"
     Contact            = "${var.contact}"
     {{.TFName}}_Volume_Attach = "${data.template_file.stack_name.rendered}-k8s-{{.TFName}}-${count.index+1}"
-    Role               = "{{.TFName}}"
-    tarmak_role        = "{{.TFName}}-${count.index+1}"
+    Role               = "{{.Role.Name}}"
+    tarmak_role        = "{{.Role.Name}}-${count.index+1}"
   }
 
   user_data = "${element(data.template_file.{{.TFName}}_user_data.*.rendered, count.index)}"

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -92,7 +92,7 @@ module "jenkins" {
   certificate_arn = "${var.jenkins_certificate_arn}"
   admin_ips = ["${var.admin_ips}"]
   public_zone_id = "${module.state.public_zone_id}"
-  stack_name_prefix = "${var.jenkins_stack_name_prefix}"
+  stack_name_prefix = "${var.stack_name_prefix}"
   availability_zones = ["${var.availability_zones}"]
   name = "${var.name}"
 }


### PR DESCRIPTION
**What this PR does / why we need it**: stateful instances are named incorrectly (including the word k8s) and containing hyphens which was inconsistent with the stateless instances. Additionally, jenkins instances had a special prefix  resulting in `tarmak clusters instances list` not working properly. This PR fixes that

```release-note
NONE
```
