### PR TITLE
Adds set-current cluster subcommand

### DIFF
--- a/cmd/tarmak/cmd/cluster_set-current.go
+++ b/cmd/tarmak/cmd/cluster_set-current.go
@@ -1,0 +1,45 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/jetstack/tarmak/pkg/tarmak"
+)
+
+var clusterSetCurrentCmd = &cobra.Command{
+	Use:   "set-current",
+	Short: "Set current cluster in config",
+	Run: func(cmd *cobra.Command, args []string) {
+		t := tarmak.New(globalFlags)
+		defer t.Cleanup()
+
+		if len(args) != 1 {
+			t.Log().Fatalf("Only one cluster can be set as current cluster")
+		}
+
+		found := false
+	LOOP:
+		for _, env := range t.Environments() {
+			for _, cluster := range env.Clusters() {
+				if args[0] == cluster.ClusterName() {
+					found = true
+					break LOOP
+				}
+			}
+		}
+
+		if !found {
+			t.Log().Fatalf("Failed to find cluster '%s' in config", args[0])
+		}
+
+		if err := t.Config().SetCurrentCluster(args[0]); err != nil {
+			t.Log().Fatalf("Failed to set current cluster in config: %v", err)
+		}
+
+	},
+}
+
+func init() {
+	clusterCmd.AddCommand(clusterSetCurrentCmd)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the only way to  set the current cluster is to edit the yaml. This adds a new cluster subcommand, set-current, that gives the option to change the current-cluster in the CLI.

fixes #155 

```release-note
Add subcommand to set-current cluster
```
