### PR TITLE
Use ClusterFirstWithHostNet for fluent-bit daemon set

### DIFF
--- a/puppet/modules/fluent_bit/templates/fluent-bit-daemonset.yaml.erb
+++ b/puppet/modules/fluent_bit/templates/fluent-bit-daemonset.yaml.erb
@@ -22,6 +22,7 @@ spec:
         prometheus.io/path: /api/v1/metrics/prometheus
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: fluent-bit
         image: "<%= @fluent_bit_image %>:<%= @fluent_bit_version %>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this, setting `hostNetwork: true` will prevent the shipping of
logs to an in-cluster target.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

It appears others are configuring fluent-bit in this way:
https://github.com/openstack/openstack-helm-infra/blob/master/fluent-logging/templates/daemonset-fluent-bit.yaml#L98

**Release note**:

```release-note
Configure ClusterFirstWithHostNet dnsPolicy for fluent-bit
```
