### PR TITLE
Pass through etcd instance pool min count to puppet

### DIFF
--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -332,6 +332,11 @@ func (p *Puppet) writeHieraData(puppetPath string, cluster interfaces.Cluster) e
 			variables = append(variables, fmt.Sprintf(`kubernetes_addons::cluster_autoscaler::instance_pool_name: "%s"`, workerInstancePoolName))
 		}
 
+		// etcd
+		if instancePool.Role().Name() == clusterv1alpha1.KubernetesEtcdRoleName {
+			variables = append(variables, fmt.Sprintf(`tarmak::etcd_instances: %d`, instancePool.MinCount()))
+		}
+
 		//  classes
 		err = p.writeLines(
 			filepath.Join(hieraPath, "instance_pools", fmt.Sprintf("%s_classes.yaml", instancePool.Name())), classes,

--- a/puppet/hieradata/common.yaml
+++ b/puppet/hieradata/common.yaml
@@ -12,9 +12,6 @@ tarmak::etcd_advertise_client_network: 10.0.0.0/8
 tarmak::cloud_provider: aws
 tarmak::kubernetes_api_url: "https://api.%{::tarmak_cluster}.%{::tarmak_dns_root}:6443"
 
-# TODO: This should come from terraform
-tarmak::etcd_instances: 3
-
 # point heapster to influxdb
 kubernetes_addons::heapster::sink: influxdb:http://monitoring-influxdb.kube-system:8086
 


### PR DESCRIPTION
**What this PR does / why we need it**: Currently the number of instances in an etcd cluster is hard coded to 3. This PR passes through the value from the etcd instance pool to puppet

```release-note
Pass through etcd instance pool min count to puppet
```
