### PR TITLE
Upgrade terraform to 0.11.7

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -869,8 +869,8 @@
     "tfdiags",
     "version"
   ]
-  revision = "dbce85d85ff0beebc660b3d1805b4ef15361af00"
-  version = "v0.11.6"
+  revision = "41e50bd32a8825a84535e353c3674af8ce799161"
+  version = "v0.11.7"
 
 [[projects]]
   name = "github.com/hashicorp/vault"
@@ -2035,6 +2035,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3085b95b7c4d2c1d02c95156083f277ba1cd0ed90fb3bf3123e2e7ae1f27e97a"
+  inputs-digest = "f6b75f0b21ff90f6ef740e7039d65701516193d86a280cd5fe3dc9d3d775a1d1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,7 +92,7 @@ required = [
 
 [[constraint]]
   name = "github.com/hashicorp/terraform"
-  version = "0.11.5"
+  version = "0.11.7"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-aws"

--- a/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
@@ -789,7 +789,8 @@ func (i *Interpolater) resourceCountMax(
 	// If we're NOT applying, then we assume we can read the count
 	// from the state. Plan and so on may not have any state yet so
 	// we do a full interpolation.
-	if i.Operation != walkApply {
+	// Don't forget walkDestroy, which is a special case of walkApply
+	if !(i.Operation == walkApply || i.Operation == walkDestroy) {
 		if cr == nil {
 			return 0, nil
 		}

--- a/vendor/github.com/hashicorp/terraform/version/version.go
+++ b/vendor/github.com/hashicorp/terraform/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-const Version = "0.11.6"
+const Version = "0.11.7"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
**What this PR does / why we need it**: Upgrades vendored terraform to the latest release (0.11.7)

```release-note
Upgrade vendored Terraform to version 0.11.7
```
