### PR TITLE
Fix errors when failing to parse config

### DIFF
--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -176,11 +176,11 @@ type Config interface {
 	AppendEnvironment(*tarmakv1alpha1.Environment) error
 	UniqueEnvironmentName(name string) error
 	// currently selected <env name>-<cluster name>
-	CurrentCluster() string
+	CurrentCluster() (string, error)
 	// currently selected cluster name
-	CurrentClusterName() string
+	CurrentClusterName() (string, error)
 	// currently selected env name
-	CurrentEnvironmentName() string
+	CurrentEnvironmentName() (string, error)
 	Contact() string
 	Project() string
 	WingDevMode() bool

--- a/pkg/tarmak/kubectl/kubectl.go
+++ b/pkg/tarmak/kubectl/kubectl.go
@@ -275,7 +275,11 @@ func (k *Kubectl) verifyAPIVersion(c api.Config) (version string, err error) {
 
 func (k *Kubectl) Kubectl(args []string) error {
 	if k.tarmak.Cluster().Type() == clusterv1alpha1.ClusterTypeHub {
-		return fmt.Errorf("the current cluster '%s' is a hub and therefore does not contain a Kubernetes cluster", k.tarmak.Config().CurrentCluster())
+		currentCluster, err := k.tarmak.Config().CurrentCluster()
+		if err != nil {
+			return fmt.Errorf("error retrieving current cluster: %s", err)
+		}
+		return fmt.Errorf("the current cluster '%s' is a hub and therefore does not contain a Kubernetes cluster", currentCluster)
 	}
 
 	tunnel, err := k.ensureWorkingKubeconfig()

--- a/pkg/tarmak/tarmak_test.go
+++ b/pkg/tarmak/tarmak_test.go
@@ -69,14 +69,14 @@ func (tt *testTarmak) fakeAWSProvider(name string) {
 func (tt *testTarmak) addEnvironment(env *tarmakv1alpha1.Environment) {
 	tt.environments = append(tt.environments, env)
 	tt.fakeConfig.EXPECT().Environment(env.Name).Return(env, nil)
-	tt.fakeConfig.EXPECT().CurrentEnvironmentName().Return(env.Name)
+	tt.fakeConfig.EXPECT().CurrentEnvironmentName().Return(env.Name, nil)
 	tt.fakeConfig.EXPECT().Environments().AnyTimes().Return(tt.environments)
 }
 
 func (tt *testTarmak) addCluster(cluster *clusterv1alpha1.Cluster) {
 	tt.clusters = append(tt.clusters, cluster)
 	tt.fakeConfig.EXPECT().Cluster(cluster.Environment, cluster.Name).AnyTimes().Return(cluster, nil)
-	tt.fakeConfig.EXPECT().CurrentClusterName().Return(cluster.Name)
+	tt.fakeConfig.EXPECT().CurrentClusterName().Return(cluster.Name, nil)
 	// TODO: support multiple environments
 	tt.fakeConfig.EXPECT().Clusters(cluster.Environment).AnyTimes().Return(tt.clusters)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This config fixes a number of errors when parsing the config:
- returns descriptive error if failing to parse config
- checks for nil when retrieving using config
- returns descriptive error if current cluster name is in the wrong format

```release-note
Return useful errors when failing to parse config
```
