### PR TITLE
Remove unneeded input for Jenkins instance size

### DIFF
--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -82,9 +82,6 @@ variable "bastion_root_size" {
 }
 {{ if .JenkinsInstall -}}
 variable "jenkins_ami" {}
-variable "jenkins_instance_type" {
-  default = "t2.large"
-}
 variable "jenkins_root_size" {
   default = "16"
 }
@@ -141,5 +138,3 @@ variable "tools_cluster_name" {
 data "template_file" "stack_name" {
   template = "${var.stack_name_prefix}${var.environment}-${var.name}"
 }
-
-

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -83,7 +83,6 @@ module "jenkins" {
   private_zone = "${var.private_zone}"
   private_zone_id = "${module.network.private_zone_id[0]}"
   jenkins_ami = "${var.jenkins_ami}"
-  jenkins_instance_type = "${var.jenkins_instance_type}"
   public_subnet_ids = ["${module.network.public_subnet_ids}"]
   private_subnet_ids = ["${module.network.private_subnet_ids}"]
   key_name = "${var.key_name}"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
We can remove this variable both from inputs.tf.template and modules.tf.template because we already template it in from instance_pool_variables.template. In iinstance_pool_variables.template we use GO templating to set the correct instance size. This change fixes that we always brought up Jenkins as an t2.large instead of the size we intended.
Before this change we always installed Jenkins as t2.large

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #311 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix to set correct instance size for Jenkins.
```
