### PR TITLE
Fix duplicate ELB name error

### DIFF
--- a/terraform/amazon/templates/instance_pools/role_elb.tf.template
+++ b/terraform/amazon/templates/instance_pools/role_elb.tf.template
@@ -122,7 +122,7 @@ resource "aws_route53_record" "{{.Role.TFName}}_elb" {
 }
 
 resource "aws_elb" "{{.Role.TFName}}" {
-  name         = "${format("%.20s-ingress", data.template_file.stack_name.rendered)}"
+  name         = "${format("%.20s{{.Role.Name}}", data.template_file.stack_name.rendered)}"
   subnets      = ["${var.public_subnet_ids}"]
   idle_timeout = 600
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When you bring up an Jenkins in your cluster, you will get an AWS/Terraform error to tell you that you try to create 2 ELBs with the same name. This changes solves this by adding the Name of the role to the ELB name. This also fixes the double `-` in the name.

```
DEBU[0136] Error: Error applying plan:  app=tarmak module=terraform std=err
DEBU[0136]                                               app=tarmak module=terraform std=err
DEBU[0136] 1 error occurred:                             app=tarmak module=terraform std=err
DEBU[0136]                                               app=tarmak module=terraform std=err
DEBU[0136] * module.kubernetes.aws_elb.kubernetes_worker: 1 error occurred:  app=tarmak module=terraform std=err
DEBU[0136]                                               app=tarmak module=terraform std=err
DEBU[0136] * aws_elb.kubernetes_worker: DuplicateLoadBalancerName: Load Balancer named mattiasmulticluster--ingress already exists and it is configured with different parameters.  app=tarmak module=terraform std=err
DEBU[0136] 	status code: 400, request id: 49e7eaf5-7527-11e8-88b4-d950d7f894c9  app=tarmak module=terraform std=err
DEBU[0136]                                               app=tarmak module=terraform std=err
DEBU[0136] Terraform does not automatically rollback in the face of errors.  app=tarmak module=terraform std=err
DEBU[0136] Instead, your Terraform state file has been partially updated with  app=tarmak module=terraform std=err
DEBU[0136] any resources that successfully completed. Please address the error  app=tarmak module=terraform std=err
DEBU[0136] above and apply again to incrementally change your infrastructure.  app=tarmak module=terraform std=err
DEBU[0136]                                               app=tarmak module=terraform std=err
DEBU[0136]                                   app=tarmak module=terraform std=err
ERRO[0136] Tarmak exited with an error: exit status 1    error="exit status 1"
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This can be a breaking change, but there is no real way around it I think.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix duplicate ELB name
```
