### PR TITLE
Adds validation to enforce single non-worker instance pools

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -218,12 +218,12 @@ func (c *Cluster) validateInstancePoolMultiple() error {
 
 	list := make(map[string][]*clusterv1alpha1.InstancePool)
 	for _, i := range c.Config().InstancePools {
-		list[i.Name] = append(list[i.Name], &i)
+		list[i.Type] = append(list[i.Type], &i)
 	}
 
-	for name, v := range list {
-		if name != "worker" && len(v) > 1 {
-			err := fmt.Errorf("'%s' only supports a single instance pool", name)
+	for instanceType, v := range list {
+		if instanceType != clusterv1alpha1.InstancePoolTypeWorker && len(v) > 1 {
+			err := fmt.Errorf("instance pool type '%s' only supports a single instance pool", instanceType)
 			result = multierror.Append(result, err)
 		}
 	}

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -181,6 +181,13 @@ func TestCluster_InstancePoolValidation(t *testing.T) {
 	}
 
 	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+		Type: clusterv1alpha1.InstancePoolTypeWorker,
+	})
+	if err := c.validateInstancePoolMultiple(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
 		Type: clusterv1alpha1.InstancePoolTypeBastion,
 	})
 	if err := c.validateInstancePoolMultiple(); err == nil {

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -163,6 +163,38 @@ func TestCluster_NewMinimalHub(t *testing.T) {
 	}
 }
 
+func TestCluster_InstancePoolValidation(t *testing.T) {
+	clusterConfig := config.NewHub("multi")
+	config.ApplyDefaults(clusterConfig)
+	clusterConfig.Location = "my-region"
+	c := newFakeCluster(t, nil)
+	defer c.Finish()
+
+	var err error
+	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+
+	if err := c.validateInstancePoolMultiple(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+		Type: clusterv1alpha1.InstancePoolTypeBastion,
+	})
+	if err := c.validateInstancePoolMultiple(); err == nil {
+		t.Errorf("expected error got=none")
+	}
+
+	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+		Type: clusterv1alpha1.InstancePoolTypeVault,
+	})
+	if err := c.validateInstancePoolMultiple(); err == nil {
+		t.Errorf("expected error got=none")
+	}
+}
+
 /*
 func testDefaultClusterConfig() *config.Cluster {
 	return &config.Cluster{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently tarmak does not error early when creating multiple non-worker instance pools. This adds a validation check to top this.

fixes #320 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @dippynark 
