### PR TITLE
Multi-cluster environment  instance pool validation check

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -203,7 +203,54 @@ func (c *Cluster) Validate() (result error) {
 		}
 	}
 
+	// validate instance instance pools according to hub and kubernetes multi cluster
+	if err := c.validateMultiClusterInstancePoolTypes(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	return result
+}
+
+func (c *Cluster) validateMultiClusterInstancePoolTypes() error {
+	errMap := make(map[string]bool)
+
+	if c.Type() == clusterv1alpha1.ClusterTypeHub {
+		hubTypes := map[string]bool{
+			clusterv1alpha1.InstancePoolTypeVault:   true,
+			clusterv1alpha1.InstancePoolTypeBastion: true,
+		}
+
+		for _, i := range c.Config().InstancePools {
+			if _, ok := hubTypes[i.Type]; !ok {
+				errMap[i.Type] = true
+			}
+		}
+
+	} else if c.Type() == clusterv1alpha1.ClusterTypeClusterMulti {
+		multiClusterTypes := map[string]bool{
+			clusterv1alpha1.InstancePoolTypeMaster:     true,
+			clusterv1alpha1.InstancePoolTypeWorker:     true,
+			clusterv1alpha1.InstancePoolTypeEtcd:       true,
+			clusterv1alpha1.InstancePoolTypeJenkins:    true,
+			clusterv1alpha1.InstancePoolTypeMasterEtcd: true,
+			clusterv1alpha1.InstancePoolTypeHybrid:     true,
+			clusterv1alpha1.InstancePoolTypeAll:        true,
+		}
+
+		for _, i := range c.Config().InstancePools {
+			if _, ok := multiClusterTypes[i.Type]; !ok {
+				errMap[i.Type] = true
+			}
+		}
+	}
+
+	var result *multierror.Error
+	for t := range errMap {
+		err := fmt.Errorf("instance pool type '%s' not valid in cluster type '%s'", t, c.Type())
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
 }
 
 // validate network configuration

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -203,7 +203,7 @@ func (c *Cluster) Validate() (result error) {
 		}
 	}
 
-	// validate instance instance pools according to hub and kubernetes multi cluster
+	// validate instance pools according to hub and kubernetes multi cluster environments
 	if err := c.validateMultiClusterInstancePoolTypes(); err != nil {
 		result = multierror.Append(result, err)
 	}

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -163,6 +163,124 @@ func TestCluster_NewMinimalHub(t *testing.T) {
 	}
 }
 
+func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
+	clusterConfig := config.NewHub("multi")
+	config.ApplyDefaults(clusterConfig)
+	clusterConfig.Location = "my-region"
+	c := newFakeCluster(t, nil)
+	defer c.Finish()
+
+	var err error
+	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+
+	if err := c.Cluster.validateMultiClusterInstancePoolTypes(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	volume := clusterv1alpha1.Volume{}
+	volume.Name = "root"
+
+	for _, i := range []string{
+		clusterv1alpha1.InstancePoolTypeVault,
+		clusterv1alpha1.InstancePoolTypeBastion,
+	} {
+		config := clusterConfig
+		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+			Type:     i,
+			MaxCount: 1,
+			Volumes:  []clusterv1alpha1.Volume{volume},
+		})
+
+		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+	}
+
+	for _, i := range []string{
+		clusterv1alpha1.InstancePoolTypeMaster,
+		clusterv1alpha1.InstancePoolTypeWorker,
+		clusterv1alpha1.InstancePoolTypeEtcd,
+		clusterv1alpha1.InstancePoolTypeJenkins,
+		clusterv1alpha1.InstancePoolTypeMasterEtcd,
+	} {
+		config := clusterConfig
+		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+			Type:     i,
+			MaxCount: 1,
+			Volumes:  []clusterv1alpha1.Volume{volume},
+		})
+
+		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+		if err == nil {
+			t.Errorf("expected error, got=none. type (%s)", i)
+		}
+	}
+}
+
+func TestCluster_ValidateClusterInstancePoolTypesMulti(t *testing.T) {
+	clusterConfig := config.NewClusterMulti("multi", "foo")
+	config.ApplyDefaults(clusterConfig)
+	clusterConfig.Location = "my-region"
+	c := newFakeCluster(t, nil)
+	defer c.Finish()
+
+	var err error
+	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+
+	if err := c.Cluster.validateMultiClusterInstancePoolTypes(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	volume := clusterv1alpha1.Volume{}
+	volume.Name = "root"
+
+	for _, i := range []string{
+		clusterv1alpha1.InstancePoolTypeMaster,
+		clusterv1alpha1.InstancePoolTypeWorker,
+		clusterv1alpha1.InstancePoolTypeEtcd,
+		clusterv1alpha1.InstancePoolTypeJenkins,
+		clusterv1alpha1.InstancePoolTypeMasterEtcd,
+	} {
+		config := clusterConfig
+		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+			Type:     i,
+			MaxCount: 1,
+			Volumes:  []clusterv1alpha1.Volume{volume},
+		})
+
+		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+	}
+
+	for _, i := range []string{
+		clusterv1alpha1.InstancePoolTypeVault,
+		clusterv1alpha1.InstancePoolTypeBastion,
+	} {
+		config := clusterConfig
+		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+			Type:     i,
+			MaxCount: 1,
+			Volumes:  []clusterv1alpha1.Volume{volume},
+		})
+
+		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+		if err == nil {
+			t.Errorf("expected error, got=none. type (%s)", i)
+		}
+	}
+}
+
 /*
 func testDefaultClusterConfig() *config.Cluster {
 	return &config.Cluster{

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -251,6 +251,7 @@ type InstancePool interface {
 	Validate() error
 	MinCount() int
 	MaxCount() int
+	InstanceType() string
 }
 
 type Volume interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a validation check to ensure instance pool types in multi-cluster environments are correct according to their cluster.

**Which issue this PR fixes**
fixes #333 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @dippynark 
