### PR TITLE
Remove internal worker ELB

### DIFF
--- a/pkg/tarmak/cluster/roles.go
+++ b/pkg/tarmak/cluster/roles.go
@@ -49,7 +49,6 @@ func defineKubernetesRoles(roleMap map[string]*role.Role) {
 	workerRole := &role.Role{
 		Stateful: false,
 		AWS: &role.RoleAWS{
-			ELBIngress:                     true,
 			IAMEC2Read:                     true,
 			IAMEC2ModifyInstanceAttributes: false,
 		},

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -90,7 +90,12 @@ resource "aws_autoscaling_group" "{{.TFName}}" {
   vpc_zone_identifier       = ["${var.private_subnet_ids}"]
   launch_configuration      = "${aws_launch_configuration.{{.TFName}}.name}"
   load_balancers            = [
+{{ if .Role.AWS.ELBAPI -}}
     "${aws_elb.{{.Role.TFName}}.name}",
+{{ end -}}
+{{ if .Role.AWS.ELBIngress -}}
+    "${aws_elb.{{.Role.TFName}}.name}",
+{{ end -}}
 {{ if .Role.AWS.ELBAPIPublic -}}
     "${aws_elb.{{.Role.TFName}}_public.name}",
 {{ end -}}


### PR DESCRIPTION
**What this PR does / why we need it**: The worker pool is deployed with an unnecessary ELB

Fixes: https://github.com/jetstack/tarmak/issues/334

```release-note
NONE
```
