### PR TITLE
Remove cluster autoscaler scrape

### DIFF
--- a/puppet/modules/kubernetes_addons/templates/cluster-autoscaler-deployment.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/cluster-autoscaler-deployment.yaml.erb
@@ -18,8 +18,6 @@ spec:
       labels:
         app: cluster-autoscaler
       annotations:
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ''
 <%- if @version_before_1_6 -%>
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'


### PR DESCRIPTION
**What this PR does / why we need it**: Cluster Autoscaler needs to run on the master but Prometheus then can't scrape it (since connections are only allowed from masters to workers and not the other way around) - this PR removes the annotation telling Prometheus to try to scrape it

```release-note
NONE
```
