### PR TITLE
Add security group to allow cluster autoscaler scraping

### DIFF
--- a/pkg/tarmak/cluster/firewall/rules.go
+++ b/pkg/tarmak/cluster/firewall/rules.go
@@ -33,21 +33,22 @@ type Rule struct {
 }
 
 var (
-	zeroPort          = uint16(0)
-	sshPort           = uint16(22)
-	bgpPort           = uint16(179)
-	overlayPort       = uint16(2359)
-	k8sEventsPort     = uint16(2369)
-	k8sPort           = uint16(2379)
-	apiPort           = uint16(6443)
-	consulRCPPort     = uint16(8300)
-	consulSerfPort    = uint16(8301)
-	vaultPort         = uint16(8200)
-	calicoMetricsPort = uint16(9091)
-	nodePort          = uint16(9100)
-	blackboxPort      = uint16(9115)
-	wingPort          = uint16(9443)
-	maxPort           = uint16(65535)
+	zeroPort                     = uint16(0)
+	sshPort                      = uint16(22)
+	bgpPort                      = uint16(179)
+	overlayPort                  = uint16(2359)
+	k8sEventsPort                = uint16(2369)
+	k8sPort                      = uint16(2379)
+	apiPort                      = uint16(6443)
+	consulRCPPort                = uint16(8300)
+	consulSerfPort               = uint16(8301)
+	vaultPort                    = uint16(8200)
+	clusterAutoscalerMetricsPort = uint16(8085)
+	calicoMetricsPort            = uint16(9091)
+	nodePort                     = uint16(9100)
+	blackboxPort                 = uint16(9115)
+	wingPort                     = uint16(9443)
+	maxPort                      = uint16(65535)
 
 	k8sIdentifier       = "k8s"
 	k8sEventsIdentifier = "k8sevents"
@@ -96,10 +97,20 @@ func newSSHService() Service {
 
 func newCalicoMetricsService() Service {
 	return Service{
-		Name:     "metrics",
+		Name:     "calico",
 		Protocol: "tcp",
 		Ports: []Port{
 			Port{Single: &calicoMetricsPort},
+		},
+	}
+}
+
+func newClusterAutoscalerMetricsService() Service {
+	return Service{
+		Name:     "cluster_autoscaler",
+		Protocol: "tcp",
+		Ports: []Port{
+			Port{Single: &clusterAutoscalerMetricsPort},
 		},
 	}
 }
@@ -302,8 +313,8 @@ func Rules() (rules []*Rule) {
 
 		//// Master
 		&Rule{
-			Comment:   "allow workers/master to connect to calico's service + api server",
-			Services:  []Service{newBGPService(), newIPIPService(), newCalicoMetricsService(), newAPIService()},
+			Comment:   "allow workers/master to connect to calico's service, cluster autoscaler's service + api server",
+			Services:  []Service{newBGPService(), newIPIPService(), newCalicoMetricsService(), newClusterAutoscalerMetricsService(), newAPIService()},
 			Direction: "ingress",
 			Sources: []Host{
 				Host{Role: "master"},


### PR DESCRIPTION
**What this PR does / why we need it**: Cluster Autoscaler needs to run on a master for IAM permissions so a security group rule needs to be added to allow Prometheus to scrape metrics

```release-note
NONE
```
