### PR TITLE
Use latest versions of Cluster Autoscaler

### DIFF
--- a/puppet/modules/kubernetes_addons/manifests/cluster_autoscaler.pp
+++ b/puppet/modules/kubernetes_addons/manifests/cluster_autoscaler.pp
@@ -28,14 +28,16 @@ class kubernetes_addons::cluster_autoscaler(
   }
 
   if $version == '' {
-    if versioncmp($::kubernetes::version, '1.10.0') >= 0 {
-      $_version = '1.2.0'
+    if versioncmp($::kubernetes::version, '1.11.0') >= 0 {
+      $_version = '1.3.0'
+    } elsif versioncmp($::kubernetes::version, '1.10.0') >= 0 {
+      $_version = '1.2.2'
     } elsif versioncmp($::kubernetes::version, '1.9.0') >= 0 {
-      $_version = '1.1.0'
+      $_version = '1.1.2'
     } elsif versioncmp($::kubernetes::version, '1.8.0') >= 0 {
-      $_version = '1.0.0'
+      $_version = '1.0.4'
     } elsif versioncmp($::kubernetes::version, '1.7.0') >= 0 {
-      $_version = '0.6.0'
+      $_version = '0.6.4'
     } elsif versioncmp($::kubernetes::version, '1.6.0') >= 0 {
       $_version = '0.5.4'
     } elsif versioncmp($::kubernetes::version, '1.5.0') >= 0 {

--- a/puppet/modules/kubernetes_addons/spec/classes/cluster_autoscaler_spec.rb
+++ b/puppet/modules/kubernetes_addons/spec/classes/cluster_autoscaler_spec.rb
@@ -100,7 +100,7 @@ describe 'kubernetes_addons::cluster_autoscaler' do
       '1.7.0'
     end
     it 'uses correct image version' do
-      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v0.6.0})
+      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v0.6.4})
     end
   end
 
@@ -109,7 +109,7 @@ describe 'kubernetes_addons::cluster_autoscaler' do
       '1.8.0'
     end
     it 'uses correct image version' do
-      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.0.0})
+      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.0.4})
     end
   end
 
@@ -118,7 +118,7 @@ describe 'kubernetes_addons::cluster_autoscaler' do
       '1.9.0'
     end
     it 'uses correct image version' do
-      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.1.0})
+      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.1.2})
     end
   end
 
@@ -127,7 +127,16 @@ describe 'kubernetes_addons::cluster_autoscaler' do
       '1.10.0'
     end
     it 'uses correct image version' do
-      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.2.0})
+      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.2.2})
+    end
+  end
+
+  context 'with kubernetes 1.11' do
+    let(:kubernetes_version) do
+      '1.11.0'
+    end
+    it 'uses correct image version' do
+      expect(manifests[0]).to match(%r{gcr.io/google_containers/cluster-autoscaler:v1.3.0})
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**: Upgrades CA versions

```release-note
Use latest versions of Cluster Autoscaler
```
