### PR TITLE
Validate cluster instance pools

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -216,7 +216,7 @@ func (c *Cluster) Validate() (result error) {
 		}
 	}
 
-	// validate instance instance pools according to hub and kubernetes multi cluster
+	// validate instance pools according to hub and kubernetes multi cluster environments
 	if err := c.validateMultiClusterInstancePoolTypes(); err != nil {
 		result = multierror.Append(result, err)
 	}

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -138,7 +138,6 @@ func (c *Cluster) validateClusterInstancePoolTypes() error {
 			clusterv1alpha1.InstancePoolTypeMaster:     true,
 			clusterv1alpha1.InstancePoolTypeWorker:     true,
 			clusterv1alpha1.InstancePoolTypeEtcd:       true,
-			clusterv1alpha1.InstancePoolTypeJenkins:    true,
 			clusterv1alpha1.InstancePoolTypeMasterEtcd: true,
 			clusterv1alpha1.InstancePoolTypeHybrid:     true,
 			clusterv1alpha1.InstancePoolTypeAll:        true,

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -179,7 +179,9 @@ func (c *Cluster) VerifyInstancePools() (result error) {
 	return nil
 }
 
-func (c *Cluster) Validate() (result error) {
+func (c *Cluster) Validate() error {
+	var result *multierror.Error
+
 	// validate instance pools
 	if err := c.validateInstancePools(); err != nil {
 		result = multierror.Append(result, err)
@@ -221,7 +223,30 @@ func (c *Cluster) Validate() (result error) {
 		result = multierror.Append(result, err)
 	}
 
-	return result
+	// validate enforcement of instance pool count
+	if err := c.validateInstancePoolMultiple(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (c *Cluster) validateInstancePoolMultiple() error {
+	var result *multierror.Error
+
+	list := make(map[string][]*clusterv1alpha1.InstancePool)
+	for _, i := range c.Config().InstancePools {
+		list[i.Name] = append(list[i.Name], &i)
+	}
+
+	for name, v := range list {
+		if name != "worker" && len(v) > 1 {
+			err := fmt.Errorf("'%s' only supports a single instance pool", name)
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result.ErrorOrNil()
 }
 
 func (c *Cluster) validateMultiClusterInstancePoolTypes() error {

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -236,12 +236,12 @@ func (c *Cluster) validateInstancePoolMultiple() error {
 
 	list := make(map[string][]*clusterv1alpha1.InstancePool)
 	for _, i := range c.Config().InstancePools {
-		list[i.Name] = append(list[i.Name], &i)
+		list[i.Type] = append(list[i.Type], &i)
 	}
 
-	for name, v := range list {
-		if name != "worker" && len(v) > 1 {
-			err := fmt.Errorf("'%s' only supports a single instance pool", name)
+	for instanceType, v := range list {
+		if instanceType != clusterv1alpha1.InstancePoolTypeWorker && len(v) > 1 {
+			err := fmt.Errorf("instance pool type '%s' only supports a single instance pool", instanceType)
 			result = multierror.Append(result, err)
 		}
 	}

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -246,9 +246,16 @@ func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
 		clusterv1alpha1.InstancePoolTypeJenkins,
 	}
 	tryInstancePoolTypes(c, passTypes, failTypes, t)
+
+	singleTypes := []string{
+		clusterv1alpha1.InstancePoolTypeBastion,
+		clusterv1alpha1.InstancePoolTypeVault,
+	}
+	multiTypes := []string{}
+	tryInstancePoolCount(c, singleTypes, multiTypes, t)
 }
 
-func TestCluster_ValidateClusterInstancePoolsTypesMulti(t *testing.T) {
+func TestCluster_ValidateClusterInstancePoolsMulti(t *testing.T) {
 	clusterConfig := config.NewClusterMulti("env", "cluster")
 	config.ApplyDefaults(clusterConfig)
 	c := newFakeCluster(t, nil)
@@ -268,16 +275,25 @@ func TestCluster_ValidateClusterInstancePoolsTypesMulti(t *testing.T) {
 		clusterv1alpha1.InstancePoolTypeMaster,
 		clusterv1alpha1.InstancePoolTypeWorker,
 		clusterv1alpha1.InstancePoolTypeEtcd,
-		clusterv1alpha1.InstancePoolTypeJenkins,
 	}
 	failTypes := []string{
 		clusterv1alpha1.InstancePoolTypeBastion,
 		clusterv1alpha1.InstancePoolTypeVault,
+		clusterv1alpha1.InstancePoolTypeJenkins,
 	}
 	tryInstancePoolTypes(c, passTypes, failTypes, t)
+
+	singleTypes := []string{
+		clusterv1alpha1.InstancePoolTypeEtcd,
+	}
+	multiTypes := []string{
+		clusterv1alpha1.InstancePoolTypeMaster,
+		clusterv1alpha1.InstancePoolTypeWorker,
+	}
+	tryInstancePoolCount(c, singleTypes, multiTypes, t)
 }
 
-func TestCluster_ValidateClusterInstancePoolsTypesSingle(t *testing.T) {
+func TestCluster_ValidateClusterInstancePoolsSingle(t *testing.T) {
 	clusterConfig := config.NewClusterSingle("env", "cluster")
 	config.ApplyDefaults(clusterConfig)
 	c := newFakeCluster(t, nil)
@@ -303,13 +319,23 @@ func TestCluster_ValidateClusterInstancePoolsTypesSingle(t *testing.T) {
 	}
 	failTypes := []string{}
 	tryInstancePoolTypes(c, passTypes, failTypes, t)
+
+	singleTypes := []string{
+		clusterv1alpha1.InstancePoolTypeEtcd,
+		clusterv1alpha1.InstancePoolTypeVault,
+		clusterv1alpha1.InstancePoolTypeBastion,
+	}
+	multiTypes := []string{
+		clusterv1alpha1.InstancePoolTypeMaster,
+		clusterv1alpha1.InstancePoolTypeWorker,
+	}
+	tryInstancePoolCount(c, singleTypes, multiTypes, t)
 }
 
 func tryInstancePoolTypes(c *fakeCluster, passTypes, failTypes []string, t *testing.T) {
 	baseConfig := c.conf.DeepCopy()
 
 	for _, i := range passTypes {
-		c.conf = baseConfig.DeepCopy()
 		c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
 			Type: i,
 		})
@@ -317,10 +343,11 @@ func tryInstancePoolTypes(c *fakeCluster, passTypes, failTypes []string, t *test
 		if err := c.validateClusterInstancePoolTypes(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
+
+		c.conf = baseConfig.DeepCopy()
 	}
 
 	for _, i := range failTypes {
-		c.conf = baseConfig.DeepCopy()
 		c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
 			Type: i,
 		})
@@ -328,165 +355,58 @@ func tryInstancePoolTypes(c *fakeCluster, passTypes, failTypes []string, t *test
 		if err := c.validateClusterInstancePoolTypes(); err == nil {
 			t.Errorf("expected error, got=none for cluster type '%s', instance pool '%s'", c.Type(), i)
 		}
+
+		c.conf = baseConfig.DeepCopy()
 	}
 }
 
-//func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
-//	clusterConfig := config.NewHub("multi")
-//	config.ApplyDefaults(clusterConfig)
-//	clusterConfig.Location = "my-region"
-//	c := newFakeCluster(t, nil)
-//	defer c.Finish()
-//
-//	var err error
-//	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
-//	if err != nil {
-//		t.Fatal("unexpected error: ", err)
-//	}
-//
-//	if err := c.Cluster.validateInstancePools(); err != nil {
-//		t.Errorf("unexpected error: %v", err)
-//	}
-//
-//	volume := clusterv1alpha1.Volume{}
-//	volume.Name = "root"
-//
-//	for _, i := range []string{
-//		clusterv1alpha1.InstancePoolTypeVault,
-//		clusterv1alpha1.InstancePoolTypeBastion,
-//	} {
-//		config := clusterConfig
-//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-//			Type:     i,
-//			MaxCount: 1,
-//			Volumes:  []clusterv1alpha1.Volume{volume},
-//		})
-//
-//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-//		if err != nil {
-//			t.Errorf("unexpected error: %v", err)
-//			continue
-//		}
-//	}
-//
-//	for _, i := range []string{
-//		clusterv1alpha1.InstancePoolTypeMaster,
-//		clusterv1alpha1.InstancePoolTypeWorker,
-//		clusterv1alpha1.InstancePoolTypeEtcd,
-//		clusterv1alpha1.InstancePoolTypeJenkins,
-//		clusterv1alpha1.InstancePoolTypeMasterEtcd,
-//	} {
-//		config := clusterConfig
-//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-//			Type:     i,
-//			MaxCount: 1,
-//			Volumes:  []clusterv1alpha1.Volume{volume},
-//		})
-//
-//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-//		if err == nil {
-//			t.Errorf("expected error, got=none. type (%s)", i)
-//		}
-//	}
-//}
-//
-//func TestCluster_ValidateClusterInstancePoolTypesMulti(t *testing.T) {
-//	clusterConfig := config.NewClusterMulti("multi", "foo")
-//	config.ApplyDefaults(clusterConfig)
-//	clusterConfig.Location = "my-region"
-//	c := newFakeCluster(t, nil)
-//	defer c.Finish()
-//
-//	var err error
-//	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
-//	if err != nil {
-//		t.Fatal("unexpected error: ", err)
-//	}
-//
-//	if err := c.Cluster.validateInstancePools(); err != nil {
-//		t.Errorf("unexpected error: %v", err)
-//	}
-//
-//	volume := clusterv1alpha1.Volume{}
-//	volume.Name = "root"
-//
-//	for _, i := range []string{
-//		clusterv1alpha1.InstancePoolTypeMaster,
-//		clusterv1alpha1.InstancePoolTypeWorker,
-//		clusterv1alpha1.InstancePoolTypeEtcd,
-//		clusterv1alpha1.InstancePoolTypeJenkins,
-//		clusterv1alpha1.InstancePoolTypeMasterEtcd,
-//	} {
-//		config := clusterConfig
-//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-//			Type:     i,
-//			MaxCount: 1,
-//			Volumes:  []clusterv1alpha1.Volume{volume},
-//		})
-//
-//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-//		if err != nil {
-//			t.Errorf("unexpected error: %v", err)
-//			continue
-//		}
-//	}
-//
-//	for _, i := range []string{
-//		clusterv1alpha1.InstancePoolTypeVault,
-//		clusterv1alpha1.InstancePoolTypeBastion,
-//	} {
-//		config := clusterConfig
-//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-//			Type:     i,
-//			MaxCount: 1,
-//			Volumes:  []clusterv1alpha1.Volume{volume},
-//		})
-//
-//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-//		if err == nil {
-//			t.Errorf("expected error, got=none. type (%s)", i)
-//		}
-//	}
-//}
-//
-//func TestCluster_InstancePoolValidation(t *testing.T) {
-//	clusterConfig := config.NewHub("multi")
-//	config.ApplyDefaults(clusterConfig)
-//	clusterConfig.Location = "my-region"
-//	c := newFakeCluster(t, nil)
-//	defer c.Finish()
-//
-//	var err error
-//	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
-//	if err != nil {
-//		t.Fatal("unexpected error: ", err)
-//	}
-//
-//	if err := c.validateInstancePools(); err != nil {
-//		t.Errorf("unexpected error: %v", err)
-//	}
-//
-//	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
-//		Type: clusterv1alpha1.InstancePoolTypeWorker,
-//	})
-//	if err := c.validateInstancePools(); err != nil {
-//		t.Errorf("unexpected error: %v", err)
-//	}
-//
-//	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
-//		Type: clusterv1alpha1.InstancePoolTypeBastion,
-//	})
-//	if err := c.validateInstancePools(); err == nil {
-//		t.Errorf("expected error got=none")
-//	}
-//
-//	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
-//		Type: clusterv1alpha1.InstancePoolTypeVault,
-//	})
-//	if err := c.validateInstancePools(); err == nil {
-//		t.Errorf("expected error got=none")
-//	}
-//}
+func tryInstancePoolCount(c *fakeCluster, singleTypes, multiTypes []string, t *testing.T) {
+	baseConfig := c.Cluster.conf.DeepCopy()
+
+	for _, i := range multiTypes {
+		c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+			Type: i,
+		})
+
+		if err := c.validateClusterInstancePoolCount(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		c.conf = baseConfig.DeepCopy()
+	}
+
+	for _, i := range singleTypes {
+		c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+			Type: i,
+		})
+
+		if err := c.validateClusterInstancePoolCount(); err == nil {
+			t.Errorf("expected error, got=none for cluster type '%s', instance pool '%s'", c.Type(), i)
+		}
+
+		c.conf = baseConfig.DeepCopy()
+	}
+
+	// test that some instance pool types need at least one
+	combinedList := append(singleTypes, multiTypes...)
+	for _, i := range combinedList {
+		c.conf.InstancePools = []clusterv1alpha1.InstancePool{}
+
+		for _, j := range combinedList {
+			if i != j {
+				c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+					Type: j,
+				})
+			}
+		}
+
+		if err := c.validateClusterInstancePoolCount(); err == nil {
+			t.Errorf("expected error, got=none for cluster type '%s', instance pool '%s'", c.Type(), i)
+		}
+	}
+
+	c.conf = baseConfig.DeepCopy()
+}
 
 /*
 func testDefaultClusterConfig() *config.Cluster {

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -222,7 +222,6 @@ func TestValidateClusterAutoscaler(t *testing.T) {
 func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
 	clusterConfig := config.NewHub("multi")
 	config.ApplyDefaults(clusterConfig)
-	clusterConfig.Location = "my-region"
 	c := newFakeCluster(t, nil)
 	defer c.Finish()
 
@@ -232,56 +231,26 @@ func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
 		t.Fatal("unexpected error: ", err)
 	}
 
-	if err := c.Cluster.validateMultiClusterInstancePoolTypes(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err := c.Cluster.validateClusterInstancePoolTypes(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	volume := clusterv1alpha1.Volume{}
-	volume.Name = "root"
-
-	for _, i := range []string{
-		clusterv1alpha1.InstancePoolTypeVault,
+	passTypes := []string{
 		clusterv1alpha1.InstancePoolTypeBastion,
-	} {
-		config := clusterConfig
-		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-			Type:     i,
-			MaxCount: 1,
-			Volumes:  []clusterv1alpha1.Volume{volume},
-		})
-
-		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-			continue
-		}
+		clusterv1alpha1.InstancePoolTypeVault,
 	}
-
-	for _, i := range []string{
+	failTypes := []string{
 		clusterv1alpha1.InstancePoolTypeMaster,
 		clusterv1alpha1.InstancePoolTypeWorker,
 		clusterv1alpha1.InstancePoolTypeEtcd,
 		clusterv1alpha1.InstancePoolTypeJenkins,
-		clusterv1alpha1.InstancePoolTypeMasterEtcd,
-	} {
-		config := clusterConfig
-		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-			Type:     i,
-			MaxCount: 1,
-			Volumes:  []clusterv1alpha1.Volume{volume},
-		})
-
-		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-		if err == nil {
-			t.Errorf("expected error, got=none. type (%s)", i)
-		}
 	}
+	tryInstancePoolTypes(c, passTypes, failTypes, t)
 }
 
-func TestCluster_ValidateClusterInstancePoolTypesMulti(t *testing.T) {
-	clusterConfig := config.NewClusterMulti("multi", "foo")
+func TestCluster_ValidateClusterInstancePoolsTypesMulti(t *testing.T) {
+	clusterConfig := config.NewClusterMulti("env", "cluster")
 	config.ApplyDefaults(clusterConfig)
-	clusterConfig.Location = "my-region"
 	c := newFakeCluster(t, nil)
 	defer c.Finish()
 
@@ -291,56 +260,26 @@ func TestCluster_ValidateClusterInstancePoolTypesMulti(t *testing.T) {
 		t.Fatal("unexpected error: ", err)
 	}
 
-	if err := c.Cluster.validateMultiClusterInstancePoolTypes(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err := c.Cluster.validateClusterInstancePoolTypes(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	volume := clusterv1alpha1.Volume{}
-	volume.Name = "root"
-
-	for _, i := range []string{
+	passTypes := []string{
 		clusterv1alpha1.InstancePoolTypeMaster,
 		clusterv1alpha1.InstancePoolTypeWorker,
 		clusterv1alpha1.InstancePoolTypeEtcd,
 		clusterv1alpha1.InstancePoolTypeJenkins,
-		clusterv1alpha1.InstancePoolTypeMasterEtcd,
-	} {
-		config := clusterConfig
-		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-			Type:     i,
-			MaxCount: 1,
-			Volumes:  []clusterv1alpha1.Volume{volume},
-		})
-
-		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-			continue
-		}
 	}
-
-	for _, i := range []string{
-		clusterv1alpha1.InstancePoolTypeVault,
+	failTypes := []string{
 		clusterv1alpha1.InstancePoolTypeBastion,
-	} {
-		config := clusterConfig
-		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
-			Type:     i,
-			MaxCount: 1,
-			Volumes:  []clusterv1alpha1.Volume{volume},
-		})
-
-		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
-		if err == nil {
-			t.Errorf("expected error, got=none. type (%s)", i)
-		}
+		clusterv1alpha1.InstancePoolTypeVault,
 	}
+	tryInstancePoolTypes(c, passTypes, failTypes, t)
 }
 
-func TestCluster_InstancePoolValidation(t *testing.T) {
-	clusterConfig := config.NewHub("multi")
+func TestCluster_ValidateClusterInstancePoolsTypesSingle(t *testing.T) {
+	clusterConfig := config.NewClusterSingle("env", "cluster")
 	config.ApplyDefaults(clusterConfig)
-	clusterConfig.Location = "my-region"
 	c := newFakeCluster(t, nil)
 	defer c.Finish()
 
@@ -350,31 +289,204 @@ func TestCluster_InstancePoolValidation(t *testing.T) {
 		t.Fatal("unexpected error: ", err)
 	}
 
-	if err := c.validateInstancePoolMultiple(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err := c.Cluster.validateClusterInstancePoolTypes(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
-		Type: clusterv1alpha1.InstancePoolTypeWorker,
-	})
-	if err := c.validateInstancePoolMultiple(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+	passTypes := []string{
+		clusterv1alpha1.InstancePoolTypeMaster,
+		clusterv1alpha1.InstancePoolTypeWorker,
+		clusterv1alpha1.InstancePoolTypeEtcd,
+		clusterv1alpha1.InstancePoolTypeJenkins,
+		clusterv1alpha1.InstancePoolTypeBastion,
+		clusterv1alpha1.InstancePoolTypeVault,
+	}
+	failTypes := []string{}
+	tryInstancePoolTypes(c, passTypes, failTypes, t)
+}
+
+func tryInstancePoolTypes(c *fakeCluster, passTypes, failTypes []string, t *testing.T) {
+	baseConfig := c.conf.DeepCopy()
+
+	for _, i := range passTypes {
+		c.conf = baseConfig.DeepCopy()
+		c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+			Type: i,
+		})
+
+		if err := c.validateClusterInstancePoolTypes(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 	}
 
-	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
-		Type: clusterv1alpha1.InstancePoolTypeBastion,
-	})
-	if err := c.validateInstancePoolMultiple(); err == nil {
-		t.Errorf("expected error got=none")
-	}
+	for _, i := range failTypes {
+		c.conf = baseConfig.DeepCopy()
+		c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+			Type: i,
+		})
 
-	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
-		Type: clusterv1alpha1.InstancePoolTypeVault,
-	})
-	if err := c.validateInstancePoolMultiple(); err == nil {
-		t.Errorf("expected error got=none")
+		if err := c.validateClusterInstancePoolTypes(); err == nil {
+			t.Errorf("expected error, got=none for cluster type '%s', instance pool '%s'", c.Type(), i)
+		}
 	}
 }
+
+//func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
+//	clusterConfig := config.NewHub("multi")
+//	config.ApplyDefaults(clusterConfig)
+//	clusterConfig.Location = "my-region"
+//	c := newFakeCluster(t, nil)
+//	defer c.Finish()
+//
+//	var err error
+//	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+//	if err != nil {
+//		t.Fatal("unexpected error: ", err)
+//	}
+//
+//	if err := c.Cluster.validateInstancePools(); err != nil {
+//		t.Errorf("unexpected error: %v", err)
+//	}
+//
+//	volume := clusterv1alpha1.Volume{}
+//	volume.Name = "root"
+//
+//	for _, i := range []string{
+//		clusterv1alpha1.InstancePoolTypeVault,
+//		clusterv1alpha1.InstancePoolTypeBastion,
+//	} {
+//		config := clusterConfig
+//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+//			Type:     i,
+//			MaxCount: 1,
+//			Volumes:  []clusterv1alpha1.Volume{volume},
+//		})
+//
+//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+//		if err != nil {
+//			t.Errorf("unexpected error: %v", err)
+//			continue
+//		}
+//	}
+//
+//	for _, i := range []string{
+//		clusterv1alpha1.InstancePoolTypeMaster,
+//		clusterv1alpha1.InstancePoolTypeWorker,
+//		clusterv1alpha1.InstancePoolTypeEtcd,
+//		clusterv1alpha1.InstancePoolTypeJenkins,
+//		clusterv1alpha1.InstancePoolTypeMasterEtcd,
+//	} {
+//		config := clusterConfig
+//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+//			Type:     i,
+//			MaxCount: 1,
+//			Volumes:  []clusterv1alpha1.Volume{volume},
+//		})
+//
+//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+//		if err == nil {
+//			t.Errorf("expected error, got=none. type (%s)", i)
+//		}
+//	}
+//}
+//
+//func TestCluster_ValidateClusterInstancePoolTypesMulti(t *testing.T) {
+//	clusterConfig := config.NewClusterMulti("multi", "foo")
+//	config.ApplyDefaults(clusterConfig)
+//	clusterConfig.Location = "my-region"
+//	c := newFakeCluster(t, nil)
+//	defer c.Finish()
+//
+//	var err error
+//	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+//	if err != nil {
+//		t.Fatal("unexpected error: ", err)
+//	}
+//
+//	if err := c.Cluster.validateInstancePools(); err != nil {
+//		t.Errorf("unexpected error: %v", err)
+//	}
+//
+//	volume := clusterv1alpha1.Volume{}
+//	volume.Name = "root"
+//
+//	for _, i := range []string{
+//		clusterv1alpha1.InstancePoolTypeMaster,
+//		clusterv1alpha1.InstancePoolTypeWorker,
+//		clusterv1alpha1.InstancePoolTypeEtcd,
+//		clusterv1alpha1.InstancePoolTypeJenkins,
+//		clusterv1alpha1.InstancePoolTypeMasterEtcd,
+//	} {
+//		config := clusterConfig
+//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+//			Type:     i,
+//			MaxCount: 1,
+//			Volumes:  []clusterv1alpha1.Volume{volume},
+//		})
+//
+//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+//		if err != nil {
+//			t.Errorf("unexpected error: %v", err)
+//			continue
+//		}
+//	}
+//
+//	for _, i := range []string{
+//		clusterv1alpha1.InstancePoolTypeVault,
+//		clusterv1alpha1.InstancePoolTypeBastion,
+//	} {
+//		config := clusterConfig
+//		config.InstancePools = append(config.InstancePools, clusterv1alpha1.InstancePool{
+//			Type:     i,
+//			MaxCount: 1,
+//			Volumes:  []clusterv1alpha1.Volume{volume},
+//		})
+//
+//		c.Cluster, err = NewFromConfig(c.fakeEnvironment, config)
+//		if err == nil {
+//			t.Errorf("expected error, got=none. type (%s)", i)
+//		}
+//	}
+//}
+//
+//func TestCluster_InstancePoolValidation(t *testing.T) {
+//	clusterConfig := config.NewHub("multi")
+//	config.ApplyDefaults(clusterConfig)
+//	clusterConfig.Location = "my-region"
+//	c := newFakeCluster(t, nil)
+//	defer c.Finish()
+//
+//	var err error
+//	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+//	if err != nil {
+//		t.Fatal("unexpected error: ", err)
+//	}
+//
+//	if err := c.validateInstancePools(); err != nil {
+//		t.Errorf("unexpected error: %v", err)
+//	}
+//
+//	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+//		Type: clusterv1alpha1.InstancePoolTypeWorker,
+//	})
+//	if err := c.validateInstancePools(); err != nil {
+//		t.Errorf("unexpected error: %v", err)
+//	}
+//
+//	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+//		Type: clusterv1alpha1.InstancePoolTypeBastion,
+//	})
+//	if err := c.validateInstancePools(); err == nil {
+//		t.Errorf("expected error got=none")
+//	}
+//
+//	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+//		Type: clusterv1alpha1.InstancePoolTypeVault,
+//	})
+//	if err := c.validateInstancePools(); err == nil {
+//		t.Errorf("expected error got=none")
+//	}
+//}
 
 /*
 func testDefaultClusterConfig() *config.Cluster {

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -337,6 +337,38 @@ func TestCluster_ValidateClusterInstancePoolTypesMulti(t *testing.T) {
 	}
 }
 
+func TestCluster_InstancePoolValidation(t *testing.T) {
+	clusterConfig := config.NewHub("multi")
+	config.ApplyDefaults(clusterConfig)
+	clusterConfig.Location = "my-region"
+	c := newFakeCluster(t, nil)
+	defer c.Finish()
+
+	var err error
+	c.Cluster, err = NewFromConfig(c.fakeEnvironment, clusterConfig)
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+
+	if err := c.validateInstancePoolMultiple(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+		Type: clusterv1alpha1.InstancePoolTypeBastion,
+	})
+	if err := c.validateInstancePoolMultiple(); err == nil {
+		t.Errorf("expected error got=none")
+	}
+
+	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+		Type: clusterv1alpha1.InstancePoolTypeVault,
+	})
+	if err := c.validateInstancePoolMultiple(); err == nil {
+		t.Errorf("expected error got=none")
+	}
+}
+
 /*
 func testDefaultClusterConfig() *config.Cluster {
 	return &config.Cluster{

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -355,6 +355,13 @@ func TestCluster_InstancePoolValidation(t *testing.T) {
 	}
 
 	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
+		Type: clusterv1alpha1.InstancePoolTypeWorker,
+	})
+	if err := c.validateInstancePoolMultiple(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	c.conf.InstancePools = append(c.conf.InstancePools, clusterv1alpha1.InstancePool{
 		Type: clusterv1alpha1.InstancePoolTypeBastion,
 	})
 	if err := c.validateInstancePoolMultiple(); err == nil {

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -251,6 +251,7 @@ type InstancePool interface {
 	Validate() error
 	MinCount() int
 	MaxCount() int
+	InstanceType() string
 }
 
 type Volume interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds type and count validation checks for cluster instance pools for each cluster type.

fixes #333 #283 #320

This pull request is a consolidation of the fixed issues and the PRs that fixed each individually.


<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
