### PR TITLE
Create an SRV record for the etcd instance pool

### DIFF
--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -237,7 +237,7 @@ resource "aws_route53_record" "{{.TFName}}" {
 }
 
 {{ if eq .Role.Name "etcd" -}}
-resource "aws_route53_record" "{{.TFName}}-exporter-srv-record" {
+resource "aws_route53_record" "{{.TFName}}-exporter-srv" {
   zone_id = "${var.private_zone_id}"
   name    = "{{.Role.Name}}-exporters.${data.template_file.stack_name.rendered}"
   type    = "SRV"

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -236,4 +236,16 @@ resource "aws_route53_record" "{{.TFName}}" {
   count   = "${var.{{.TFName}}_min_count}"
 }
 
+{{ if eq .Role.Name "etcd" -}}
+resource "aws_route53_record" "{{.TFName}}-srv-record" {
+  zone_id = "${var.private_zone_id}"
+  name    = "{{.Role.Name}}-svc.${data.template_file.stack_name.rendered}"
+  type    = "SRV"
+  ttl     = "300"
+  records = [
+    "${formatlist("1 10 9115 %s", aws_route53_record.{{.TFName}}.*.name)}"
+  ]
+}
+{{ end -}}
+
 {{ end -}}

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -237,9 +237,9 @@ resource "aws_route53_record" "{{.TFName}}" {
 }
 
 {{ if eq .Role.Name "etcd" -}}
-resource "aws_route53_record" "{{.TFName}}-srv-record" {
+resource "aws_route53_record" "{{.TFName}}-exporter-srv-record" {
   zone_id = "${var.private_zone_id}"
-  name    = "{{.Role.Name}}-svc.${data.template_file.stack_name.rendered}"
+  name    = "{{.Role.Name}}-exporters.${data.template_file.stack_name.rendered}"
   type    = "SRV"
   ttl     = "300"
   records = [


### PR DESCRIPTION
When templating out the terraform config for the etcd stateful instance
pool, this will also create an SRV record in Route53 with a record for
each of the individual A records for each node.

This will eventually allow us to simplify the prometheus scrape config
the 'knowledge' of the number of nodes and their hostnames remains in
terraform only.

dig output:

```
[centos@charlie-cluster|master|ip-10-99-62-26 ~]$ dig etcd-svc.charlie-cluster.tarmak.local. SRV

; <<>> DiG 9.9.4-RedHat-9.9.4-61.el7 <<>> etcd-svc.charlie-cluster.tarmak.local. SRV
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 13292
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;etcd-svc.charlie-cluster.tarmak.local. IN SRV

;; ANSWER SECTION:
etcd-svc.charlie-cluster.tarmak.local. 60 IN SRV 1 10 9115 etcd-2.charlie-cluster.
etcd-svc.charlie-cluster.tarmak.local. 60 IN SRV 1 10 9115 etcd-3.charlie-cluster.
etcd-svc.charlie-cluster.tarmak.local. 60 IN SRV 1 10 9115 etcd-1.charlie-cluster.

;; Query time: 3 msec
;; SERVER: 10.99.0.2#53(10.99.0.2)
;; WHEN: Tue Jun 26 15:32:42 UTC 2018
;; MSG SIZE  rcvd: 192
```

**What this PR does / why we need it**:
This can help make the prometheus scraper config easier (eventually - watch this space)

**Which issue this PR fixes** 
Doesn't  complete it but this is being done as part of https://github.com/jetstack/tarmak/issues/349



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create an SRV record for the etcd instance pool
```
