### PR TITLE
Remove terraform remote state lock

### DIFF
--- a/cmd/tarmak/cmd/cluster_apply.go
+++ b/cmd/tarmak/cmd/cluster_apply.go
@@ -37,10 +37,14 @@ var clusterApplyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
+
+		applyCmd := t.NewCmdTerraform(args)
+
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
-				return t.CmdTerraformApply(args, ctx)
+				return applyCmd.Apply()
 			},
+			applyCmd.StopCh,
 		)
 	},
 }

--- a/cmd/tarmak/cmd/cluster_apply.go
+++ b/cmd/tarmak/cmd/cluster_apply.go
@@ -44,7 +44,7 @@ var clusterApplyCmd = &cobra.Command{
 			func(ctx context.Context) error {
 				return applyCmd.Apply()
 			},
-			applyCmd.StopCh,
+			t.Context(),
 		)
 	},
 }

--- a/cmd/tarmak/cmd/cluster_debug_terraform_shell.go
+++ b/cmd/tarmak/cmd/cluster_debug_terraform_shell.go
@@ -15,7 +15,7 @@ var clusterDebugTerraformShellCmd = &cobra.Command{
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
 		defer plugin.CleanupClients()
-		//t.Must(t.CmdTerraformShell(args))
+		t.Must(t.NewCmdTerraform(args).Shell())
 	},
 }
 

--- a/cmd/tarmak/cmd/cluster_debug_terraform_shell.go
+++ b/cmd/tarmak/cmd/cluster_debug_terraform_shell.go
@@ -15,7 +15,7 @@ var clusterDebugTerraformShellCmd = &cobra.Command{
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
 		defer plugin.CleanupClients()
-		t.Must(t.CmdTerraformShell(args))
+		//t.Must(t.CmdTerraformShell(args))
 	},
 }
 

--- a/cmd/tarmak/cmd/cluster_destroy.go
+++ b/cmd/tarmak/cmd/cluster_destroy.go
@@ -33,7 +33,7 @@ var clusterDestroyCmd = &cobra.Command{
 			func(ctx context.Context) error {
 				return destroyCmd.Destroy()
 			},
-			destroyCmd.StopCh,
+			t.Context(),
 		)
 	},
 }

--- a/cmd/tarmak/cmd/cluster_destroy.go
+++ b/cmd/tarmak/cmd/cluster_destroy.go
@@ -22,13 +22,18 @@ var clusterDestroyCmd = &cobra.Command{
 		}
 		return nil
 	},
+
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
+
+		destroyCmd := t.NewCmdTerraform(args)
+
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
-				return t.CmdTerraformDestroy(args, ctx)
+				return destroyCmd.Destroy()
 			},
+			destroyCmd.StopCh,
 		)
 	},
 }

--- a/cmd/tarmak/cmd/cluster_images_build.go
+++ b/cmd/tarmak/cmd/cluster_images_build.go
@@ -2,12 +2,12 @@
 package cmd
 
 import (
-	//"context"
+	"context"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jetstack/tarmak/pkg/tarmak"
-	//"github.com/jetstack/tarmak/pkg/tarmak/utils"
+	"github.com/jetstack/tarmak/pkg/tarmak/utils"
 )
 
 var clusterImagesBuildCmd = &cobra.Command{
@@ -16,11 +16,12 @@ var clusterImagesBuildCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
-		//utils.WaitOrCancel(
-		//	func(ctx context.Context) error {
-		//		return t.Packer().Build(ctx)
-		//	},
-		//)
+		utils.WaitOrCancel(
+			func(ctx context.Context) error {
+				return t.Packer().Build(ctx)
+			},
+			t.Context(),
+		)
 	},
 }
 

--- a/cmd/tarmak/cmd/cluster_images_build.go
+++ b/cmd/tarmak/cmd/cluster_images_build.go
@@ -2,12 +2,12 @@
 package cmd
 
 import (
-	"context"
+	//"context"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jetstack/tarmak/pkg/tarmak"
-	"github.com/jetstack/tarmak/pkg/tarmak/utils"
+	//"github.com/jetstack/tarmak/pkg/tarmak/utils"
 )
 
 var clusterImagesBuildCmd = &cobra.Command{
@@ -16,11 +16,11 @@ var clusterImagesBuildCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
-		utils.WaitOrCancel(
-			func(ctx context.Context) error {
-				return t.Packer().Build(ctx)
-			},
-		)
+		//utils.WaitOrCancel(
+		//	func(ctx context.Context) error {
+		//		return t.Packer().Build(ctx)
+		//	},
+		//)
 	},
 }
 

--- a/cmd/tarmak/cmd/cluster_plan.go
+++ b/cmd/tarmak/cmd/cluster_plan.go
@@ -17,13 +17,11 @@ var clusterPlanCmd = &cobra.Command{
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
 
-		planCmd := t.NewCmdTerraform(args)
-
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
-				return planCmd.Plan()
+				return t.NewCmdTerraform(args).Plan()
 			},
-			planCmd.StopCh,
+			t.Context(),
 			2,
 		)
 	},

--- a/cmd/tarmak/cmd/cluster_plan.go
+++ b/cmd/tarmak/cmd/cluster_plan.go
@@ -16,16 +16,19 @@ var clusterPlanCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
+
+		planCmd := t.NewCmdTerraform(args)
+
 		utils.WaitOrCancel(
 			func(ctx context.Context) error {
-				return t.CmdTerraformPlan(args, ctx)
+				return planCmd.Plan()
 			},
+			planCmd.StopCh,
 			2,
 		)
 	},
 }
 
 func init() {
-	//clusterPlanFlags(clusterPlanCmd.PersistentFlags())
 	clusterCmd.AddCommand(clusterPlanCmd)
 }

--- a/cmd/tarmak/cmd/terraform.go
+++ b/cmd/tarmak/cmd/terraform.go
@@ -5,14 +5,17 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-plugin"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/jetstack/tarmak/pkg/tarmak/utils"
 	"github.com/jetstack/tarmak/pkg/terraform"
 )
 
 // ensure plugin clients get closed after subcommand run
-func terraformPassthrough(args []string, stopCh chan struct{}, f func([]string, chan struct{}) int) int {
+func terraformPassthrough(args []string, f func([]string, chan struct{}) int) int {
 	defer plugin.CleanupClients()
+	stopCh := utils.BasicSignalHandler(logrus.NewEntry(logrus.New()))
 	return f(args, stopCh)
 }
 
@@ -34,7 +37,7 @@ var terraformCmd = &cobra.Command{
 var terraformPlanCmd = &cobra.Command{
 	Use: "plan",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Plan))
+		os.Exit(terraformPassthrough(args, terraform.Plan))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -43,7 +46,7 @@ var terraformPlanCmd = &cobra.Command{
 var terraformApplyCmd = &cobra.Command{
 	Use: "apply",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Apply))
+		os.Exit(terraformPassthrough(args, terraform.Apply))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -52,7 +55,7 @@ var terraformApplyCmd = &cobra.Command{
 var terraformDestroyCmd = &cobra.Command{
 	Use: "destroy",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Destroy))
+		os.Exit(terraformPassthrough(args, terraform.Destroy))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -61,7 +64,7 @@ var terraformDestroyCmd = &cobra.Command{
 var terraformOutputCmd = &cobra.Command{
 	Use: "output",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Output))
+		os.Exit(terraformPassthrough(args, terraform.Output))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -70,7 +73,7 @@ var terraformOutputCmd = &cobra.Command{
 var terraformInitCmd = &cobra.Command{
 	Use: "init",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Init))
+		os.Exit(terraformPassthrough(args, terraform.Init))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -79,7 +82,7 @@ var terraformInitCmd = &cobra.Command{
 var terraformForceUnlockCmd = &cobra.Command{
 	Use: "force-unlock",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Unlock))
+		os.Exit(terraformPassthrough(args, terraform.Unlock))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,

--- a/cmd/tarmak/cmd/terraform.go
+++ b/cmd/tarmak/cmd/terraform.go
@@ -11,9 +11,9 @@ import (
 )
 
 // ensure plugin clients get closed after subcommand run
-func terraformPassthrough(args []string, f func([]string) int) int {
+func terraformPassthrough(args []string, stopCh chan struct{}, f func([]string, chan struct{}) int) int {
 	defer plugin.CleanupClients()
-	return f(args)
+	return f(args, stopCh)
 }
 
 var internalPluginCmd = &cobra.Command{
@@ -34,7 +34,7 @@ var terraformCmd = &cobra.Command{
 var terraformPlanCmd = &cobra.Command{
 	Use: "plan",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, terraform.Plan))
+		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Plan))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -43,7 +43,7 @@ var terraformPlanCmd = &cobra.Command{
 var terraformApplyCmd = &cobra.Command{
 	Use: "apply",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, terraform.Apply))
+		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Apply))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -52,7 +52,7 @@ var terraformApplyCmd = &cobra.Command{
 var terraformDestroyCmd = &cobra.Command{
 	Use: "destroy",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, terraform.Destroy))
+		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Destroy))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -61,7 +61,7 @@ var terraformDestroyCmd = &cobra.Command{
 var terraformOutputCmd = &cobra.Command{
 	Use: "output",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, terraform.Output))
+		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Output))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -70,7 +70,7 @@ var terraformOutputCmd = &cobra.Command{
 var terraformInitCmd = &cobra.Command{
 	Use: "init",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, terraform.Init))
+		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Init))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,
@@ -79,7 +79,7 @@ var terraformInitCmd = &cobra.Command{
 var terraformForceUnlockCmd = &cobra.Command{
 	Use: "force-unlock",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(terraformPassthrough(args, terraform.Unlock))
+		os.Exit(terraformPassthrough(args, make(chan struct{}), terraform.Unlock))
 	},
 	Hidden:             true,
 	DisableFlagParsing: true,

--- a/pkg/docker/app_container.go
+++ b/pkg/docker/app_container.go
@@ -18,11 +18,11 @@ type AppContainer struct {
 
 	dockerContainer *docker.Container
 
-	WorkingDir string   // working dir inside the container
-	Env        []string // environment variables
-	Cmd        []string // command to run in the container
-	Keep       bool     // don't cleanup containers
-
+	WorkingDir string        // working dir inside the container
+	Env        []string      // environment variables
+	Cmd        []string      // command to run in the container
+	Keep       bool          // don't cleanup containers
+	stopCh     chan struct{} // signal to kill container
 }
 
 func (ac *AppContainer) SetLog(log *logrus.Entry) {
@@ -197,4 +197,15 @@ func (ac *AppContainer) Capture(cmd string, args []string) (stdOut string, stdEr
 
 func (ac *AppContainer) Start() error {
 	return ac.app.dockerClient.StartContainer(ac.dockerContainer.ID, &docker.HostConfig{})
+}
+
+func (ac *AppContainer) Kill() error {
+	if ac.dockerContainer != nil {
+		return ac.app.dockerClient.KillContainer(docker.KillContainerOptions{
+			ID:     ac.dockerContainer.ID,
+			Signal: docker.SIGKILL,
+		})
+	}
+
+	return nil
 }

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/jetstack/vault-unsealer/pkg/kv"
 	"github.com/sirupsen/logrus"
@@ -128,6 +129,7 @@ type Provider interface {
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
 	VerifyInstanceTypes(intstancePools []InstancePool) error
+	RetrieveRemoteStateStateDynamoDBTable() (*dynamodb.GetItemOutput, error)
 }
 
 type Tarmak interface {
@@ -153,6 +155,7 @@ type Tarmak interface {
 	HomeDirExpand(in string) (string, error)
 	HomeDir() string
 	KeepContainers() bool
+	Context() context.Context
 
 	// get a provider by name
 	ProviderByName(string) (Provider, error)

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/jetstack/vault-unsealer/pkg/kv"
 	"github.com/sirupsen/logrus"
@@ -128,6 +129,7 @@ type Provider interface {
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
 	VerifyInstanceTypes(intstancePools []InstancePool) error
+	RetrieveRemoteStateStateDynamoDBTable() (*dynamodb.GetItemOutput, error)
 }
 
 type Tarmak interface {

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/jetstack/vault-unsealer/pkg/kv"
 	"github.com/sirupsen/logrus"
@@ -129,7 +128,6 @@ type Provider interface {
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
 	VerifyInstanceTypes(intstancePools []InstancePool) error
-	RetrieveRemoteStateStateDynamoDBTable() (*dynamodb.GetItemOutput, error)
 }
 
 type Tarmak interface {

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -63,6 +63,7 @@ type EC2 interface {
 type DynamoDB interface {
 	DescribeTable(input *dynamodb.DescribeTableInput) (*dynamodb.DescribeTableOutput, error)
 	CreateTable(input *dynamodb.CreateTableInput) (*dynamodb.CreateTableOutput, error)
+	GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
 }
 
 type Route53 interface {

--- a/pkg/tarmak/provider/amazon/tf_remote_state.go
+++ b/pkg/tarmak/provider/amazon/tf_remote_state.go
@@ -3,6 +3,7 @@ package amazon
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -215,4 +216,25 @@ func (a *Amazon) validateRemoteStateDynamoDB() error {
 	}
 
 	return nil
+}
+
+func (a *Amazon) RetrieveRemoteStateStateDynamoDBTable() (*dynamodb.GetItemOutput, error) {
+	svc, err := a.DynamoDB()
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := svc.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(a.RemoteStateName()),
+		Key: map[string]*dynamodb.AttributeValue{
+			DynamoDBKey: &dynamodb.AttributeValue{
+				S: aws.String(filepath.Join(a.RemoteStateName(), a.tarmak.Environment().Name(), a.tarmak.Cluster().Name(), "main.tfstate")),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/pkg/tarmak/provider/amazon/tf_remote_state.go
+++ b/pkg/tarmak/provider/amazon/tf_remote_state.go
@@ -3,7 +3,6 @@ package amazon
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -216,25 +215,4 @@ func (a *Amazon) validateRemoteStateDynamoDB() error {
 	}
 
 	return nil
-}
-
-func (a *Amazon) RetrieveRemoteStateStateDynamoDBTable() (*dynamodb.GetItemOutput, error) {
-	svc, err := a.DynamoDB()
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := svc.GetItem(&dynamodb.GetItemInput{
-		TableName: aws.String(a.RemoteStateName()),
-		Key: map[string]*dynamodb.AttributeValue{
-			DynamoDBKey: &dynamodb.AttributeValue{
-				S: aws.String(filepath.Join(a.RemoteStateName(), a.tarmak.Environment().Name(), a.tarmak.Cluster().Name(), "main.tfstate")),
-			},
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
 }

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -45,6 +45,8 @@ type Tarmak struct {
 	// function pointers for easier testing
 	environmentByName func(string) (interfaces.Environment, error)
 	providerByName    func(string) (interfaces.Provider, error)
+
+	StopCh chan struct{}
 }
 
 var _ interfaces.Tarmak = &Tarmak{}
@@ -52,8 +54,9 @@ var _ interfaces.Tarmak = &Tarmak{}
 // allocate a new tarmak struct
 func New(flags *tarmakv1alpha1.Flags) *Tarmak {
 	t := &Tarmak{
-		log:   logrus.New(),
-		flags: flags,
+		log:    logrus.New(),
+		flags:  flags,
+		StopCh: make(chan struct{}),
 	}
 
 	t.initializeModules()
@@ -127,7 +130,7 @@ func New(flags *tarmakv1alpha1.Flags) *Tarmak {
 func (t *Tarmak) initializeModules() {
 	t.environmentByName = t.environmentByNameReal
 	t.providerByName = t.providerByNameReal
-	t.terraform = terraform.New(t)
+	t.terraform = terraform.New(t, t.StopCh)
 	t.packer = packer.New(t)
 	t.ssh = ssh.New(t)
 	t.puppet = puppet.New(t)

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -2,6 +2,7 @@
 package tarmak
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -21,6 +22,7 @@ import (
 	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
 	"github.com/jetstack/tarmak/pkg/tarmak/kubectl"
 	"github.com/jetstack/tarmak/pkg/tarmak/ssh"
+	"github.com/jetstack/tarmak/pkg/tarmak/utils"
 	"github.com/jetstack/tarmak/pkg/terraform"
 )
 
@@ -30,6 +32,7 @@ type Tarmak struct {
 	log             *logrus.Logger
 	flags           *tarmakv1alpha1.Flags
 	configDirectory string
+	ctx             context.Context
 
 	config    interfaces.Config
 	terraform *terraform.Terraform
@@ -45,8 +48,6 @@ type Tarmak struct {
 	// function pointers for easier testing
 	environmentByName func(string) (interfaces.Environment, error)
 	providerByName    func(string) (interfaces.Provider, error)
-
-	StopCh chan struct{}
 }
 
 var _ interfaces.Tarmak = &Tarmak{}
@@ -54,9 +55,9 @@ var _ interfaces.Tarmak = &Tarmak{}
 // allocate a new tarmak struct
 func New(flags *tarmakv1alpha1.Flags) *Tarmak {
 	t := &Tarmak{
-		log:    logrus.New(),
-		flags:  flags,
-		StopCh: make(chan struct{}),
+		log:   logrus.New(),
+		flags: flags,
+		ctx:   utils.GetContext(),
 	}
 
 	t.initializeModules()
@@ -130,7 +131,7 @@ func New(flags *tarmakv1alpha1.Flags) *Tarmak {
 func (t *Tarmak) initializeModules() {
 	t.environmentByName = t.environmentByNameReal
 	t.providerByName = t.providerByNameReal
-	t.terraform = terraform.New(t, t.StopCh)
+	t.terraform = terraform.New(t)
 	t.packer = packer.New(t)
 	t.ssh = ssh.New(t)
 	t.puppet = puppet.New(t)
@@ -328,4 +329,8 @@ func (t *Tarmak) CmdKubectl(args []string) error {
 		return err
 	}
 	return t.kubectl.Kubectl(args)
+}
+
+func (t *Tarmak) Context() context.Context {
+	return t.ctx
 }

--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -2,36 +2,50 @@
 package tarmak
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
 	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
 )
 
+type CmdTerraform struct {
+	StopCh chan struct{}
+	tarmak *Tarmak
+	args   []string
+}
+
 func (t *Tarmak) Terraform() interfaces.Terraform {
 	return t.terraform
 }
 
-func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+func (t *Tarmak) NewCmdTerraform(args []string) *CmdTerraform {
+	return &CmdTerraform{
+		StopCh: t.StopCh,
+		tarmak: t,
+		args:   args,
+	}
+
+}
+
+func (c *CmdTerraform) Plan() error {
+	if err := c.tarmak.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}
 
-	if err := t.verifyImageExists(); err != nil {
+	if err := c.tarmak.verifyImageExists(); err != nil {
 		return err
 	}
 
-	if err := t.Validate(); err != nil {
+	if err := c.tarmak.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	if err := t.Cluster().Verify(); err != nil {
+	if err := c.tarmak.Cluster().Verify(); err != nil {
 		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
 	}
 
-	t.cluster.Log().Info("running plan")
-	err := t.terraform.Plan(t.Cluster())
+	c.tarmak.cluster.Log().Info("running plan")
+	err := c.tarmak.terraform.Plan(c.tarmak.Cluster())
 	if err != nil {
 		return err
 	}
@@ -39,50 +53,50 @@ func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
 	return nil
 }
 
-func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+func (c *CmdTerraform) Apply() error {
+	if err := c.tarmak.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}
 
-	if err := t.verifyImageExists(); err != nil {
+	if err := c.tarmak.verifyImageExists(); err != nil {
 		return err
 	}
 
-	if err := t.Validate(); err != nil {
+	if err := c.tarmak.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	if err := t.Cluster().Verify(); err != nil {
+	if err := c.tarmak.Cluster().Verify(); err != nil {
 		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
 	}
 
-	t.cluster.Log().Info("running apply")
+	c.tarmak.cluster.Log().Info("running apply")
 	// run terraform apply always, do not run it when in configuration only mode
-	if !t.flags.Cluster.Apply.ConfigurationOnly {
-		err := t.terraform.Apply(t.Cluster())
+	if !c.tarmak.flags.Cluster.Apply.ConfigurationOnly {
+		err := c.tarmak.terraform.Apply(c.tarmak.Cluster())
 		if err != nil {
 			return err
 		}
 	}
 
 	// upload tar gz only if terraform hasn't uploaded it yet
-	if t.flags.Cluster.Apply.ConfigurationOnly {
-		err := t.Cluster().UploadConfiguration()
+	if c.tarmak.flags.Cluster.Apply.ConfigurationOnly {
+		err := c.tarmak.Cluster().UploadConfiguration()
 		if err != nil {
 			return err
 		}
 	}
 
 	// reapply config expect if we are in infrastructure only
-	if !t.flags.Cluster.Apply.InfrastructureOnly {
-		err := t.Cluster().ReapplyConfiguration()
+	if !c.tarmak.flags.Cluster.Apply.InfrastructureOnly {
+		err := c.tarmak.Cluster().ReapplyConfiguration()
 		if err != nil {
 			return err
 		}
 	}
 
 	// wait for convergance in every mode
-	err := t.Cluster().WaitForConvergance()
+	err := c.tarmak.Cluster().WaitForConvergance()
 	if err != nil {
 		return err
 	}
@@ -90,34 +104,34 @@ func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
 	return nil
 }
 
-func (t *Tarmak) CmdTerraformDestroy(args []string, ctx context.Context) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+func (c *CmdTerraform) Destroy() error {
+	if err := c.tarmak.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}
 
-	if err := t.Validate(); err != nil {
+	if err := c.tarmak.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	if err := t.Cluster().Verify(); err != nil {
+	if err := c.tarmak.Cluster().Verify(); err != nil {
 		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
 	}
 
-	t.cluster.Log().Info("running destroy")
+	c.tarmak.cluster.Log().Info("running destroy")
 
-	err := t.terraform.Destroy(t.Cluster())
+	err := c.tarmak.terraform.Destroy(c.tarmak.Cluster())
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (t *Tarmak) CmdTerraformShell(args []string) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+func (c *CmdTerraform) Shell(args []string) error {
+	if err := c.tarmak.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}
 
-	err := t.terraform.Shell(t.Cluster())
+	err := c.tarmak.terraform.Shell(c.tarmak.Cluster())
 	if err != nil {
 		return err
 	}

--- a/pkg/tarmak/utils/context.go
+++ b/pkg/tarmak/utils/context.go
@@ -13,7 +13,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func GetContext() (context.Context, func()) {
+type Context struct {
+	context.Context
+	cancel func()
+}
+
+func GetContext() *Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
@@ -21,6 +26,7 @@ func GetContext() (context.Context, func()) {
 		select {
 		case sig := <-ch:
 			log.Infof("caught signal '%v'", sig)
+			cancel()
 		case <-ctx.Done():
 			log.Info("context done")
 		}
@@ -28,19 +34,25 @@ func GetContext() (context.Context, func()) {
 		log.Info("cancelling")
 		cancel()
 	}()
-	return ctx, cancel
+
+	return &Context{
+		ctx,
+		cancel,
+	}
 }
 
-func WaitOrCancel(f func(context.Context) error, stopCh chan struct{}, ignoredExitStatuses ...int) {
-	ctx, cancel := GetContext()
-	defer cancel()
+func WaitOrCancel(f func(context.Context) error, c context.Context, ignoredExitStatuses ...int) {
+	ctx, ok := c.(*Context)
+	if !ok {
+		log.Error("Failed to assert context")
+		return
+	}
+	defer ctx.cancel()
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	defer wg.Wait()
 	finished := make(chan struct{})
 	defer close(finished)
-
-	closedStopCh := false
 
 	go func() {
 		select {
@@ -52,18 +64,14 @@ func WaitOrCancel(f func(context.Context) error, stopCh chan struct{}, ignoredEx
 			case <-finished:
 				wg.Done()
 				return
-			case <-time.After(time.Second):
+			case <-time.After(time.Second * 2):
 				log.Warn("Tarmak is shutting down.")
-				log.Warn("* Tarmak will exit after the current task finishes.")
+				log.Warn("* Tarmak will attempt to kill the current task.")
 				log.Warn("* Send another SIGTERM or SIGINT (ctrl-c) to exit immediately.")
-				if !closedStopCh {
-					close(stopCh)
-					closedStopCh = true
-				}
 			}
 		}
 	}()
-	err := f(ctx)
+	err := f(c)
 	switch err {
 	case context.Canceled:
 		log.Warn("Tarmak was canceled. Re-run to complete any remaining tasks.")
@@ -83,11 +91,11 @@ func WaitOrCancel(f func(context.Context) error, stopCh chan struct{}, ignoredEx
 				}
 			}
 			if !errorOk {
-				log.WithError(err).Errorf("Tarmak exited with an error: %s", err)
+				log.Errorf("Tarmak exited with an error: %s", err)
 			}
 			log.Exit(exitStatus)
 		}
-		log.WithError(err).Fatalf("Tarmak exited with an error: %s", err)
+		log.Fatalf("Tarmak exited with an error: %s", err)
 	}
 }
 

--- a/pkg/terraform/passthrough.go
+++ b/pkg/terraform/passthrough.go
@@ -57,7 +57,8 @@ func newErrUI(out io.Writer, errOut io.Writer) cli.Ui {
 	}
 }
 
-func newMeta(ui cli.Ui) command.Meta {
+func newMeta(ui cli.Ui, stopCh chan struct{}) command.Meta {
+
 	if os.Getenv("TF_LOG") == "" {
 		log.SetOutput(ioutil.Discard)
 		os.Stderr = nil
@@ -76,6 +77,7 @@ func newMeta(ui cli.Ui) command.Meta {
 
 		RunningInAutomation: inAutomation,
 		OverrideDataDir:     dataDir,
+		ShutdownCh:          stopCh,
 	}
 }
 
@@ -111,45 +113,45 @@ func InternalPlugin(args []string) int {
 	return 0
 }
 
-func Plan(args []string) int {
+func Plan(args []string, stopCh chan struct{}) int {
 	c := &command.PlanCommand{
-		Meta: newMeta(newUI(os.Stdout, os.Stderr)),
+		Meta: newMeta(newUI(os.Stdout, os.Stderr), stopCh),
 	}
 	return c.Run(args)
 }
 
-func Apply(args []string) int {
+func Apply(args []string, stopCh chan struct{}) int {
 	c := &command.ApplyCommand{
-		Meta: newMeta(newUI(os.Stdout, os.Stderr)),
+		Meta: newMeta(newUI(os.Stdout, os.Stderr), stopCh),
 	}
 	return c.Run(args)
 }
 
-func Destroy(args []string) int {
+func Destroy(args []string, stopCh chan struct{}) int {
 	c := &command.ApplyCommand{
-		Meta:    newMeta(newUI(os.Stdout, os.Stderr)),
+		Meta:    newMeta(newUI(os.Stdout, os.Stderr), stopCh),
 		Destroy: true,
 	}
 	return c.Run(args)
 }
 
-func Init(args []string) int {
+func Init(args []string, stopCh chan struct{}) int {
 	c := &command.InitCommand{
-		Meta: newMeta(newUI(os.Stdout, os.Stderr)),
+		Meta: newMeta(newUI(os.Stdout, os.Stderr), stopCh),
 	}
 	return c.Run(args)
 }
 
-func Output(args []string) int {
+func Output(args []string, stopCh chan struct{}) int {
 	c := &command.OutputCommand{
-		Meta: newMeta(newUI(os.Stdout, os.Stderr)),
+		Meta: newMeta(newUI(os.Stdout, os.Stderr), stopCh),
 	}
 	return c.Run(args)
 }
 
-func Unlock(args []string) int {
+func Unlock(args []string, stopCh chan struct{}) int {
 	c := &command.UnlockCommand{
-		Meta: newMeta(newUI(os.Stdout, os.Stderr)),
+		Meta: newMeta(newUI(os.Stdout, os.Stderr), stopCh),
 	}
 	return c.Run(args)
 }

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -4,8 +4,6 @@ package terraform
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,7 +13,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/hashicorp/terraform/command"
 	"github.com/kardianos/osext"
@@ -284,67 +281,12 @@ func (t *Terraform) command(cluster interfaces.Cluster, args []string, stdin io.
 	cmd.Dir = t.codePath(cluster)
 	cmd.Env = envVars
 
-	complete := make(chan struct{})
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	defer wg.Wait()
-	go func() {
-		for {
-			select {
-			case <-t.tarmak.Context().Done():
-				if cmd.Process != nil {
-					cmd.Process.Signal(syscall.SIGINT)
-					t.log.Infof("Attempting to remove terraform remote state lock")
-					if err := t.DeleteRemoteStateLock(cluster); err != nil {
-						t.log.Errorf("Failed to remove terraform remote state lock: %v", err)
-					}
-					t.log.Infof("Remote state lock was removed")
-				}
-				wg.Done()
-				return
-			case <-complete:
-				wg.Done()
-				return
-			}
-		}
-	}()
-
 	err = cmd.Run()
-	close(complete)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (t *Terraform) DeleteRemoteStateLock(cluster interfaces.Cluster) error {
-
-	type LockID struct {
-		ID string `json:"ID"`
-	}
-	errMsg := errors.New("remote state lock ID not found")
-
-	result, err := t.tarmak.Provider().RetrieveRemoteStateStateDynamoDBTable()
-	if err != nil {
-		return fmt.Errorf("%s: %s", errMsg, err)
-	}
-
-	item := LockID{}
-	r, ok := result.Item["Info"]
-	if !ok {
-		return errMsg
-	}
-	json.Unmarshal([]byte(*r.S), &item)
-	if item.ID == "" {
-		return errMsg
-	}
-
-	return t.terraformWrapper(
-		cluster,
-		"force-unlock",
-		[]string{"--force", item.ID},
-	)
 }
 
 func (t *Terraform) Plan(cluster interfaces.Cluster) error {

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -33,14 +33,16 @@ type Terraform struct {
 	*tarmakDocker.App
 	log    *logrus.Entry
 	tarmak interfaces.Tarmak
+	stopCh chan struct{}
 }
 
-func New(tarmak interfaces.Tarmak) *Terraform {
+func New(tarmak interfaces.Tarmak, stopCh chan struct{}) *Terraform {
 	log := tarmak.Log().WithField("module", "terraform")
 
 	return &Terraform{
 		log:    log,
 		tarmak: tarmak,
+		stopCh: stopCh,
 	}
 }
 
@@ -148,7 +150,7 @@ func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string,
 	}
 
 	// listen to rpc
-	stopCh := make(chan struct{})
+	stopRpcCh := make(chan struct{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -156,7 +158,7 @@ func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string,
 		if err := rpc.ListenUnixSocket(
 			rpc.New(t.tarmak.Cluster()),
 			t.socketPath(cluster),
-			stopCh,
+			stopRpcCh,
 		); err != nil {
 			t.log.Fatalf("error listening to unix socket: %s", err)
 		}
@@ -204,7 +206,7 @@ func (t *Terraform) terraformWrapper(cluster interfaces.Cluster, command string,
 		}
 	}
 
-	close(stopCh)
+	close(stopRpcCh)
 	wg.Wait()
 
 	return nil
@@ -281,9 +283,23 @@ func (t *Terraform) command(cluster interfaces.Cluster, args []string, stdin io.
 	cmd.Dir = t.codePath(cluster)
 	cmd.Env = envVars
 
+	complete := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-t.stopCh:
+				cmd.Process.Kill()
+				return
+			case <-complete:
+				return
+			}
+		}
+	}()
+
 	if err := cmd.Run(); err != nil {
 		return err
 	}
+	close(complete)
 
 	return nil
 }

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -4,6 +4,8 @@ package terraform
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/hashicorp/terraform/command"
 	"github.com/kardianos/osext"
@@ -33,16 +36,14 @@ type Terraform struct {
 	*tarmakDocker.App
 	log    *logrus.Entry
 	tarmak interfaces.Tarmak
-	stopCh chan struct{}
 }
 
-func New(tarmak interfaces.Tarmak, stopCh chan struct{}) *Terraform {
+func New(tarmak interfaces.Tarmak) *Terraform {
 	log := tarmak.Log().WithField("module", "terraform")
 
 	return &Terraform{
 		log:    log,
 		tarmak: tarmak,
-		stopCh: stopCh,
 	}
 }
 
@@ -284,24 +285,66 @@ func (t *Terraform) command(cluster interfaces.Cluster, args []string, stdin io.
 	cmd.Env = envVars
 
 	complete := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	defer wg.Wait()
 	go func() {
 		for {
 			select {
-			case <-t.stopCh:
-				cmd.Process.Kill()
+			case <-t.tarmak.Context().Done():
+				if cmd.Process != nil {
+					cmd.Process.Signal(syscall.SIGINT)
+					t.log.Infof("Attempting to remove terraform remote state lock")
+					if err := t.DeleteRemoteStateLock(cluster); err != nil {
+						t.log.Errorf("Failed to remove terraform remote state lock: %v", err)
+					}
+					t.log.Infof("Remote state lock was removed")
+				}
+				wg.Done()
 				return
 			case <-complete:
+				wg.Done()
 				return
 			}
 		}
 	}()
 
-	if err := cmd.Run(); err != nil {
+	err = cmd.Run()
+	close(complete)
+	if err != nil {
 		return err
 	}
-	close(complete)
 
 	return nil
+}
+
+func (t *Terraform) DeleteRemoteStateLock(cluster interfaces.Cluster) error {
+
+	type LockID struct {
+		ID string `json:"ID"`
+	}
+	errMsg := errors.New("remote state lock ID not found")
+
+	result, err := t.tarmak.Provider().RetrieveRemoteStateStateDynamoDBTable()
+	if err != nil {
+		return fmt.Errorf("%s: %s", errMsg, err)
+	}
+
+	item := LockID{}
+	r, ok := result.Item["Info"]
+	if !ok {
+		return errMsg
+	}
+	json.Unmarshal([]byte(*r.S), &item)
+	if item.ID == "" {
+		return errMsg
+	}
+
+	return t.terraformWrapper(
+		cluster,
+		"force-unlock",
+		[]string{"--force", item.ID},
+	)
 }
 
 func (t *Terraform) Plan(cluster interfaces.Cluster) error {

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -4,6 +4,8 @@ package terraform
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -292,6 +294,11 @@ func (t *Terraform) command(cluster interfaces.Cluster, args []string, stdin io.
 			case <-t.tarmak.Context().Done():
 				if cmd.Process != nil {
 					cmd.Process.Signal(syscall.SIGINT)
+					t.log.Infof("Attempting to remove terraform remote state lock")
+					if err := t.DeleteRemoteStateLock(cluster); err != nil {
+						t.log.Errorf("Failed to remove terraform remote state lock: %v", err)
+					}
+					t.log.Infof("Remote state lock was removed")
 				}
 				wg.Done()
 				return
@@ -309,6 +316,35 @@ func (t *Terraform) command(cluster interfaces.Cluster, args []string, stdin io.
 	}
 
 	return nil
+}
+
+func (t *Terraform) DeleteRemoteStateLock(cluster interfaces.Cluster) error {
+
+	type LockID struct {
+		ID string `json:"ID"`
+	}
+	errMsg := errors.New("remote state lock ID not found")
+
+	result, err := t.tarmak.Provider().RetrieveRemoteStateStateDynamoDBTable()
+	if err != nil {
+		return fmt.Errorf("%s: %s", errMsg, err)
+	}
+
+	item := LockID{}
+	r, ok := result.Item["Info"]
+	if !ok {
+		return errMsg
+	}
+	json.Unmarshal([]byte(*r.S), &item)
+	if item.ID == "" {
+		return errMsg
+	}
+
+	return t.terraformWrapper(
+		cluster,
+		"force-unlock",
+		[]string{"--force", item.ID},
+	)
 }
 
 func (t *Terraform) Plan(cluster interfaces.Cluster) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Terraform does not remove it's own state lock on interrupt. This PR attempts to remove this remote state lock during an interrupt of a terraform oporation.

**Special notes for your reviewer**:
Rebased on top of https://github.com/jetstack/tarmak/pull/356

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove terraform remote state lock during an operation interrupt
```
