### PR TITLE
Use bastion and vault instance type from config

### DIFF
--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -251,6 +251,7 @@ type InstancePool interface {
 	Validate() error
 	MinCount() int
 	MaxCount() int
+	InstanceType() string
 }
 
 type Volume interface {

--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -186,6 +186,8 @@ func (t *terraformTemplate) data(module string) map[string]interface{} {
 		"Module":                module,
 		"WingHash":              t.wingHash,
 		"WingDevMode":           t.wingDevMode,
+		"VaultInstancePool":     t.cluster.InstancePool("vault"),
+		"BastionInstancePool":   t.cluster.InstancePool("bastion"),
 	}
 }
 
@@ -246,7 +248,7 @@ func (t *terraformTemplate) generateTemplate(name string, target string, fileTyp
 		// TODO: change behaviour of data function to not have to use module kubernetes below
 		t.data("kubernetes"),
 	); err != nil {
-		return fmt.Errorf("failed to execute template '%s'", name)
+		return fmt.Errorf("failed to execute template '%s' (%s) ", name, err)
 	}
 
 	return nil

--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -75,7 +75,7 @@ variable "route_table_private_ids" {
 }
 variable "bastion_ami" {}
 variable "bastion_instance_type" {
-  default = "t2.nano"
+  default = "{{ .BastionInstancePool.InstanceType }}"
 }
 variable "bastion_root_size" {
   default = "16"
@@ -116,10 +116,10 @@ variable "vault_data_size" {
 variable "vault_min_instance_count" {}
 
 variable "vault_instance_type" {
-  default = "t2.nano"
+  default = "{{ .VaultInstancePool.InstanceType }}"
 }
 variable "vault_ami" {}
-# state 
+# state
 variable "bucket_prefix" {}
 {{end}}
 


### PR DESCRIPTION
Previously, this information was not read in correctly as the bastion and vault 'pools' are different from other instance pools.

I did this while investigating what happens when upgrading to larger vault instances on a live cluster.

**What this PR does / why we need it**:
Changing the size of nodes for bastion and vault pools in the config file wasn't having any effect.

```release-note
Correctly apply bastion and vault aws instance type from tarmak.yaml
```
