### PR TITLE
Update vault-helper to 0.9.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 | Vault       |                    | `0.9.5`  |
 | Kubernetes  | `>= 1.7 && < 1.11` | `1.9.7`  |
 | Calico      |                    | `3.1.1`  |
-| Vault Helper|                    | `0.9.12` |
+| Vault Helper|                    | `0.9.13` |
 | Etcd        |                    | `3.2.17` |
 
 ## [0.3.0]: 0.3.0 - 2018-02-20

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -930,8 +930,8 @@
 [[projects]]
   name = "github.com/jetstack/vault-helper"
   packages = ["pkg/kubernetes"]
-  revision = "0902b7a57834910635ac2ffa68c8f2c928b2bade"
-  version = "0.9.12"
+  revision = "9fb3ba240f007f40cafb27cb3083d9148c4ddafd"
+  version = "0.9.13"
 
 [[projects]]
   name = "github.com/jetstack/vault-unsealer"
@@ -1703,7 +1703,6 @@
   revision = "927313aa2f67b6f51d3ea954027cb009efb31941"
 
 [[projects]]
-  branch = "release-1.9"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1766,6 +1765,7 @@
     "third_party/forked/golang/reflect"
   ]
   revision = "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
+  version = "kubernetes-1.9.3"
 
 [[projects]]
   name = "k8s.io/apiserver"
@@ -2035,6 +2035,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "294141c59d0cffbcfcbdd2c808e6830171240cbb94ca32ad2ed0af48e96de749"
+  inputs-digest = "43759dac41f3a00b27b8c5ec13118602c48b949a5f9e5fbd207937f4ad8cf04d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,7 @@ required = [
 
 [[constraint]]
   name = "github.com/jetstack/vault-helper"
-  version = "0.9.12"
+  version = "0.9.13"
 
 [[constraint]]
   name = "github.com/cenkalti/backoff"

--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -146,6 +146,9 @@ func (t *terraformTemplate) Generate() error {
 	if err := t.generateTemplate("wing_s3", "modules/kubernetes/wing_s3", "tf"); err != nil {
 		result = multierror.Append(result, err)
 	}
+	if err := t.generateTemplate("vault_instances", "modules/vault/vault_instances", "tf"); err != nil {
+		result = multierror.Append(result, err)
+	}
 
 	if err := t.generateTemplate("puppet_agent_user_data", "modules/kubernetes/templates/puppet_agent_user_data", "yaml"); err != nil {
 		result = multierror.Append(result, err)

--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -127,27 +127,21 @@ func (t *terraformTemplate) Generate() error {
 			result = multierror.Append(result, err)
 		}
 	}
-	if err := t.generateTemplate("modules", "modules", "tf"); err != nil {
-		result = multierror.Append(result, err)
-	}
-	if err := t.generateTemplate("inputs", "inputs", "tf"); err != nil {
-		result = multierror.Append(result, err)
-	}
-	if err := t.generateTemplate("outputs", "outputs", "tf"); err != nil {
-		result = multierror.Append(result, err)
-	}
-	if err := t.generateTemplate("providers", "providers", "tf"); err != nil {
-		result = multierror.Append(result, err)
-	}
-	if err := t.generateTemplate("jenkins_elb", "modules/jenkins/jenkins_elb", "tf"); err != nil {
-		result = multierror.Append(result, err)
-	}
-	// TODO time for a loop over an array of pairs?
-	if err := t.generateTemplate("wing_s3", "modules/kubernetes/wing_s3", "tf"); err != nil {
-		result = multierror.Append(result, err)
-	}
-	if err := t.generateTemplate("vault_instances", "modules/vault/vault_instances", "tf"); err != nil {
-		result = multierror.Append(result, err)
+
+	for _, tmpl := range []struct {
+		name, target string
+	}{
+		{"modules", "modules"},
+		{"inputs", "inputs"},
+		{"outputs", "outputs"},
+		{"providers", "providers"},
+		{"jenkins_elb", "modules/jenkins/jenkins_elb"},
+		{"wing_s3", "modules/kubernetes/wing_s3"},
+		{"vault_instances", "modules/vault/vault_instances"},
+	} {
+		if err := t.generateTemplate(tmpl.name, tmpl.target, "tf"); err != nil {
+			result = multierror.Append(result, err)
+		}
 	}
 
 	if err := t.generateTemplate("puppet_agent_user_data", "modules/kubernetes/templates/puppet_agent_user_data", "yaml"); err != nil {

--- a/puppet/modules/vault_client/files/vault-dev-server.service
+++ b/puppet/modules/vault_client/files/vault-dev-server.service
@@ -4,7 +4,7 @@ Description=vault dev server for acceptance tests
 [Service]
 Type=notify
 Environment=VAULT_VERSION=0.9.5
-Environment=VAULT_HELPER_VERSION=0.9.12
+Environment=VAULT_HELPER_VERSION=0.9.13
 Environment=VAULT_CMD=/opt/bin/vault-helper
 Environment=VAULT_ADDR=http://127.0.0.1:8200
 ExecStart=/bin/bash /etc/puppetlabs/code/modules/vault_client/files/vault-dev-server.sh

--- a/puppet/modules/vault_client/manifests/params.pp
+++ b/puppet/modules/vault_client/manifests/params.pp
@@ -5,7 +5,7 @@
 #
 class vault_client::params {
   $app_name = 'vault-helper'
-  $version = '0.9.12'
+  $version = '0.9.13'
   $bin_dir = '/opt/bin'
   $dest_dir = '/opt'
   $config_dir = '/etc/vault'

--- a/terraform/amazon/modules/vault/vault_instances.tf
+++ b/terraform/amazon/modules/vault/vault_instances.tf
@@ -106,3 +106,12 @@ resource "aws_ebs_volume" "vault" {
     #prevent_destroy = true
   }
 }
+
+resource "tarmak_vault_cluster" "vault" {
+  internal_fqdns = ["${aws_route53_record.per-instance.*.fqdn}"]
+  vault_ca = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"
+  vault_kms_key_id = "${element(split("/", var.secrets_kms_arn), 1)}"
+  vault_unseal_key_name = "${data.template_file.vault_unseal_key_name.rendered}"
+
+  depends_on = ["aws_instance.vault","tls_locally_signed_cert.vault","aws_route53_record.per-instance","tls_self_signed_cert.ca"]
+}

--- a/terraform/amazon/templates/vault_instances.tf.template
+++ b/terraform/amazon/templates/vault_instances.tf.template
@@ -50,8 +50,8 @@ resource "aws_cloudwatch_metric_alarm" "vault-autorecover" {
 }
 
 data "tarmak_bastion_instance" "bastion" {
-  hostname = "bastion"
-  username = "centos"
+  hostname    = "bastion"
+  username    = "centos"
   instance_id = "${var.bastion_instance_id}"
 }
 
@@ -107,11 +107,13 @@ resource "aws_ebs_volume" "vault" {
   }
 }
 
+{{ if eq .ClusterType .ClusterTypeClusterMulti}}
 resource "tarmak_vault_cluster" "vault" {
-  internal_fqdns = ["${aws_route53_record.per-instance.*.fqdn}"]
-  vault_ca = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"
-  vault_kms_key_id = "${element(split("/", var.secrets_kms_arn), 1)}"
+  internal_fqdns        = ["${aws_route53_record.per-instance.*.fqdn}"]
+  vault_ca              = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"
+  vault_kms_key_id      = "${element(split("/", var.secrets_kms_arn), 1)}"
   vault_unseal_key_name = "${data.template_file.vault_unseal_key_name.rendered}"
 
-  depends_on = ["aws_instance.vault","tls_locally_signed_cert.vault","aws_route53_record.per-instance","tls_self_signed_cert.ca"]
+  depends_on = ["aws_instance.vault", "tls_locally_signed_cert.vault", "aws_route53_record.per-instance", "tls_self_signed_cert.ca"]
 }
+{{ end }}

--- a/terraform/amazon/templates/vault_instances.tf.template
+++ b/terraform/amazon/templates/vault_instances.tf.template
@@ -107,7 +107,7 @@ resource "aws_ebs_volume" "vault" {
   }
 }
 
-{{ if eq .ClusterType .ClusterTypeClusterMulti}}
+{{ if eq .ClusterType .ClusterTypeHub}}
 resource "tarmak_vault_cluster" "vault" {
   internal_fqdns        = ["${aws_route53_record.per-instance.*.fqdn}"]
   vault_ca              = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure dry run was panicking due to a logic error in vault-helper. This PR upgrades vault-helper to fix this issue. 

fixes #363 

```release-note
Upgrade vault-helper to 0.9.13
```

/assign @simonswine 
