### PR TITLE
Improve AWS validate/verify

### DIFF
--- a/pkg/tarmak/environment/environment.go
+++ b/pkg/tarmak/environment/environment.go
@@ -302,7 +302,13 @@ func (e *Environment) ValidateAdminCIDRs() (result error) {
 	return result
 }
 
-func (e *Environment) Verify() (result error) {
+func (e *Environment) Verify() error {
+	var result *multierror.Error
+
+	if err := e.Provider().Verify(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
 	return result
 }
 

--- a/pkg/tarmak/initialize/initialize.go
+++ b/pkg/tarmak/initialize/initialize.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-ozzo/ozzo-validation/is"
 	"github.com/sirupsen/logrus"
 
+	"github.com/hashicorp/go-multierror"
 	clusterv1alpha1 "github.com/jetstack/tarmak/pkg/apis/cluster/v1alpha1"
 	tarmakv1alpha1 "github.com/jetstack/tarmak/pkg/apis/tarmak/v1alpha1"
 	"github.com/jetstack/tarmak/pkg/tarmak/cluster"
@@ -17,7 +18,6 @@ import (
 	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
 	"github.com/jetstack/tarmak/pkg/tarmak/provider"
 	"github.com/jetstack/tarmak/pkg/tarmak/utils/input"
-	"github.com/hashicorp/go-multierror"
 )
 
 var _ interfaces.Initialize = &Initialize{}

--- a/pkg/tarmak/initialize/initialize.go
+++ b/pkg/tarmak/initialize/initialize.go
@@ -121,9 +121,9 @@ creationLoop:
 				}
 
 			}
-			err = multierror.Append(err, i.tarmak.Config().AppendProvider(providerConf))
-			if err != nil {
-				return nil, err
+			appendError := i.tarmak.Config().AppendProvider(providerConf)
+			if appendError != nil {
+				return nil, appendError
 			}
 			break
 		}

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -358,8 +358,30 @@ func (a *Amazon) Validate() error {
 
 }
 
-func (a *Amazon) Verify() (result error) {
-	return result
+func (a *Amazon) Verify() error {
+	var result *multierror.Error
+
+	if err := a.VerifyAWSCredentials(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (a *Amazon) VerifyAWSCredentials() error {
+	svc, err := a.EC2()
+	if err != nil {
+		return err
+	}
+	input := &ec2.DescribeRegionsInput{}
+
+	_, err = svc.DescribeRegions(input)
+	if err != nil {
+		fmt.Printf("In Here")
+		return err
+	}
+
+	return nil
 }
 
 func (a *Amazon) getAvailablityZoneByRegion() (zones []string, err error) {

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -367,7 +367,7 @@ func (a *Amazon) VerifyAWSCredentials() error {
 
 	_, err = svc.DescribeRegions(input)
 	if err != nil {
-		return fmt.Errorf("There was a problem with veryfing your AWS credentials: %s", err)
+		return fmt.Errorf("there was a problem with veryfing your AWS credentials: %s", err)
 	}
 
 	return nil

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -323,7 +323,6 @@ func (a *Amazon) Validate() error {
 }
 
 func (a *Amazon) Verify() error {
-	fmt.Printf("In here")
 	var result *multierror.Error
 
 	// If this fails we don't want to verify any of the other steps as they will have the same error
@@ -368,8 +367,7 @@ func (a *Amazon) VerifyAWSCredentials() error {
 
 	_, err = svc.DescribeRegions(input)
 	if err != nil {
-		fmt.Printf("In Here")
-		return err
+		return fmt.Errorf("There was a problem with veryfing your AWS credentials: %s", err)
 	}
 
 	return nil

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -319,49 +319,38 @@ func (a *Amazon) readVaultToken() (string, error) {
 }
 
 func (a *Amazon) Validate() error {
-	var result error
-	var err error
-
-	// These checks only make sense with an environment given
-	if a.tarmak.Environment() != nil {
-		err = a.validateRemoteStateBucket()
-		if err != nil {
-			result = multierror.Append(result, err)
-		}
-
-		err = a.validateRemoteStateDynamoDB()
-		if err != nil {
-			result = multierror.Append(result, err)
-		}
-
-		err = a.validateAvailabilityZones()
-		if err != nil {
-			result = multierror.Append(result, err)
-		}
-
-		err = a.validateAWSKeyPair()
-		if err != nil {
-			result = multierror.Append(result, err)
-		}
-
-	}
-
-	err = a.validatePublicZone()
-	if err != nil {
-		result = multierror.Append(result, err)
-	}
-
-	if result != nil {
-		return result
-	}
 	return nil
-
 }
 
 func (a *Amazon) Verify() error {
+	fmt.Printf("In here")
 	var result *multierror.Error
 
+	// If this fails we don't want to verify any of the other steps as they will have the same error
 	if err := a.VerifyAWSCredentials(); err != nil {
+		return err
+	}
+
+	// These checks only make sense with an environment given
+	if a.tarmak.Environment() != nil {
+		if err := a.validateRemoteStateBucket(); err != nil {
+			result = multierror.Append(result, err)
+		}
+
+		if err := a.validateRemoteStateDynamoDB(); err != nil {
+			result = multierror.Append(result, err)
+		}
+
+		if err := a.validateAvailabilityZones(); err != nil {
+			result = multierror.Append(result, err)
+		}
+
+		if err := a.validateAWSKeyPair(); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if err := a.validatePublicZone(); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -357,6 +357,8 @@ func (a *Amazon) Verify() error {
 	return result.ErrorOrNil()
 }
 
+// Check if AWS credentials are setup correctly.
+// AWS GO SDK doesn't have an default check if access is successfull. We check if we can query the region without errors
 func (a *Amazon) VerifyAWSCredentials() error {
 	svc, err := a.EC2()
 	if err != nil {

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -297,6 +297,22 @@ func (t *Tarmak) Validate() error {
 	return result
 }
 
+func (t *Tarmak) Verify() error {
+	if err := t.Cluster().Verify(); err != nil {
+		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
+	}
+
+	if err := t.Cluster().Environment().Provider().Verify(); err != nil {
+		return fmt.Errorf("failed to verify tarmak provider: %s", err)
+	}
+
+	if err := t.verifyImageExists(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (t *Tarmak) Cleanup() {
 	// clean up assets directory
 	if t.rootPath != nil {

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -298,12 +298,12 @@ func (t *Tarmak) Validate() error {
 }
 
 func (t *Tarmak) Verify() error {
-	if err := t.Cluster().Verify(); err != nil {
-		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
+	if err := t.Cluster().Environment().Verify(); err != nil {
+		return fmt.Errorf("failed to verify tarmak provider: %s", err)
 	}
 
-	if err := t.Cluster().Environment().Provider().Verify(); err != nil {
-		return fmt.Errorf("failed to verify tarmak provider: %s", err)
+	if err := t.Cluster().Verify(); err != nil {
+		return fmt.Errorf("failed to verify tarmak cluster: %s", err)
 	}
 
 	if err := t.verifyImageExists(); err != nil {

--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -14,20 +14,19 @@ func (t *Tarmak) Terraform() interfaces.Terraform {
 }
 
 func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
-		return err
-	}
-
-	if err := t.verifyImageExists(); err != nil {
-		return err
-	}
-
+	t.cluster.Log().Info("Validate steps")
 	if err := t.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	if err := t.Cluster().Verify(); err != nil {
-		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
+	t.cluster.Log().Info("Verify steps")
+	if err := t.Validate(); err != nil {
+		return err
+	}
+
+	t.cluster.Log().Info("Write SSH config")
+	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+		return err
 	}
 
 	t.cluster.Log().Info("running plan")
@@ -40,20 +39,19 @@ func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
 }
 
 func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
-		return err
-	}
-
-	if err := t.verifyImageExists(); err != nil {
-		return err
-	}
-
+	t.cluster.Log().Info("Validate steps")
 	if err := t.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	if err := t.Cluster().Verify(); err != nil {
-		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
+	t.cluster.Log().Info("Verify steps")
+	if err := t.Validate(); err != nil {
+		return err
+	}
+
+	t.cluster.Log().Info("Write SSH config")
+	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+		return err
 	}
 
 	t.cluster.Log().Info("running apply")
@@ -91,16 +89,19 @@ func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
 }
 
 func (t *Tarmak) CmdTerraformDestroy(args []string, ctx context.Context) error {
-	if err := t.writeSSHConfigForClusterHosts(); err != nil {
-		return err
-	}
-
+	t.cluster.Log().Info("Validate steps")
 	if err := t.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	if err := t.Cluster().Verify(); err != nil {
-		return fmt.Errorf("failed to validate tarmak cluster: %s", err)
+	t.cluster.Log().Info("Verify steps")
+	if err := t.Validate(); err != nil {
+		return err
+	}
+
+	t.cluster.Log().Info("Write SSH config")
+	if err := t.writeSSHConfigForClusterHosts(); err != nil {
+		return err
 	}
 
 	t.cluster.Log().Info("running destroy")

--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -14,17 +14,17 @@ func (t *Tarmak) Terraform() interfaces.Terraform {
 }
 
 func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
-	t.cluster.Log().Info("Validate steps")
+	t.cluster.Log().Info("validate steps")
 	if err := t.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	t.cluster.Log().Info("Verify steps")
+	t.cluster.Log().Info("verify steps")
 	if err := t.Verify(); err != nil {
 		return err
 	}
 
-	t.cluster.Log().Info("Write SSH config")
+	t.cluster.Log().Info("write SSH config")
 	if err := t.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}
@@ -39,17 +39,17 @@ func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
 }
 
 func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
-	t.cluster.Log().Info("Validate steps")
+	t.cluster.Log().Info("validate steps")
 	if err := t.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	t.cluster.Log().Info("Verify steps")
+	t.cluster.Log().Info("verify steps")
 	if err := t.Verify(); err != nil {
 		return err
 	}
 
-	t.cluster.Log().Info("Write SSH config")
+	t.cluster.Log().Info("write SSH config")
 	if err := t.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}
@@ -89,17 +89,17 @@ func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
 }
 
 func (t *Tarmak) CmdTerraformDestroy(args []string, ctx context.Context) error {
-	t.cluster.Log().Info("Validate steps")
+	t.cluster.Log().Info("validate steps")
 	if err := t.Validate(); err != nil {
 		return fmt.Errorf("failed to validate tarmak: %s", err)
 	}
 
-	t.cluster.Log().Info("Verify steps")
+	t.cluster.Log().Info("verify steps")
 	if err := t.Verify(); err != nil {
 		return err
 	}
 
-	t.cluster.Log().Info("Write SSH config")
+	t.cluster.Log().Info("write SSH config")
 	if err := t.writeSSHConfigForClusterHosts(); err != nil {
 		return err
 	}

--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -20,7 +20,7 @@ func (t *Tarmak) CmdTerraformPlan(args []string, ctx context.Context) error {
 	}
 
 	t.cluster.Log().Info("Verify steps")
-	if err := t.Validate(); err != nil {
+	if err := t.Verify(); err != nil {
 		return err
 	}
 
@@ -45,7 +45,7 @@ func (t *Tarmak) CmdTerraformApply(args []string, ctx context.Context) error {
 	}
 
 	t.cluster.Log().Info("Verify steps")
-	if err := t.Validate(); err != nil {
+	if err := t.Verify(); err != nil {
 		return err
 	}
 
@@ -95,7 +95,7 @@ func (t *Tarmak) CmdTerraformDestroy(args []string, ctx context.Context) error {
 	}
 
 	t.cluster.Log().Info("Verify steps")
-	if err := t.Validate(); err != nil {
+	if err := t.Verify(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
- This moves everything that does an external call to the verify method.
- Check if our AWS credentials are correctly setup is the first verify step and it will fail on that if it doesn't work. AWS unfortunately doesn't have a better way of checking our AWS credentials and getting a better error back is really hard.
- Run verify step on provider check and not only the validate step
- Fails a bit better now
```
validation failed: 1 error occurred:

* There was a problem with veryfing your AWS credentials: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #154 
fixes #282 

This also tackles part of the problem in #280 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve verification of AWS credentials on provider creation
```
