### PR TITLE
Prepare hub before terraforming other clusters

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -308,10 +308,15 @@ func (c *Cluster) Verify() error {
 }
 
 func (c *Cluster) verifyHubState() error {
-	errMsg := "ensure hub cluster has been fully applied"
+	// The hub should be manually applied first to ensure the vault token and private key can be saved
+	errMsg := "hub cluster must be applied once first"
+	err := c.Environment().Tarmak().Terraform().Prepare(c.Environment().Hub())
+	if err != nil {
+		return fmt.Errorf("failed to prepare hub cluster for output, %s: %v", errMsg, err)
+	}
 	output, err := c.Environment().Tarmak().Terraform().Output(c.Environment().Hub())
 	if err != nil {
-		return fmt.Errorf("failed to retrieve hub cluster output, %s: %v", errMsg, err)
+		return fmt.Errorf("failed to get hub cluster output values, %s: %v", errMsg, err)
 	}
 
 	requiredHubResources := []string{


### PR DESCRIPTION
We had an issue (https://github.com/jetstack/tarmak/issues/377) where weneeded to plan the hub just to get the local files in place before running operations against other clusters.

This 'Prepares' the hub cluster before verifying it which puts the required files in place.

If the hub has not been applied, then trying to terraform another cluster in the env will still fail.

I've also added a comment explaining this function a little more as it's caused me some confusion in the past.

**What this PR does / why we need it**:
Fixes https://github.com/jetstack/tarmak/issues/377

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/jetstack/tarmak/issues/377

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prepare Hub clusters for output before terraforming other clusters in a multicluster environment. Fixes need to plan against hubs before applying.
```
