### PR TITLE
Fix audit max backups and log location

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -2,9 +2,9 @@
 class kubernetes::apiserver(
   $allow_privileged = true,
   Optional[Boolean] $audit_enabled = undef,
-  String $audit_log_directory = '/etc/kubernetes/audit',
-  String $audit_log_path = '/etc/kubernetes/audit/kubernetes-audit.log',
-  String $audit_policy_file = '/etc/kubernetes/audit/audit-policy.yaml',
+  String $audit_log_directory = '/var/log/kubernetes',
+  Integer $audit_log_maxbackup = 1,
+  Integer $audit_log_maxsize = 100,
   $admission_control = undef,
   $feature_gates = [],
   $count = 1,
@@ -192,13 +192,17 @@ class kubernetes::apiserver(
 
   if $_audit_enabled {
 
+    $audit_log_path = "${audit_log_directory}/audit.log"
     file {$audit_log_directory:
       ensure => directory,
       mode   => '0750',
       owner  => $::kubernetes::params::user,
       group  => $::kubernetes::params::group,
+      notify => Service["${service_name}.service"],
     }
-    -> file{$audit_policy_file:
+
+    $audit_policy_file = "${::kubernetes::config_dir}/audit-policy.yaml"
+    file{$audit_policy_file:
       ensure  => file,
       mode    => '0640',
       owner   => 'root',

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -20,8 +20,8 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @_audit_enabled -%>
   --audit-policy-file=<%= scope['kubernetes::apiserver::audit_policy_file'] %> \
   --audit-log-path=<%= scope['kubernetes::apiserver::audit_log_path'] %> \
-  --audit-log-maxbackup=0 \
-  --audit-log-maxsize=100 \
+  --audit-log-maxbackup=<%= scope['kubernetes::apiserver::audit_log_maxbackup'] %> \
+  --audit-log-maxsize=<%= scope['kubernetes::apiserver::audit_log_maxsize'] %> \
 <% end -%>
 <% if @secure_port -%>
   --secure-port=<%= @secure_port %> \


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes audit log max backups and log location

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #384

```release-note
Fix apiserver audit log location and rotation
```
