### PR TITLE
Return multierror with ErrorOrNil

### DIFF
--- a/pkg/tarmak/environment/environment.go
+++ b/pkg/tarmak/environment/environment.go
@@ -308,7 +308,7 @@ func (e *Environment) Verify() error {
 		result = multierror.Append(result, err)
 	}
 
-	return result
+	return result.ErrorOrNil()
 }
 
 func (e *Environment) WingTunnel() interfaces.Tunnel {


### PR DESCRIPTION
**What this PR does / why we need it**: Master is currently broken due to a multierror not being returned with `ErrorOrNil`

```release-note
NONE
```