### PR TITLE
Ensures results are of type *multierror.Error and call ErrorOrNil at return

### DIFF
--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -399,7 +399,7 @@ func (a *Amazon) getAvailablityZoneByRegion() (zones []string, err error) {
 }
 
 func (a *Amazon) validateAvailabilityZones() error {
-	var result error
+	var result *multierror.Error
 
 	zones, err := a.getAvailablityZoneByRegion()
 	if err != nil {
@@ -432,7 +432,7 @@ func (a *Amazon) validateAvailabilityZones() error {
 		}
 	}
 	if result != nil {
-		return result
+		return result.ErrorOrNil()
 	}
 
 	if len(availabilityZones) == 0 {
@@ -522,7 +522,7 @@ func (a *Amazon) vaultSession() (*session.Session, error) {
 }
 
 func (a *Amazon) VerifyInstanceTypes(instancePools []interfaces.InstancePool) error {
-	var result error
+	var result *multierror.Error
 
 	svc, err := a.EC2()
 	if err != nil {
@@ -540,11 +540,11 @@ func (a *Amazon) VerifyInstanceTypes(instancePools []interfaces.InstancePool) er
 		}
 	}
 
-	return result
+	return result.ErrorOrNil()
 }
 
 func (a *Amazon) verifyInstanceType(instanceType string, zones []string, svc EC2) error {
-	var result error
+	var result *multierror.Error
 	var available bool
 
 	//Request offering, filter by given instance type
@@ -579,7 +579,7 @@ func (a *Amazon) verifyInstanceType(instanceType string, zones []string, svc EC2
 		}
 	}
 
-	return result
+	return result.ErrorOrNil()
 }
 
 // This methods converts and possibly validates a generic instance type to a

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -281,20 +281,17 @@ func (t *Tarmak) Version() string {
 }
 
 func (t *Tarmak) Validate() error {
-	var err error
-	var result error
+	var result *multierror.Error
 
-	err = t.Cluster().Validate()
-	if err != nil {
+	if err := t.Cluster().Validate(); err != nil {
 		result = multierror.Append(result, err)
 	}
 
-	err = t.Cluster().Environment().Validate()
-	if err != nil {
+	if err := t.Cluster().Environment().Validate(); err != nil {
 		result = multierror.Append(result, err)
 	}
 
-	return result
+	return result.ErrorOrNil()
 }
 
 func (t *Tarmak) Verify() error {

--- a/pkg/tarmak/utils/networks.go
+++ b/pkg/tarmak/utils/networks.go
@@ -21,7 +21,7 @@ func UnusedPort() int {
 }
 
 func NetworkOverlap(netCIDRs []*net.IPNet) error {
-	var result error
+	var result *multierror.Error
 	for i, _ := range netCIDRs {
 		for j := i + 1; j < len(netCIDRs); j++ {
 			// check for overlap per network
@@ -34,5 +34,5 @@ func NetworkOverlap(netCIDRs []*net.IPNet) error {
 			}
 		}
 	}
-	return result
+	return result.ErrorOrNil()
 }

--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -118,7 +118,7 @@ type terraformTemplate struct {
 
 func (t *terraformTemplate) Generate() error {
 
-	var result error
+	var result *multierror.Error
 	if err := t.generateRemoteStateConfig(); err != nil {
 		result = multierror.Append(result, err)
 	}
@@ -151,7 +151,7 @@ func (t *terraformTemplate) Generate() error {
 		result = multierror.Append(result, err)
 	}
 
-	return result
+	return result.ErrorOrNil()
 }
 
 func (t *terraformTemplate) data(module string) map[string]interface{} {


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to a result being miss returned a bug was created. This PR ensures all append results are of *multierror.Error and return ErrorOrNil()


```release-note
NONE
```
