### PR TITLE
Build unversioned Wing before hashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,13 @@ go_build:
 	CGO_ENABLED=0 GOOS=linux  GOARCH=amd64 go build -tags netgo -ldflags '-w -X main.version=$(CI_COMMIT_TAG) -X main.commit=$(CI_COMMIT_SHA) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)' -o wing_linux_amd64 ./cmd/wing
 ifeq ($(CI_COMMIT_TAG),dev)
 	# Building in Dev mode
-	# Build a hashable version of the wing binary without build variables
-	CGO_ENABLED=0 GOOS=linux  GOARCH=amd64 go build -tags netgo -o wing_linux_amd64_unversioned ./cmd/wing
-	# The hash of this binary is used to test if wing has changed in the s3 object key name
-	$(eval WING_HASH := $(shell md5sum wing_linux_amd64_unversioned | awk '{print $$1}'))
+	# Build a hashable version of the wing binary without build variables. The
+	# hash of this binary is used to test if wing has changed in the s3 object
+	# key name
+	$(eval WING_HASH = $(shell \
+		CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags netgo -o wing_linux_amd64_unversioned ./cmd/wing && \
+		md5sum wing_linux_amd64_unversioned | awk '{print $$1}' \
+	))
 	# Include binaries into devmode build of tarmak
 	go generate -tags devmode $$(go list ./pkg/... ./cmd/...)
 endif

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -22,8 +22,8 @@ data "template_file" "{{.TFName}}_user_data" {
     puppet_tar_gz_bucket_path = "${var.secrets_bucket}/${aws_s3_bucket_object.puppet-tar-gz.key}"
 
     # These are only used in the template when running in Wing dev mode
-    wing_binary_path = "${var.secrets_bucket}/${var.wing_binary_path}"
-    wing_version     = "${var.wing_version}"
+    wing_binary_path          = "${var.secrets_bucket}/${aws_s3_bucket_object.wing-binary.key}"
+    wing_version              = "${var.wing_version}"
 
     vault_token = "${tarmak_vault_instance_role.{{.Role.Name}}.init_token}"
     vault_ca    = "${base64encode(var.vault_ca)}"

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -265,5 +265,3 @@ resource "aws_route53_record" "{{.TFName}}-exporter-srv" {
 {{ end -}}
 {{ end -}}
 {{ end -}}
-
-{{ end -}}

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -1,5 +1,5 @@
-{{/* vim: set ft=tf: */ -}}
 {{ $AmazonEBSEncrypted := .AmazonEBSEncrypted -}}
+{{ $WingDevMode := .WingDevMode -}}
 {{ with .InstancePool -}}
 {{ $instancePool := . -}}
 
@@ -21,9 +21,11 @@ data "template_file" "{{.TFName}}_user_data" {
 
     puppet_tar_gz_bucket_path = "${var.secrets_bucket}/${aws_s3_bucket_object.puppet-tar-gz.key}"
 
+{{ if $WingDevMode -}}
     # These are only used in the template when running in Wing dev mode
     wing_binary_path          = "${var.secrets_bucket}/${aws_s3_bucket_object.wing-binary.key}"
     wing_version              = "${var.wing_version}"
+{{ end -}}
 
     vault_token = "${tarmak_vault_instance_role.{{.Role.Name}}.init_token}"
     vault_ca    = "${base64encode(var.vault_ca)}"
@@ -262,4 +264,6 @@ resource "aws_route53_record" "{{.TFName}}-exporter-srv" {
 }
 {{ end -}}
 {{ end -}}
+{{ end -}}
+
 {{ end -}}

--- a/terraform/amazon/templates/instance_pools/instance_pools.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pools.tf.template
@@ -20,6 +20,7 @@
 {{ template "instance_pool_variables.tf.template" . -}}
 # Instance for {{.TFName}}
 {{ template "instance_pool_instance.tf.template" dict "InstancePool" . "AmazonEBSEncrypted" $AmazonEBSEncrypted }}
+{{ template "instance_pool_instance.tf.template" dict "InstancePool" . "WingDevMode" $WingDevMode }}
 # IAM role for {{.TFName}}
 {{ template "instance_pool_iam.tf.template" . }}
 {{- end }}


### PR DESCRIPTION
Without this, the build will only work when the unversioned wing is already in the current directory.

**What this PR does / why we need it**:
Fixes issue where the wing binary wasn't being built before hashing/versioning.

```release-note
NONE
```
