### PR TITLE
Make vault-helper download URL customizable

### DIFF
--- a/puppet/modules/vault_client/manifests/init.pp
+++ b/puppet/modules/vault_client/manifests/init.pp
@@ -25,6 +25,7 @@ class vault_client (
   $version = $::vault_client::params::version,
   $bin_dir = $::vault_client::params::bin_dir,
   $download_dir = $::vault_client::params::download_dir,
+  $download_url = $::vault_client::params::download_url,
   $dest_dir = $::vault_client::params::dest_dir,
   $server_url = $::vault_client::params::server_url,
   $systemd_dir = $::vault_client::params::systemd_dir,
@@ -51,8 +52,8 @@ class vault_client (
   }
 
   ## build download URL
-  $download_url = regsubst(
-    $::vault_client::params::download_url,
+  $real_download_url = regsubst(
+    $download_url,
     '#VERSION#',
     $version,
     'G'

--- a/puppet/modules/vault_client/manifests/install.pp
+++ b/puppet/modules/vault_client/manifests/install.pp
@@ -11,7 +11,7 @@ class vault_client::install {
         mode   => '0755',
     }
     -> exec {"vault-helper-${vault_client::version}-download":
-        command => "curl -sL ${::vault_client::download_url} -o ${vault_helper_path}/vault-helper",
+        command => "curl -sL ${::vault_client::real_download_url} -o ${vault_helper_path}/vault-helper",
         creates => "${vault_helper_path}/vault-helper",
         path    => ['/usr/bin', '/bin'],
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR lets vault-helper download URL to be modifiable to point to internal mirrors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #393 

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
