### PR TITLE
Recover properly when bastion goes down

### DIFF
--- a/pkg/terraform/providers/tarmak/data_source_bastion_instance.go
+++ b/pkg/terraform/providers/tarmak/data_source_bastion_instance.go
@@ -19,10 +19,6 @@ func dataSourceBastionInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"instance_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"username": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/pkg/terraform/providers/tarmak/resource_vault_cluster.go
+++ b/pkg/terraform/providers/tarmak/resource_vault_cluster.go
@@ -18,6 +18,7 @@ func resourceTarmakVaultCluster() *schema.Resource {
 		Create: resourceTarmakVaultClusterCreate,
 		Read:   resourceTarmakVaultClusterRead,
 		Delete: resourceTarmakVaultClusterDelete,
+		Update: resourceTarmakVaultClusterCreate,
 
 		Schema: map[string]*schema.Schema{
 			"internal_fqdns": {
@@ -43,6 +44,10 @@ func resourceTarmakVaultCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"bastion_status": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -52,12 +57,10 @@ func resourceTarmakVaultCluster() *schema.Resource {
 }
 
 func resourceTarmakVaultClusterCreate(d *schema.ResourceData, meta interface{}) (err error) {
+
 	client := meta.(*rpc.Client)
 
 	vaultInternalFQDNs := []string{}
-
-	//return fmt.Errorf("DEBUG: %#v", d.Get("internal_fqdns").([]interface{})[0])
-
 	for _, internalFQDN := range d.Get("internal_fqdns").([]interface{}) {
 		vaultInternalFQDNs = append(vaultInternalFQDNs, internalFQDN.(string))
 	}
@@ -94,6 +97,7 @@ func resourceTarmakVaultClusterCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceTarmakVaultClusterRead(d *schema.ResourceData, meta interface{}) (err error) {
+
 	client := meta.(*rpc.Client)
 
 	vaultInternalFQDNs := []string{}

--- a/terraform/amazon/modules/bastion/bastion.tf
+++ b/terraform/amazon/modules/bastion/bastion.tf
@@ -24,8 +24,14 @@ resource "aws_security_group" "bastion" {
   }
 }
 
+data "tarmak_bastion_instance" "bastion" {
+  hostname    = "bastion"
+  username    = "centos"
+
+  depends_on = ["aws_instance.bastion"]
+}
+
 resource "aws_instance" "bastion" {
-  count                  = 1
   ami                    = "${var.bastion_ami}"
   instance_type          = "${var.bastion_instance_type}"
   subnet_id              = "${var.public_subnet_ids[0]}"

--- a/terraform/amazon/modules/bastion/outputs.tf
+++ b/terraform/amazon/modules/bastion/outputs.tf
@@ -1,24 +1,11 @@
-output "bastion_instance_id" {
-  value = "${element(concat(aws_instance.bastion.*.id, list("")), 0)}"
-}
-
-
-output "bastion_fqdn" {
-  value = "${aws_route53_record.bastion.fqdn}"
-}
-
-output "bastion_private_ip" {
-  value = "${aws_eip.bastion.public_ip}"
-}
-
-output "bastion_ip" {
-  value = "${aws_eip.bastion.public_ip}"
+output "bastion_status" {
+  value = "${data.tarmak_bastion_instance.bastion.status}"
 }
 
 output "bastion_security_group_id" {
   value = "${element(concat(aws_security_group.bastion.*.id, list("")), 0)}"
 }
 
-output "remote_admin_security_group_id" {
-  value = "${aws_security_group.remote_admin.id}"
+output "bastion_instance_id" {
+  value = "${element(concat(aws_instance.bastion.*.id, list("")), 0)}"
 }

--- a/terraform/amazon/modules/kubernetes/inputs.tf
+++ b/terraform/amazon/modules/kubernetes/inputs.tf
@@ -47,10 +47,6 @@ variable "internal_fqdns" {
   type = "list"
 }
 
-variable "vault_kms_key_id" {}
-
-variable "vault_unseal_key_name" {}
-
 # template variables
 variable "availability_zones" {
   type = "list"
@@ -77,3 +73,5 @@ variable "public_zone_id" {}
 variable "vault_security_group_id" {}
 
 variable "bastion_security_group_id" {}
+
+variable "vault_status" {}

--- a/terraform/amazon/modules/kubernetes/vault.tf
+++ b/terraform/amazon/modules/kubernetes/vault.tf
@@ -1,17 +1,9 @@
-resource "tarmak_vault_cluster" "vault" {
-  internal_fqdns = ["${var.internal_fqdns}"]
-  vault_ca = "${var.vault_ca}"
-  vault_kms_key_id = "${var.vault_kms_key_id}"
-  vault_unseal_key_name = "${var.vault_unseal_key_name}"
-}
-
 resource "tarmak_vault_instance_role" "master" {  
   role_name = "master"
   vault_cluster_name = "${var.vault_cluster_name}"
   internal_fqdns = ["${var.internal_fqdns}"]
   vault_ca = "${var.vault_ca}"
-
-  depends_on = ["tarmak_vault_cluster.vault"]
+  vault_status = "${var.vault_status}"
 }
 
 resource "tarmak_vault_instance_role" "worker" {
@@ -19,8 +11,7 @@ resource "tarmak_vault_instance_role" "worker" {
   vault_cluster_name = "${var.vault_cluster_name}"
   internal_fqdns = ["${var.internal_fqdns}"]
   vault_ca = "${var.vault_ca}"
-
-  depends_on = ["tarmak_vault_cluster.vault"]
+  vault_status = "${var.vault_status}"
 }
 
 resource "tarmak_vault_instance_role" "etcd" {
@@ -28,6 +19,5 @@ resource "tarmak_vault_instance_role" "etcd" {
   vault_cluster_name = "${var.vault_cluster_name}"
   internal_fqdns = ["${var.internal_fqdns}"]
   vault_ca = "${var.vault_ca}"
-
-  depends_on = ["tarmak_vault_cluster.vault"]
+  vault_status = "${var.vault_status}"
 }

--- a/terraform/amazon/modules/vault/cluster.tf
+++ b/terraform/amazon/modules/vault/cluster.tf
@@ -1,0 +1,7 @@
+resource "tarmak_vault_cluster" "vault" {
+  bastion_status = "${var.bastion_status}"
+  internal_fqdns = ["${aws_route53_record.per-instance.*.fqdn}"]
+  vault_ca = "${element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0)}"
+  vault_kms_key_id = "${element(split("/", var.secrets_kms_arn), 1)}"
+  vault_unseal_key_name = "${data.template_file.vault_unseal_key_name.rendered}"
+}

--- a/terraform/amazon/modules/vault/inputs.tf
+++ b/terraform/amazon/modules/vault/inputs.tf
@@ -72,8 +72,6 @@ variable "bastion_security_group_id" {}
 # data.terraform_remote_state.network.vpc_id
 variable "vpc_id" {}
 
-variable "bastion_instance_id" {}
-
 variable "vault_cluster_name" {}
 
 data "template_file" "stack_name" {
@@ -84,4 +82,4 @@ data "template_file" "vault_unseal_key_name" {
   template = "vault-${var.environment}-"
 }
 
-
+variable "bastion_status" {}

--- a/terraform/amazon/modules/vault/outputs.tf
+++ b/terraform/amazon/modules/vault/outputs.tf
@@ -6,14 +6,6 @@ output "vault_url" {
   value = "https://${element(concat(aws_route53_record.endpoint.*.fqdn, list("")), 0)}:8200"
 }
 
-output "vault_kms_key_id" {
-  value = "${element(split("/", var.secrets_kms_arn), 1)}"
-}
-
-output "vault_unseal_key_name" {
-  value = "${data.template_file.vault_unseal_key_name.rendered}"
-}
-
 output "instance_fqdns" {
   value = ["${aws_route53_record.per-instance.*.fqdn}"]
 }
@@ -24,4 +16,8 @@ output "vault_security_group_id" {
 
 output "vault_aws_caller_identity_current_account_id" {
   value = "${data.aws_caller_identity.current.account_id}"
+}
+
+output "vault_status" {
+  value = "${tarmak_vault_cluster.vault.status}"
 }

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -128,8 +128,8 @@ module "vault" {
   availability_zones = ["${var.availability_zones}"]
   bastion_security_group_id = "${module.bastion.bastion_security_group_id}"
   vpc_id = "${module.network.vpc_id}" 
-  bastion_instance_id = "${module.bastion.bastion_instance_id}"
   vault_cluster_name = "${var.vault_cluster_name}"
+  bastion_status = "${module.bastion.bastion_status}"
 }
 {{end}}
 
@@ -160,8 +160,6 @@ module "kubernetes" {
   private_subnet_ids = ["${module.network.private_subnet_ids}"]
   public_subnet_ids = ["${module.network.public_subnet_ids}"]
   internal_fqdns = ["${module.vault.instance_fqdns}"]
-  vault_kms_key_id = "${module.vault.vault_kms_key_id}"
-  vault_unseal_key_name = "${module.vault.vault_unseal_key_name}"
   # template variables
   availability_zones = ["${module.network.availability_zones}"]
   vpc_id = "${module.network.vpc_id}"
@@ -173,6 +171,7 @@ module "kubernetes" {
   public_zone_id = "${module.state.public_zone_id}"
   vault_security_group_id = "${module.vault.vault_security_group_id}"
   bastion_security_group_id = "${module.bastion.bastion_security_group_id}"
+  vault_status = "${module.vault.vault_status}"
 }
 {{end}}
 
@@ -226,5 +225,6 @@ module "kubernetes" {
   vault_ca = "${data.terraform_remote_state.hub_state.vault_vault_ca}"
   vault_url = "${data.terraform_remote_state.hub_state.vault_vault_url}"
   vault_security_group_id = "${data.terraform_remote_state.hub_state.vault_vault_security_group_id}"
+  vault_status = "${module.vault.vault_status}"
 }
 {{end}}

--- a/terraform/amazon/templates/vault_instances.tf.template
+++ b/terraform/amazon/templates/vault_instances.tf.template
@@ -49,12 +49,6 @@ resource "aws_cloudwatch_metric_alarm" "vault-autorecover" {
   }
 }
 
-data "tarmak_bastion_instance" "bastion" {
-  hostname    = "bastion"
-  username    = "centos"
-  instance_id = "${var.bastion_instance_id}"
-}
-
 resource "aws_instance" "vault" {
   ami                  = "${var.vault_ami}"
   instance_type        = "${var.vault_instance_type}"
@@ -86,8 +80,6 @@ resource "aws_instance" "vault" {
   lifecycle {
     ignore_changes = ["volume_tags"]
   }
-
-  depends_on = ["data.tarmak_bastion_instance.bastion"]
 }
 
 resource "aws_ebs_volume" "vault" {


### PR DESCRIPTION
**What this PR does / why we need it**: Allows the bastion to be created by reapplying when there it goes down

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #187

```release-note
Allow bastion to be recreated by reapplying
```
