### PR TITLE
Fix failing terraform destroy

### DIFF
--- a/terraform/amazon/modules/state/outputs.tf
+++ b/terraform/amazon/modules/state/outputs.tf
@@ -23,6 +23,6 @@ output "secrets_bucket" {
 }
 
 output "secrets_kms_arn" {
-  value = "${aws_kms_key.secrets.*.arn}"
+  value = "${concat(aws_kms_key.secrets.*.arn, list(""))}"
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Terraform destroy failed due to an empty variable due to interpolation. This change makes sure the variable is never empty but has at least one element in it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Probably needs to be cherry picked for 0.4

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
