### PR TITLE
Automated cherry pick of #397

### DIFF
--- a/terraform/amazon/modules/state/outputs.tf
+++ b/terraform/amazon/modules/state/outputs.tf
@@ -23,6 +23,6 @@ output "secrets_bucket" {
 }
 
 output "secrets_kms_arn" {
-  value = "${aws_kms_key.secrets.*.arn}"
+  value = "${concat(aws_kms_key.secrets.*.arn, list(""))}"
 }
 


### PR DESCRIPTION
Cherry pick of #397 on release-0.4.

```release-note
NONE
```

#397: Fix failing terraform destroy