### PR TITLE
Use TLS by default for logging sinks

### DIFF
--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -80,8 +80,11 @@ func SetDefaults_Cluster(obj *Cluster) {
 			if loggingSink.ElasticSearch.Host == "" {
 				loggingSink.ElasticSearch.Host = "127.0.0.1"
 			}
+			if loggingSink.ElasticSearch.TLS == nil {
+				loggingSink.ElasticSearch.TLS = boolPointer(true)
+			}
 			if loggingSink.ElasticSearch.Port == 0 {
-				if loggingSink.ElasticSearch.TLS {
+				if *loggingSink.ElasticSearch.TLS {
 					loggingSink.ElasticSearch.Port = 443
 				} else {
 					loggingSink.ElasticSearch.Port = 80
@@ -102,6 +105,10 @@ func SetDefaults_Cluster(obj *Cluster) {
 		}
 	}
 
+}
+
+func boolPointer(x bool) *bool {
+	return &x
 }
 
 func allocateAmazonESProxyPort(loggingSinks []*LoggingSink) int {

--- a/pkg/apis/cluster/v1alpha1/defaults_test.go
+++ b/pkg/apis/cluster/v1alpha1/defaults_test.go
@@ -1,0 +1,62 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import "testing"
+
+func TestLoggingDefaults(t *testing.T) {
+
+	cluster := &Cluster{
+		LoggingSinks: []*LoggingSink{
+			&LoggingSink{
+				ElasticSearch: &LoggingSinkElasticSearch{
+					TLS: boolPointer(true),
+				},
+			},
+			&LoggingSink{
+				ElasticSearch: &LoggingSinkElasticSearch{
+					TLS: boolPointer(false),
+				},
+			},
+			&LoggingSink{
+				ElasticSearch: &LoggingSinkElasticSearch{},
+			},
+		},
+	}
+
+	SetDefaults_Cluster(cluster)
+
+	if cluster.LoggingSinks == nil {
+		t.Errorf("logging sinks not set")
+	} else {
+		for index, loggingSink := range cluster.LoggingSinks {
+			if loggingSink.ElasticSearch == nil {
+				t.Errorf("elasticsearch is not set for logging sink %d", index)
+			} else {
+				if loggingSink.ElasticSearch.TLS == nil {
+					t.Errorf("elasticsearch tls is not set for logging sink %d", index)
+				} else {
+					if (index == 0 || index == 2) && *loggingSink.ElasticSearch.TLS != true {
+						t.Errorf("elasticsearch for logging sink %d does not have TLS enabled", index)
+					}
+					if index == 1 && *loggingSink.ElasticSearch.TLS != false {
+						t.Errorf("elasticsearch for logging sink %d has TLS enabled", index)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/apis/cluster/v1alpha1/logging.go
+++ b/pkg/apis/cluster/v1alpha1/logging.go
@@ -34,7 +34,7 @@ type LoggingSinkElasticSearch struct {
 	Host           string         `json:"host,omitempty"`
 	Port           int            `json:"port,omitempty"`
 	LogstashPrefix string         `json:"logstashPrefix,omitempty"`
-	TLS            bool           `json:"tls,omitempty"`
+	TLS            *bool          `json:"tls,omitempty"`
 	TLSVerify      bool           `json:"tlsVerify,omitempty"`
 	TLSCA          string         `json:"tlsCA,omitempty"`
 	HTTPBasicAuth  *HTTPBasicAuth `json:"httpBasicAuth,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**: Set more sensible defaults for TLS when logging

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #403 

**Release note**:
```release-note
Use TLS by default for logging sinks
```
