### PR TITLE
Tolerate dedicated on calico, node-exporter & fluent-bit

### DIFF
--- a/puppet/modules/calico/templates/node-daemonset.yaml.erb
+++ b/puppet/modules/calico/templates/node-daemonset.yaml.erb
@@ -23,7 +23,7 @@ spec:
 <%- if @version_before_1_6 -%>
         scheduler.alpha.kubernetes.io/tolerations: |
           [
-            {"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+            {"key": "dedicated", "operator": "Exists" },
             {"key": "CriticalAddonsOnly", "operator":"Exists"},
             {"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}
           ]
@@ -44,8 +44,7 @@ spec:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
       - key: "dedicated"
-        value: "master"
-        effect: "NoSchedule"
+        operator: "Exists"
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
 <%- end -%>

--- a/puppet/modules/fluent_bit/templates/fluent-bit-daemonset.yaml.erb
+++ b/puppet/modules/fluent_bit/templates/fluent-bit-daemonset.yaml.erb
@@ -72,6 +72,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: "dedicated"
+        operator: "Exists"
 <%- if @rbac_enabled -%>
 ---
 apiVersion: v1

--- a/puppet/modules/prometheus/templates/node-exporter-ds.yaml.erb
+++ b/puppet/modules/prometheus/templates/node-exporter-ds.yaml.erb
@@ -19,6 +19,8 @@ spec:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
+      - key: "dedicated"
+        operator: "Exists"
       containers:
         - name: node-exporter
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements additional tolerations for infrastructure pods - see: https://github.com/jetstack/tarmak/issues/404

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Fixes https://github.com/jetstack/tarmak/issues/404

**Special notes for your reviewer**:
Two questions:
- do we need to handle before_1_6 in fluent-bit and the node-exporter?
- should these only tolerate NoSchedule? I set them to tolerate everything.

**Release note**:
```release-note
Broaden scope of dedicated tolerations for infrastructure pods.
```
