### PR TITLE
Automated cherry pick of #185 #319 #386 #387 #408

### DIFF
--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -80,8 +80,11 @@ func SetDefaults_Cluster(obj *Cluster) {
 			if loggingSink.ElasticSearch.Host == "" {
 				loggingSink.ElasticSearch.Host = "127.0.0.1"
 			}
+			if loggingSink.ElasticSearch.TLS == nil {
+				loggingSink.ElasticSearch.TLS = boolPointer(true)
+			}
 			if loggingSink.ElasticSearch.Port == 0 {
-				if loggingSink.ElasticSearch.TLS {
+				if *loggingSink.ElasticSearch.TLS {
 					loggingSink.ElasticSearch.Port = 443
 				} else {
 					loggingSink.ElasticSearch.Port = 80
@@ -102,6 +105,10 @@ func SetDefaults_Cluster(obj *Cluster) {
 		}
 	}
 
+}
+
+func boolPointer(x bool) *bool {
+	return &x
 }
 
 func allocateAmazonESProxyPort(loggingSinks []*LoggingSink) int {

--- a/pkg/apis/cluster/v1alpha1/defaults_test.go
+++ b/pkg/apis/cluster/v1alpha1/defaults_test.go
@@ -1,0 +1,62 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import "testing"
+
+func TestLoggingDefaults(t *testing.T) {
+
+	cluster := &Cluster{
+		LoggingSinks: []*LoggingSink{
+			&LoggingSink{
+				ElasticSearch: &LoggingSinkElasticSearch{
+					TLS: boolPointer(true),
+				},
+			},
+			&LoggingSink{
+				ElasticSearch: &LoggingSinkElasticSearch{
+					TLS: boolPointer(false),
+				},
+			},
+			&LoggingSink{
+				ElasticSearch: &LoggingSinkElasticSearch{},
+			},
+		},
+	}
+
+	SetDefaults_Cluster(cluster)
+
+	if cluster.LoggingSinks == nil {
+		t.Errorf("logging sinks not set")
+	} else {
+		for index, loggingSink := range cluster.LoggingSinks {
+			if loggingSink.ElasticSearch == nil {
+				t.Errorf("elasticsearch is not set for logging sink %d", index)
+			} else {
+				if loggingSink.ElasticSearch.TLS == nil {
+					t.Errorf("elasticsearch tls is not set for logging sink %d", index)
+				} else {
+					if (index == 0 || index == 2) && *loggingSink.ElasticSearch.TLS != true {
+						t.Errorf("elasticsearch for logging sink %d does not have TLS enabled", index)
+					}
+					if index == 1 && *loggingSink.ElasticSearch.TLS != false {
+						t.Errorf("elasticsearch for logging sink %d has TLS enabled", index)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/apis/cluster/v1alpha1/logging.go
+++ b/pkg/apis/cluster/v1alpha1/logging.go
@@ -34,7 +34,7 @@ type LoggingSinkElasticSearch struct {
 	Host           string         `json:"host,omitempty"`
 	Port           int            `json:"port,omitempty"`
 	LogstashPrefix string         `json:"logstashPrefix,omitempty"`
-	TLS            bool           `json:"tls,omitempty"`
+	TLS            *bool          `json:"tls,omitempty"`
 	TLSVerify      bool           `json:"tlsVerify,omitempty"`
 	TLSCA          string         `json:"tlsCA,omitempty"`
 	HTTPBasicAuth  *HTTPBasicAuth `json:"httpBasicAuth,omitempty"`

--- a/pkg/wing/controller.go
+++ b/pkg/wing/controller.go
@@ -73,6 +73,11 @@ func (c *Controller) syncToStdout(key string) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: c.wing.flags.InstanceName,
 			},
+			Status: &v1alpha1.InstanceStatus{
+				Converge: &v1alpha1.InstanceStatusManifest{
+					State: v1alpha1.InstanceManifestStateConverging,
+				},
+			},
 		}
 		_, err := instanceAPI.Create(instance)
 		if err != nil {

--- a/pkg/wing/controller.go
+++ b/pkg/wing/controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -67,6 +68,16 @@ func (c *Controller) syncToStdout(key string) error {
 	if !exists {
 		// Below we will warm up our cache with a Instance, so that we will see a delete for one instance
 		fmt.Printf("Instance %s does not exist anymore\n", key)
+		instanceAPI := c.wing.clientset.WingV1alpha1().Instances(c.wing.flags.ClusterName)
+		instance := &v1alpha1.Instance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: c.wing.flags.InstanceName,
+			},
+		}
+		_, err := instanceAPI.Create(instance)
+		if err != nil {
+			return fmt.Errorf("error creating instance: %s", err)
+		}
 	} else {
 		// Note that you also have to check the uid if you have a local controlled resource, which
 		// is dependent on the actual instance, to detect that a Instance was recreated with the same name

--- a/puppet/modules/fluent_bit/templates/fluent-bit-daemonset.yaml.erb
+++ b/puppet/modules/fluent_bit/templates/fluent-bit-daemonset.yaml.erb
@@ -22,6 +22,7 @@ spec:
         prometheus.io/path: /api/v1/metrics/prometheus
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: fluent-bit
         image: "<%= @fluent_bit_image %>:<%= @fluent_bit_version %>"

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -2,9 +2,9 @@
 class kubernetes::apiserver(
   $allow_privileged = true,
   Optional[Boolean] $audit_enabled = undef,
-  String $audit_log_directory = '/etc/kubernetes/audit',
-  String $audit_log_path = '/etc/kubernetes/audit/kubernetes-audit.log',
-  String $audit_policy_file = '/etc/kubernetes/audit/audit-policy.yaml',
+  String $audit_log_directory = '/var/log/kubernetes',
+  Integer $audit_log_maxbackup = 1,
+  Integer $audit_log_maxsize = 100,
   $admission_control = undef,
   $count = 1,
   $storage_backend = undef,
@@ -185,13 +185,17 @@ class kubernetes::apiserver(
 
   if $_audit_enabled {
 
+    $audit_log_path = "${audit_log_directory}/audit.log"
     file {$audit_log_directory:
       ensure => directory,
       mode   => '0750',
       owner  => $::kubernetes::params::user,
       group  => $::kubernetes::params::group,
+      notify => Service["${service_name}.service"],
     }
-    -> file{$audit_policy_file:
+
+    $audit_policy_file = "${::kubernetes::config_dir}/audit-policy.yaml"
+    file{$audit_policy_file:
       ensure  => file,
       mode    => '0640',
       owner   => 'root',

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -20,8 +20,8 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @_audit_enabled -%>
   --audit-policy-file=<%= scope['kubernetes::apiserver::audit_policy_file'] %> \
   --audit-log-path=<%= scope['kubernetes::apiserver::audit_log_path'] %> \
-  --audit-log-maxbackup=0 \
-  --audit-log-maxsize=100 \
+  --audit-log-maxbackup=<%= scope['kubernetes::apiserver::audit_log_maxbackup'] %> \
+  --audit-log-maxsize=<%= scope['kubernetes::apiserver::audit_log_maxsize'] %> \
 <% end -%>
 <% if @secure_port -%>
   --secure-port=<%= @secure_port %> \


### PR DESCRIPTION
Cherry pick of #185 #319 #386 #387 #408 on release-0.4.

#185: Prepare terraform when running kubectl
#319: Use ClusterFirstWithHostNet for fluent-bit ds
#386: Fix audit max backups and log location
#387: Recreate wing instances when absent
#408: Use TLS by default for logging sinks

```release-note
cherry-pick additional fixes to 0.4 release
```