### PR TITLE
Adds documentation for custom binary URLs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,7 +32,7 @@ docker_html:
 	# start documentaion build
 	$(eval CONTAINER_ID := $(shell docker create $(IMAGE_ID)))
 	(git ls-files && git ls-files --others --exclude-standard) | tar cf -  -T - | docker cp - $(CONTAINER_ID):/site
-	docker start -a $(CONTAINER_ID)
+	- docker start -a $(CONTAINER_ID)
 	docker cp $(CONTAINER_ID):/site/_build - | tar xf -
 	docker rm $(CONTAINER_ID)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,7 +32,7 @@ docker_html:
 	# start documentaion build
 	$(eval CONTAINER_ID := $(shell docker create $(IMAGE_ID)))
 	(git ls-files && git ls-files --others --exclude-standard) | tar cf -  -T - | docker cp - $(CONTAINER_ID):/site
-	- docker start -a $(CONTAINER_ID)
+	docker start -a $(CONTAINER_ID)
 	docker cp $(CONTAINER_ID):/site/_build - | tar xf -
 	docker rm $(CONTAINER_ID)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -84,3 +84,5 @@ preempted
 millicores
 yaml
 autoscale
+hyperkube
+Makefile

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -689,9 +689,9 @@ included in Cloud-Init configuration within terraform templates. These URLs can
 therefore be changed within template files: ``terraform/modules/{tool related
 module}/templates/...`` and ``terraform/templates/...``
 
-For these changes to take effect the puppet binary data must be regenerated and
-included into the Tarmak binary. This is done by rebuilding through the
-Makefile:
+For these changes to take effect the puppet and terraform binary data must be
+regenerated and included into the Tarmak binary. This is done by rebuilding
+through the Makefile:
 
 ::
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -674,3 +674,26 @@ You add labels and taints in the tarmak yaml like this:
 **Note**, these are only applied when the node is first registered. Changes to
 these values will not remove taints and labels from nodes that are already
 registered.
+
+Custom Tooling URLs
+~~~~~~~~~~~~~~~~~~~
+
+You may wish to change the default source URL for various tools and binaries
+such as vault-helper or hyperkube, downloaded and installed within the Tarmak
+cluster. To do this, change the ``$download_url`` parameter within the relevant
+puppet module's parameters file: ``puppet/modules/{tool
+module}/manifests/params.pp``
+
+Some tooling URLs such as Wing are not defined in puppet and may instead be
+included in Cloud-Init configuration within terraform templates. These URLs can
+therefore be changed within template files: ``terraform/modules/{tool related
+module}/templates/...`` and ``terraform/templates/...``
+
+For these changes to take effect the puppet binary data must be regenerated and
+included into the Tarmak binary. This is done by rebuilding through the
+Makefile:
+
+::
+
+  $ make build
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds some documentation on how to use custom URLs for various tools and binaries in tarmak.

fixes #393 

```release-note
NONE
```

/assign @simonswine