### PR TITLE
Update Kubernetes to 1.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 | Terraform   |                    | `0.11.7` |
 | Consul      |                    | `1.0.6`  |
 | Vault       |                    | `0.9.5`  |
-| Kubernetes  | `>= 1.7 && < 1.11` | `1.9.10` |
+| Kubernetes  | `>= 1.7 && < 1.11` | `1.10.6` |
 | Calico      |                    | `3.1.1`  |
 | Vault Helper|                    | `0.9.13` |
 | Etcd        |                    | `3.2.17` |
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 | Terraform   |                    | `0.11.7` |
 | Consul      |                    | `1.0.6`  |
 | Vault       |                    | `0.9.5`  |
-| Kubernetes  | `>= 1.7 && < 1.11` | `1.9.10` |
+| Kubernetes  | `>= 1.7 && < 1.11` | `1.10.6` |
 | Calico      |                    | `3.1.1`  |
 | Vault Helper|                    | `0.9.13` |
 | Etcd        |                    | `3.2.17` |

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -38,7 +38,7 @@ func SetDefaults_Cluster(obj *Cluster) {
 
 	// set default kubernetes version
 	if obj.Kubernetes.Version == "" {
-		obj.Kubernetes.Version = "1.9.10"
+		obj.Kubernetes.Version = "1.10.6"
 	}
 
 	// zone

--- a/puppet/modules/kubernetes/manifests/params.pp
+++ b/puppet/modules/kubernetes/manifests/params.pp
@@ -1,6 +1,6 @@
 # == Class kubernetes::params
 class kubernetes::params {
-  $version = '1.9.7'
+  $version = '1.10.6'
   $bin_dir = '/opt/bin'
   $dest_dir = '/opt'
   $config_dir = '/etc/kubernetes'

--- a/puppet/modules/kubernetes_addons/spec/classes/tiller_spec.rb
+++ b/puppet/modules/kubernetes_addons/spec/classes/tiller_spec.rb
@@ -4,7 +4,7 @@ describe 'kubernetes_addons::tiller' do
     "
       class kubernetes{
         $_authorization_mode = ['RBAC']
-        $version = '1.9.7'
+        $version = '1.10.6'
       }
       define kubernetes::apply(
         $manifests,

--- a/puppet/modules/tarmak/manifests/params.pp
+++ b/puppet/modules/tarmak/manifests/params.pp
@@ -14,7 +14,7 @@ class tarmak::params{
   }
 
   ## Kubernetes
-  $kubernetes_version = '1.9.7'
+  $kubernetes_version = '1.10.6'
 
   ## etcd
   $etcd_advertise_client_network = '172.16.0.0/12'

--- a/puppet/modules/tarmak/spec/acceptance/single_node_spec.rb
+++ b/puppet/modules/tarmak/spec/acceptance/single_node_spec.rb
@@ -13,7 +13,7 @@ describe '::pupperentes::single_node' do
   end
 
   let :kubernetes_version do
-    ENV['KUBERNETES_VERSION'] || '1.9.7'
+    ENV['KUBERNETES_VERSION'] || '1.10.6'
   end
 
   let :kubernetes_authorization_mode do


### PR DESCRIPTION
**What this PR does / why we need it**:
Use Kubernetes 1.10.6 as default version

fixes #421 

```release-note
Kubernetes default version 1.10.6
```
