### PR TITLE
Unset deprecated flags from 1.11

### DIFF
--- a/docs/generated/reference/output/api-docs.html
+++ b/docs/generated/reference/output/api-docs.html
@@ -725,6 +725,14 @@ Appears In:
 <td>AWS specifc options</td>
 </tr>
 <tr>
+<td><code>disableAdmissionControllers</code><br /> <em>string array</em></td>
+<td></td>
+</tr>
+<tr>
+<td><code>enableAdmissionControllers</code><br /> <em>string array</em></td>
+<td></td>
+</tr>
+<tr>
 <td><code>oidc</code><br /> <em><a href="#clusterkubernetesapiserveroidc-v1alpha1">ClusterKubernetesAPIServerOIDC</a></em></td>
 <td>OIDC</td>
 </tr>

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -38,6 +38,7 @@ hostname
 iam
 init
 initialize
+initializers
 iptables
 isn
 Istio

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -575,8 +575,11 @@ Enabled and disabled plugins can be configured as follows:
 
   kubernetes:
     apiServer:
-      enableAdmissionControllers: ["DefaultStorageClass", "DefaultTolerationSeconds"]
-      disableAdmissionControllers: ["MutatingAdmissionWebhook"]
+      enableAdmissionControllers:
+         - "DefaultStorageClass"
+         - "DefaultTolerationSeconds"
+      disableAdmissionControllers:
+         - "MutatingAdmissionWebhook"
 
 **Note:** Disabling admission control plugins is only available with Kubernetes
 version 1.11+

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -563,6 +563,24 @@ by limiting the access to a list of CIDR blocks. This can be configured on a
 environment level for all public endpoint and if wanted can be overwritten on a
 specific public endpoint.
 
+API Server Admission Plugins
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+API admission control plugins can be enabled and disabled through the Tarmak
+configuration file.
+`Information on admission plugins can be found here <https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/>`_.
+Enabled and disabled plugins can be configured as follows:
+
+.. code-block:: yaml
+
+  kubernetes:
+    apiServer:
+      enableAdmissionControllers: ["DefaultStorageClass", "DefaultTolerationSeconds"]
+      disableAdmissionControllers: ["MutatingAdmissionWebhook"]
+
+**Note:** Disabling admission control plugins is only available with Kubernetes
+version 1.11+
+
 Environment level
 +++++++++++++++++
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -563,27 +563,6 @@ by limiting the access to a list of CIDR blocks. This can be configured on a
 environment level for all public endpoint and if wanted can be overwritten on a
 specific public endpoint.
 
-API Server Admission Plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-API admission control plugins can be enabled and disabled through the Tarmak
-configuration file.
-`Information on admission plugins can be found here <https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/>`_.
-Enabled and disabled plugins can be configured as follows:
-
-.. code-block:: yaml
-
-  kubernetes:
-    apiServer:
-      enableAdmissionControllers:
-         - "DefaultStorageClass"
-         - "DefaultTolerationSeconds"
-      disableAdmissionControllers:
-         - "MutatingAdmissionWebhook"
-
-**Note:** Disabling admission control plugins is only available with Kubernetes
-version 1.11+
-
 Environment level
 +++++++++++++++++
 
@@ -641,6 +620,59 @@ to the kubernetes block.
         public: true
         allowCIDRs:
         - y.y.y.y/24
+
+API Server Admission Plugins
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+API admission control plugins can be enabled and disabled through the Tarmak
+configuration file.  `Information on admission plugins can be found here
+<https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/>`_.
+Enabled and disabled plugins can be configured as follows:
+
+.. code-block:: yaml
+
+  kubernetes:
+    apiServer:
+      enableAdmissionControllers:
+         - "DefaultStorageClass"
+         - "DefaultTolerationSeconds"
+      disableAdmissionControllers:
+         - "MutatingAdmissionWebhook"
+
+.. note::
+  Disabling admission control plugins is only available with Kubernetes
+  version 1.11+
+
+Unless one or more enabled admission controller has been defined, the following
+defaults will be applied in this order:
+
++-------------------------------+-----------------------------+
+| *Admission Controller Plugin* | *Minimum Requirement*       |
++-------------------------------+-----------------------------+
+| Initializers                  | v1.8.x                      |
++-------------------------------+-----------------------------+
+| NamespaceLifecycle            | none                        |
++-------------------------------+-----------------------------+
+| LimitRanger                   | none                        |
++-------------------------------+-----------------------------+
+| ServiceAccount                | none                        |
++-------------------------------+-----------------------------+
+| DefaultStorageClass           | v1.4.x                      |
++-------------------------------+-----------------------------+
+| DefaultTolerationSeconds      | v1.6.x                      |
++-------------------------------+-----------------------------+
+| MutatingAdmissionWebhook      | v1.9.x                      |
++-------------------------------+-----------------------------+
+| ValidatingAdmissionWebhook    | v1.9.x                      |
++-------------------------------+-----------------------------+
+| ResourceQuota                 | none                        |
++-------------------------------+-----------------------------+
+| PodSecurityPolicy             | Pod Security Policy Enabled |
++-------------------------------+-----------------------------+
+| NodeRestriction               | v1.8.x                      |
++-------------------------------+-----------------------------+
+| Priority                      | Pod Priority Enabled        |
++-------------------------------+-----------------------------+
 
 Additional IAM policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -128,6 +128,9 @@ type ClusterKubernetesAPIServer struct {
 	Public     bool     `json:"public,omitempty"`
 	AllowCIDRs []string `json:"allowCIDRs,omitempty"`
 
+	EnableAdmissionControllers  []string `json:"enableAdmissionControllers,omitempty"`
+	DisableAdmissionControllers []string `json:"disableAdmissionControllers,omitempty"`
+
 	// OIDC
 	OIDC *ClusterKubernetesAPIServerOIDC `json:"oidc,omitempty"`
 

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -226,6 +226,16 @@ func (in *ClusterKubernetesAPIServer) DeepCopyInto(out *ClusterKubernetesAPIServ
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableAdmissionControllers != nil {
+		in, out := &in.EnableAdmissionControllers, &out.EnableAdmissionControllers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.DisableAdmissionControllers != nil {
+		in, out := &in.DisableAdmissionControllers, &out.DisableAdmissionControllers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OIDC != nil {
 		in, out := &in.OIDC, &out.OIDC
 		if *in == nil {

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -102,7 +102,7 @@ func kubernetesClusterConfig(conf *clusterv1alpha1.ClusterKubernetes, hieraData 
 	if a := conf.APIServer; a != nil {
 
 		if len(a.EnableAdmissionControllers) > 0 {
-			hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::admission_control: ["%s"]`, strings.Join(a.DisableAdmissionControllers, ",")))
+			hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::admission_control: ["%s"]`, strings.Join(a.EnableAdmissionControllers, ",")))
 		}
 
 		if len(a.DisableAdmissionControllers) > 0 {

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -99,39 +99,50 @@ func kubernetesClusterConfig(conf *clusterv1alpha1.ClusterKubernetes, hieraData 
 	}
 
 	// forward oidc settings
-	if conf.APIServer != nil && conf.APIServer.OIDC != nil {
-		oidc := conf.APIServer.OIDC
-		t := reflect.TypeOf(oidc).Elem()
-		v := reflect.ValueOf(oidc).Elem()
-		for i := 0; i < t.NumField(); i++ {
-			tagValue := t.Field(i).Tag.Get("hiera")
+	if a := conf.APIServer; a != nil {
 
-			// skip fields without hiera tag
-			if tagValue == "" {
-				continue
-			}
+		if len(a.EnableAdmissionControllers) > 0 {
+			hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::admission_control: ["%s"]`, strings.Join(a.DisableAdmissionControllers, ",")))
+		}
 
-			val := v.Field(i)
-			switch val.Kind() {
-			case reflect.String:
-				// skip empty string
-				if val.String() == "" {
-					continue
-				}
-				hieraData.variables = append(hieraData.variables, fmt.Sprintf(`%s: "%s"`, tagValue, val.String()))
-			case reflect.Slice:
-				// skip empty slice
-				if val.Len() == 0 {
+		if len(a.DisableAdmissionControllers) > 0 {
+			hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::disable_admission_control: ["%s"]`, strings.Join(a.DisableAdmissionControllers, ",")))
+		}
+
+		if a.OIDC != nil {
+			oidc := a.OIDC
+			t := reflect.TypeOf(oidc).Elem()
+			v := reflect.ValueOf(oidc).Elem()
+			for i := 0; i < t.NumField(); i++ {
+				tagValue := t.Field(i).Tag.Get("hiera")
+
+				// skip fields without hiera tag
+				if tagValue == "" {
 					continue
 				}
 
-				data, err := json.Marshal(val.Interface())
-				if err != nil {
-					panic(err)
+				val := v.Field(i)
+				switch val.Kind() {
+				case reflect.String:
+					// skip empty string
+					if val.String() == "" {
+						continue
+					}
+					hieraData.variables = append(hieraData.variables, fmt.Sprintf(`%s: "%s"`, tagValue, val.String()))
+				case reflect.Slice:
+					// skip empty slice
+					if val.Len() == 0 {
+						continue
+					}
+
+					data, err := json.Marshal(val.Interface())
+					if err != nil {
+						panic(err)
+					}
+					hieraData.variables = append(hieraData.variables, fmt.Sprintf("%s: %s", tagValue, string(data)))
+				default:
+					panic(fmt.Sprintf("unknown type: %v", val.Kind()))
 				}
-				hieraData.variables = append(hieraData.variables, fmt.Sprintf("%s: %s", tagValue, string(data)))
-			default:
-				panic(fmt.Sprintf("unknown type: %v", val.Kind()))
 			}
 		}
 	}

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -69,7 +69,7 @@ class kubernetes::apiserver(
 
   # Admission controllers cf. https://kubernetes.io/docs/admin/admission-controllers/
   if $admission_control == undef {
-    $unfiltered_admission_control = delete_undef_values([
+    $_admission_control = delete_undef_values([
       $post_1_8 ? { true => 'Initializers', default => undef },
       'NamespaceLifecycle',
       'LimitRanger',
@@ -84,14 +84,7 @@ class kubernetes::apiserver(
       $::kubernetes::_enable_pod_priority ? { true => 'Priority', default => undef },
     ])
   } else {
-    $unfiltered_admission_control = $admission_control
-  }
-
-  if $post_1_11 {
-    $defaults = ['NamespaceLifecycle','LimitRanger','ServiceAccount','PersistentVolumeLabel','DefaultStorageClass','DefaultTolerationSeconds','MutatingAdmissionWebhook','ValidatingAdmissionWebhook','ResourceQuota','Priority']
-    $_admission_control = $unfiltered_admission_control.filter |$value| { !($value in $defaults) }
-  } else {
-    $_admission_control = $unfiltered_admission_control
+    $_admission_control = $admission_control
   }
 
   $_disable_admission_control = $disable_admission_control

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -53,7 +53,6 @@ class kubernetes::apiserver(
   $_systemd_before = $systemd_before
 
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
-  $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
   $post_1_9 = versioncmp($::kubernetes::version, '1.9.0') >= 0
   $post_1_8 = versioncmp($::kubernetes::version, '1.8.0') >= 0
   $post_1_7 = versioncmp($::kubernetes::version, '1.7.0') >= 0
@@ -112,7 +111,7 @@ class kubernetes::apiserver(
     $_oidc_signing_algs = []
   }
 
-  # Do not insecure bind the API server on kubernetes 1.11+
+  # Do not set insecure_port variable of the API server on kubernetes 1.11+
   if !$post_1_11 {
     $insecure_port = $::kubernetes::_apiserver_insecure_port
     $etcd_quorum_read = true

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -52,6 +52,7 @@ class kubernetes (
   }
 
   # do not insecure bind the apiserver after 1.5
+
   if $apiserver_insecure_port == -1 and versioncmp($version, '1.6.0') < 0 {
     $_apiserver_insecure_port = 8080
   } elsif $apiserver_insecure_port == -1 {

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -51,8 +51,6 @@ class kubernetes (
     $_authorization_mode = $authorization_mode
   }
 
-  # do not insecure bind the apiserver after 1.5
-
   if $apiserver_insecure_port == -1 and versioncmp($version, '1.6.0') < 0 {
     $_apiserver_insecure_port = 8080
   } elsif $apiserver_insecure_port == -1 {

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -232,5 +232,75 @@ describe 'kubernetes::apiserver' do
       let(:authorization_mode) { '[\'AlwaysAllow\']' }
       it { should contain_file(service_file).with_content(/#{Regexp.escape('--authorization-mode=AlwaysAllow')}/)}
     end
+
+    context 'deprecated insecure-port flag after 1.11' do
+      context 'insecure-port' do
+        context 'should exist before 1.11' do
+          let(:pre_condition) {[
+          """
+          class{'kubernetes': version => '1.10.7'}
+          """
+          ]}
+
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--insecure-port=')}/)}
+        end
+
+        context 'should not exist after 1.11' do
+          let(:pre_condition) {[
+            """
+            class{'kubernetes': version => '1.11.0'}
+              """
+          ]}
+
+          it {should_not contain_file(service_file).with_content(/#{Regexp.escape('--insecure-port=')}/)}
+        end
+      end
+
+      context 'etc-quorum-read' do
+        context 'should exist before 1.11' do
+          let(:pre_condition) {[
+              """
+            class{'kubernetes': version => '1.10.7'}
+              """
+          ]}
+
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--etcd-quorum-read=true')}/)}
+        end
+
+        context 'should not exist after 1.11' do
+          let(:pre_condition) {[
+              """
+          class{'kubernetes': version => '1.11.0'}
+              """
+          ]}
+
+          it {should_not contain_file(service_file).with_content(/#{Regexp.escape('--etcd-quorum-read=true')}/)}
+        end
+      end
+
+      context 'admission-control' do
+        context 'should exist before 1.11' do
+          let(:pre_condition) {[
+          """
+          class{'kubernetes': version => '1.10.7'}
+          """
+          ]}
+
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--admission-control=')}/)}
+        end
+
+        context 'should not exist after 1.11' do
+          let(:pre_condition) {[
+            """
+            class{'kubernetes': version => '1.11.0'}
+              """
+          ]}
+
+          it {should_not contain_file(service_file).with_content(/#{Regexp.escape('--admission-control=')}/)}
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=')}/)}
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--disable-admission-plugins=')}/)}
+        end
+      end
+    end
   end
 end

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -298,7 +298,7 @@ describe 'kubernetes::apiserver' do
           let(:params) { {'admission_control' => ['NamespaceLifecycle', 'LimitRanger', 'foo'] } }
 
           it {should_not contain_file(service_file).with_content(/#{Regexp.escape('--admission-control=')}/)}
-          it {should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=foo')}/)}
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=NamespaceLifecycle,LimitRanger,foo')}/)}
           it {should contain_file(service_file).with_content(/#{Regexp.escape('--disable-admission-plugins=')}/)}
         end
       end

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -295,9 +295,10 @@ describe 'kubernetes::apiserver' do
             class{'kubernetes': version => '1.11.0'}
               """
           ]}
+          let(:params) { {'admission_control' => ['NamespaceLifecycle', 'LimitRanger', 'foo'] } }
 
           it {should_not contain_file(service_file).with_content(/#{Regexp.escape('--admission-control=')}/)}
-          it {should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=')}/)}
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=foo')}/)}
           it {should contain_file(service_file).with_content(/#{Regexp.escape('--disable-admission-plugins=')}/)}
         end
       end

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -64,7 +64,9 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
   --proxy-client-key-file=<%= @proxy_client_key_file %> \
 <%- end -%>
   "--etcd-servers=<%= @etcd_servers %>" \
+<% if @etcd_quorum_read -%>
   "--etcd-quorum-read=true" \
+<% end -%>
 <% @etcd_servers_overrides.each do |override| -%>
   "--etcd-servers-overrides=<%= override %>" \
 <% end -%>
@@ -78,7 +80,12 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
   --etcd-keyfile=<%= scope['kubernetes::apiserver::etcd_key_file'] %> \
 <% end -%>
   --service-cluster-ip-range=<%= scope['kubernetes::service_ip_range_network'] %>/<%= scope['kubernetes::service_ip_range_mask'] %> \
+<% if @post_1_11 -%>
+  --enable-admission-plugins=<%= @_admission_control.join(',') %> \
+  --disable-admission-plugins=<%= @_disable_admission_control.join(',') %> \
+<%- else -%>
   --admission-control=<%= @_admission_control.join(',') %> \
+<% end -%>
 <%- if scope['kubernetes::_service_account_key_file'] -%>
   --service-account-key-file=<%= scope['kubernetes::_service_account_key_file'] %> \
 <% end -%>


### PR DESCRIPTION
**What this PR does / why we need it**:
Unset depreciated flags for Kubernetes 1.11

fixes #425 
fixes #426 


```release-note
Unset API Server depreciated flags for Kubernetes version >= 1.11
```
/assign @simonswine 