### PR TITLE
Kublet and Kube-Proxy config file

### DIFF
--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -125,6 +125,15 @@ class kubernetes::kubelet(
     $_feature_gates = $feature_gates
   }
 
+  $_config_feature_gates = $_feature_gates.map |$gate| {
+    $s = split($gate, '=')
+    if $s.length < 2 {
+      $feature = $s[0]; "${feature}: true"
+    } else {
+      $feature = $s[0,-2].join('='); $enable = $s[-1]; "${feature}: ${enable}"
+    }
+  }
+
   if !$_register_schedulable {
     $_default_node_taints = {
       'node-role.kubernetes.io/master' => ':NoSchedule',

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -283,11 +283,7 @@ class kubernetes::kubelet(
       owner   => 'root',
       group   => $kubernetes::group,
       content => template('kubernetes/kubelet-config.yaml.erb'),
-    }
-    ~> exec { "${service_name}-config-daemon-reload":
-      command     => 'systemctl daemon-reload',
-      path        => $::kubernetes::path,
-      refreshonly => true,
+      notify  => Service["${service_name}.service"],
     }
   }
 

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -53,7 +53,7 @@ class kubernetes::kubelet(
   Array[String] $systemd_requires = [],
   Array[String] $systemd_after = [],
   Array[String] $systemd_before = [],
-  String $kubelet_config_file = "${kubelet_dir}/kubelet-config.yaml",
+  String $config_file = "${kubelet_dir}/kubelet-config.yaml",
 ){
   require ::kubernetes
 
@@ -268,12 +268,17 @@ class kubernetes::kubelet(
   }
 
   if $post_1_11 {
-    file{$kubelet_config_file:
+    file{$config_file:
       ensure  => file,
       mode    => '0640',
       owner   => 'root',
       group   => $kubernetes::group,
       content => template('kubernetes/kubelet-config.yaml.erb'),
+    }
+    ~> exec { "${service_name}-config-daemon-reload":
+      command     => 'systemctl daemon-reload',
+      path        => $::kubernetes::path,
+      refreshonly => true,
     }
   }
 

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -53,8 +53,8 @@ class kubernetes::kubelet(
   Array[String] $systemd_requires = [],
   Array[String] $systemd_after = [],
   Array[String] $systemd_before = [],
-  String $config_file = "${kubelet_dir}/kubelet-config.yaml",
-){
+  String $config_file = "${::kubernetes::params::config_dir}/kubelet-config.yaml",
+) inherits kubernetes::params{
   require ::kubernetes
 
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0

--- a/puppet/modules/kubernetes/manifests/proxy.pp
+++ b/puppet/modules/kubernetes/manifests/proxy.pp
@@ -43,10 +43,7 @@ class kubernetes::proxy(
       owner   => 'root',
       group   => $kubernetes::group,
       content => template('kubernetes/kube-proxy-config.yaml.erb'),
-    } ~> exec { "${service_name}-config-daemon-reload":
-      command     => 'systemctl daemon-reload',
-      path        => $::kubernetes::path,
-      refreshonly => true,
+      notify  => Service["${service_name}.service"],
     }
   }
 

--- a/puppet/modules/kubernetes/manifests/proxy.pp
+++ b/puppet/modules/kubernetes/manifests/proxy.pp
@@ -7,8 +7,8 @@ class kubernetes::proxy(
   Array[String] $systemd_requires = [],
   Array[String] $systemd_after = [],
   Array[String] $systemd_before = [],
-  String $config_file = "${::kubernetes::config_dir}/kube-proxy-config.yaml",
-){
+  String $config_file = "${::kubernetes::params::config_dir}/kube-proxy-config.yaml",
+) inherits kubernetes::params{
   require ::kubernetes
 
   $service_name = 'kube-proxy'

--- a/puppet/modules/kubernetes/manifests/proxy.pp
+++ b/puppet/modules/kubernetes/manifests/proxy.pp
@@ -7,7 +7,7 @@ class kubernetes::proxy(
   Array[String] $systemd_requires = [],
   Array[String] $systemd_after = [],
   Array[String] $systemd_before = [],
-  String $proxy_config_file = "${::kubernetes::config_dir}/kube-proxy-config.yaml",
+  String $config_file = "${::kubernetes::config_dir}/kube-proxy-config.yaml",
 ){
   require ::kubernetes
 
@@ -37,12 +37,16 @@ class kubernetes::proxy(
   }
 
   if $post_1_11 {
-    file{$proxy_config_file:
+    file{$config_file:
       ensure  => file,
       mode    => '0640',
       owner   => 'root',
       group   => $kubernetes::group,
       content => template('kubernetes/kube-proxy-config.yaml.erb'),
+    } ~> exec { "${service_name}-config-daemon-reload":
+      command     => 'systemctl daemon-reload',
+      path        => $::kubernetes::path,
+      refreshonly => true,
     }
   }
 

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -10,6 +10,10 @@ describe 'kubernetes::kubelet' do
       '/etc/kubernetes/kubeconfig-kubelet'
   end
 
+  let :kubelet_config do
+      '/var/lib/kubelet/kubelet-config.yaml'
+  end
+
   context 'defaults' do
     it do
       should contain_file(service_file).with_content(/--register-node=true/)
@@ -357,5 +361,32 @@ describe 'kubernetes::kubelet' do
         should_not contain_file(service_file).with_content(%r{--enforce-node-allocatable= })
       end
     end
+  end
+
+  context 'kubelet config' do
+    context 'on kubernetes 1.10' do
+      let(:pre_condition) {[
+        """
+        class{'kubernetes': version => '1.10.0'}
+        """
+      ]}
+      it 'is not used' do
+        should_not contain_file(service_file).with_content(%r{--config=/var/lib/kubelet/kubelet-config\.yaml})
+        should_not contain_file(kubelet_config)
+      end
+    end
+
+    context 'on kubernetes 1.11' do
+      let(:pre_condition) {[
+        """
+        class{'kubernetes': version => '1.11.0'}
+        """
+      ]}
+      it 'is used' do
+          should contain_file(service_file).with_content(%r{--config=/var/lib/kubelet/kubelet-config\.yaml})
+          should contain_file(kubelet_config)
+      end
+    end
+
   end
 end

--- a/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/kubelet_spec.rb
@@ -382,9 +382,15 @@ describe 'kubernetes::kubelet' do
         class{'kubernetes': version => '1.11.0'}
         """
       ]}
+      let(:params) { {
+        "feature_gates" => ["PodPriority=true", "foobar=true", "foo", "edge=case=true"]
+      }}
       it 'is used' do
           should contain_file(service_file).with_content(%r{--config=/var/lib/kubelet/kubelet-config\.yaml})
-          should contain_file(kubelet_config)
+          should contain_file(kubelet_config).with_content(%r{PodPriority: true})
+          should contain_file(kubelet_config).with_content(%r{foobar: true})
+          should contain_file(kubelet_config).with_content(%r{foo: true})
+          should contain_file(kubelet_config).with_content(%r{edge=case: true})
       end
     end
 

--- a/puppet/modules/kubernetes/spec/classes/proxy_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/proxy_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'kubernetes::proxy' do
+
+  let :service_file do
+      '/etc/systemd/system/kube-proxy.service'
+  end
+
+  let :proxy_config do
+      '/etc/kubernetes/kube-proxy-config.yaml'
+  end
+
+
+  context 'proxy config' do
+    context 'on kubernetes 1.10' do
+      let(:pre_condition) {[
+        """
+        class{'kubernetes': version => '1.10.0'}
+        """
+      ]}
+      it 'is not used' do
+        should_not contain_file(service_file).with_content(%r{--config=/etc/kubernetes/kube-proxy-config\.yaml})
+        should_not contain_file(proxy_config)
+      end
+    end
+
+    context 'on kubernetes 1.11' do
+      let(:pre_condition) {[
+        """
+        class{'kubernetes': version => '1.11.0'}
+        """
+      ]}
+      it 'is used' do
+          should contain_file(service_file).with_content(%r{--config=/etc/kubernetes/kube-proxy-config\.yaml})
+          should contain_file(proxy_config)
+      end
+    end
+  end
+end

--- a/puppet/modules/kubernetes/templates/kube-proxy-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy-config.yaml.erb
@@ -1,0 +1,8 @@
+kind: KubeProxyConfiguration
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+clusterCIDR: <%= scope['kubernetes::pod_network'] %>
+resourceContainer: podruntime.slice
+<% if @kubeconfig_path -%>
+clientConnection:
+    kubeconfig: <%= @kubeconfig_path %>
+<% end -%>

--- a/puppet/modules/kubernetes/templates/kube-proxy.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy.service.erb
@@ -9,9 +9,8 @@ ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
 ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-ip6tables=1
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \
   --v=<%= scope['kubernetes::log_level'] %> \
-  --logtostderr=true \
 <% if @post_1_11 -%>
-  --config=<%= @proxy_config_file  %> \
+  --config=<%= @config_file  %> \
 <% else -%>
   --cluster-cidr=<%= scope['kubernetes::pod_network'] %> \
   --resource-container=podruntime.slice \
@@ -19,6 +18,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \
   --kubeconfig=<%= @kubeconfig_path %> \
 <% end -%>
 <% end -%>
+  --logtostderr=true
 
 Restart=on-failure
 LimitNOFILE=65536

--- a/puppet/modules/kubernetes/templates/kube-proxy.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-proxy.service.erb
@@ -9,12 +9,16 @@ ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
 ExecStartPre=/sbin/sysctl -w net.bridge.bridge-nf-call-ip6tables=1
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/proxy \
   --v=<%= scope['kubernetes::log_level'] %> \
+  --logtostderr=true \
+<% if @post_1_11 -%>
+  --config=<%= @proxy_config_file  %> \
+<% else -%>
   --cluster-cidr=<%= scope['kubernetes::pod_network'] %> \
   --resource-container=podruntime.slice \
 <% if @kubeconfig_path -%>
   --kubeconfig=<%= @kubeconfig_path %> \
 <% end -%>
-  --logtostderr=true
+<% end -%>
 
 Restart=on-failure
 LimitNOFILE=65536

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -20,8 +20,8 @@ authorization:
 cgroupDriver: <%= @cgroup_driver %>
 cgroupRoot: <%= @cgroup_root %>
 <% if @cgroup_kube_name -%>
-kubeReservedCgroup: <%= @cgroup_kube_name %>
 kubeletCgroups: <%= @cgroup_kube_name %>
+kubeReservedCgroup: <%= @cgroup_kube_name %>
 kubeReserved:
 <% if !@cgroup_kube_reserved_cpu.nil? and @cgroup_kube_reserved_cpu != 'nil' -%>
     cpu: <%= @cgroup_kube_reserved_cpu %>
@@ -31,6 +31,7 @@ kubeReserved:
 <% end -%>
 <% end -%>
 <% if @cgroup_system_name -%>
+systemCgroups: <%= @cgroup_system_name %>
 systemReservedCgroup: <%= @cgroup_system_name %>
 systemReserved:
 <% if !@cgroup_system_reserved_cpu.nil? and @cgroup_system_reserved_cpu != 'nil' -%>
@@ -88,7 +89,7 @@ evictionMinimumReclaim:
 <% if !@eviction_minimum_reclaim_nodefs_inodes_free.nil? and @eviction_minimum_reclaim_nodefs_inodes_free != 'nil' -%>
     nodefs.inodesFree: <%= @eviction_minimum_reclaim_nodefs_inodes_free %>
 <% end -%>
-<% if @_config_feature_gates -%>
+<% if @_config_feature_gates != [] -%>
 featureGates:
     <%= @_config_feature_gates.join("\n    ") %>
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -88,6 +88,7 @@ evictionMinimumReclaim:
 <% if !@eviction_minimum_reclaim_nodefs_inodes_free.nil? and @eviction_minimum_reclaim_nodefs_inodes_free != 'nil' -%>
     nodefs.inodesFree: <%= @eviction_minimum_reclaim_nodefs_inodes_free %>
 <% end -%>
-<% if @_feature_gates != [] -%>
-featureGates: <%= @_feature_gates.join(',') %>
+<% if @_config_feature_gates -%>
+    featureGates:
+        <%= @_config_feature_gates.join("\n        ") %>
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -89,6 +89,6 @@ evictionMinimumReclaim:
     nodefs.inodesFree: <%= @eviction_minimum_reclaim_nodefs_inodes_free %>
 <% end -%>
 <% if @_config_feature_gates -%>
-    featureGates:
-        <%= @_config_feature_gates.join("\n        ") %>
+featureGates:
+    <%= @_config_feature_gates.join("\n    ") %>
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -1,0 +1,93 @@
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+clusterDNS:
+    - <%= @cluster_dns %>
+clusterDomain: <%= @cluster_domain %>
+<% if @pod_cidr -%>
+podCIDR: <%= @pod_cidr %>
+<% end -%>
+<% if @client_ca_file  -%>
+authentication:
+    x509:
+        clientCAFile: <%= @client_ca_file %>
+    anonymous:
+        enabled: false
+    webook:
+        enabled: true
+authorization:
+    mode: Webhook
+<% end -%>
+cgroupDriver: <%= @cgroup_driver %>
+cgroupRoot: <%= @cgroup_root %>
+<% if @cgroup_kube_name -%>
+kubeReservedCgroup: <%= @cgroup_kube_name %>
+kubeletCgroups: <%= @cgroup_kube_name %>
+kubeReserved:
+<% if !@cgroup_kube_reserved_cpu.nil? and @cgroup_kube_reserved_cpu != 'nil' -%>
+    cpu: <%= @cgroup_kube_reserved_cpu %>
+<% end -%>
+<% if !@cgroup_kube_reserved_memory.nil? and @cgroup_kube_reserved_memory != 'nil' -%>
+    memory: <%= @_cgroup_kube_reserved_memory %>
+<% end -%>
+<% end -%>
+<% if @cgroup_system_name -%>
+systemReservedCgroup: <%= @cgroup_system_name %>
+systemReserved:
+<% if !@cgroup_system_reserved_cpu.nil? and @cgroup_system_reserved_cpu != 'nil' -%>
+    cpu: <%= @cgroup_system_reserved_cpu %>
+<% end -%>
+<% if !@cgroup_system_reserved_memory.nil? and @cgroup_system_reserved_memory != 'nil' -%>
+    memory: <%= @cgroup_system_reserved_cpu %>
+<% end -%>
+<% end -%>
+<% if @cert_file and @key_file -%>
+tlsCertFile: <%= @cert_file %>
+tlsPrivateKeyFile: <%= @key_file %>
+<% end -%>
+evictionHard:
+<% if !@eviction_hard_memory_available_threshold.nil? and @eviction_hard_memory_available_threshold != 'nil' -%>
+    memory.available: <%= @eviction_hard_memory_available_threshold %>
+<% end -%>
+<% if !@eviction_hard_nodefs_available_threshold.nil? and @eviction_hard_nodefs_available_threshold != 'nil' -%>
+    nodefs.available: <%= @eviction_hard_nodefs_available_threshold %>
+<% end -%>
+<% if !@eviction_hard_nodefs_inodes_free_threshold.nil? and @eviction_hard_nodefs_inodes_free_threshold != 'nil' -%>
+    nodefs.inodesFree: <%= @eviction_hard_nodefs_available_threshold %>
+<% end -%>
+<% if @eviction_soft_enabled -%>
+evictionSoft:
+<% if !@eviction_soft_memory_available_threshold.nil? and @eviction_soft_memory_available_threshold != 'nil' -%>
+    memory.available: <%= @eviction_soft_memory_available_threshold %>
+<% end -%>
+<% if !@eviction_soft_nodefs_available_threshold.nil? and @eviction_soft_nodefs_available_threshold != 'nil' -%>
+    nodefs.available: <%= @eviction_soft_nodefs_available_threshold %>
+<% end -%>
+<% if !@eviction_soft_nodefs_inodes_free_threshold.nil? and @eviction_soft_nodefs_inodes_free_threshold != 'nil' -%>
+    nodefs.inodesFree: <%= @eviction_soft_nodefs_available_threshold %>
+<% end -%>
+evictionSoftGracePeriod:
+<% if !@eviction_soft_memory_available_grace_period.nil? and @eviction_soft_memory_available_grace_period != 'nil' -%>
+    memory.available: <%= @eviction_soft_memory_available_grace_period %>
+<% end -%>
+<% if !@eviction_soft_nodefs_available_grace_period.nil? and @eviction_soft_nodefs_available_grace_period != 'nil' -%>
+    nodefs.available: <%= @eviction_soft_nodefs_available_grace_period %>
+<% end -%>
+<% if !@eviction_soft_nodefs_inodes_free_grace_period.nil? and @eviction_soft_nodefs_inodes_free_grace_period != 'nil' -%>
+    nodefs.inodesFree: <%= @eviction_soft_nodefs_available_grace_period %>
+<% end -%>
+evictionMaxPodGracePeriod: <%= @eviction_max_pod_grace_period %>
+evictionPressureTransitionPeriod: <%= @eviction_pressure_transition_period %>
+<% end -%>
+evictionMinimumReclaim:
+<% if !@eviction_minimum_reclaim_memory_available.nil? and @eviction_minimum_reclaim_memory_available != 'nil' -%>
+    memory.available: <%= @eviction_minimum_reclaim_memory_available %>
+<% end -%>
+<% if !@eviction_minimum_reclaim_nodefs_available.nil? and @eviction_minimum_reclaim_nodefs_available != 'nil' -%>
+    nodefs.available: <%= @eviction_minimum_reclaim_nodefs_available %>
+<% end -%>
+<% if !@eviction_minimum_reclaim_nodefs_inodes_free.nil? and @eviction_minimum_reclaim_nodefs_inodes_free != 'nil' -%>
+    nodefs.inodesFree: <%= @eviction_minimum_reclaim_nodefs_inodes_free %>
+<% end -%>
+<% if @_feature_gates != [] -%>
+featureGates: <%= @_feature_gates.join(',') %>
+<% end -%>

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -26,7 +26,7 @@ kubeReserved:
 <% if !@cgroup_kube_reserved_cpu.nil? and @cgroup_kube_reserved_cpu != 'nil' -%>
     cpu: <%= @cgroup_kube_reserved_cpu %>
 <% end -%>
-<% if !@cgroup_kube_reserved_memory.nil? and @cgroup_kube_reserved_memory != 'nil' -%>
+<% if !@_cgroup_kube_reserved_memory.nil? and @_cgroup_kube_reserved_memory != 'nil' -%>
     memory: <%= @_cgroup_kube_reserved_memory %>
 <% end -%>
 <% end -%>
@@ -37,7 +37,7 @@ systemReserved:
     cpu: <%= @cgroup_system_reserved_cpu %>
 <% end -%>
 <% if !@cgroup_system_reserved_memory.nil? and @cgroup_system_reserved_memory != 'nil' -%>
-    memory: <%= @cgroup_system_reserved_cpu %>
+    memory: <%= @cgroup_system_reserved_memory %>
 <% end -%>
 <% end -%>
 <% if @cert_file and @key_file -%>
@@ -52,28 +52,28 @@ evictionHard:
     nodefs.available: <%= @eviction_hard_nodefs_available_threshold %>
 <% end -%>
 <% if !@eviction_hard_nodefs_inodes_free_threshold.nil? and @eviction_hard_nodefs_inodes_free_threshold != 'nil' -%>
-    nodefs.inodesFree: <%= @eviction_hard_nodefs_available_threshold %>
+    nodefs.inodesFree: <%= @eviction_hard_nodefs_inodes_free_threshold %>
 <% end -%>
 <% if @eviction_soft_enabled -%>
 evictionSoft:
 <% if !@eviction_soft_memory_available_threshold.nil? and @eviction_soft_memory_available_threshold != 'nil' -%>
     memory.available: <%= @eviction_soft_memory_available_threshold %>
 <% end -%>
-<% if !@eviction_soft_nodefs_available_threshold.nil? and @eviction_soft_nodefs_available_threshold != 'nil' -%>
-    nodefs.available: <%= @eviction_soft_nodefs_available_threshold %>
+<% if !@_eviction_soft_nodefs_available_threshold.nil? and @_eviction_soft_nodefs_available_threshold != 'nil' -%>
+    nodefs.available: <%= @_eviction_soft_nodefs_available_threshold %>
 <% end -%>
-<% if !@eviction_soft_nodefs_inodes_free_threshold.nil? and @eviction_soft_nodefs_inodes_free_threshold != 'nil' -%>
-    nodefs.inodesFree: <%= @eviction_soft_nodefs_available_threshold %>
+<% if !@_eviction_soft_nodefs_inodes_free_threshold.nil? and @_eviction_soft_nodefs_inodes_free_threshold != 'nil' -%>
+    nodefs.inodesFree: <%= @_eviction_soft_nodefs_available_threshold %>
 <% end -%>
 evictionSoftGracePeriod:
 <% if !@eviction_soft_memory_available_grace_period.nil? and @eviction_soft_memory_available_grace_period != 'nil' -%>
     memory.available: <%= @eviction_soft_memory_available_grace_period %>
 <% end -%>
-<% if !@eviction_soft_nodefs_available_grace_period.nil? and @eviction_soft_nodefs_available_grace_period != 'nil' -%>
-    nodefs.available: <%= @eviction_soft_nodefs_available_grace_period %>
+<% if !@_eviction_soft_nodefs_available_grace_period.nil? and @_eviction_soft_nodefs_available_grace_period != 'nil' -%>
+    nodefs.available: <%= @_eviction_soft_nodefs_available_grace_period %>
 <% end -%>
-<% if !@eviction_soft_nodefs_inodes_free_grace_period.nil? and @eviction_soft_nodefs_inodes_free_grace_period != 'nil' -%>
-    nodefs.inodesFree: <%= @eviction_soft_nodefs_available_grace_period %>
+<% if !@_eviction_soft_nodefs_inodes_free_grace_period.nil? and @_eviction_soft_nodefs_inodes_free_grace_period != 'nil' -%>
+    nodefs.inodesFree: <%= @_eviction_soft_nodefs_inodes_free_grace_period %>
 <% end -%>
 evictionMaxPodGracePeriod: <%= @eviction_max_pod_grace_period %>
 evictionPressureTransitionPeriod: <%= @eviction_pressure_transition_period %>

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -7,8 +7,8 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Slice=podruntime.slice
 WorkingDirectory=<%= @kubelet_dir %>
 <% if @cloud_provider == 'aws' -%>
-# prevent metadata service access on AWS
-ExecStartPre=/bin/sh -e -c "iptables -C PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181 2> /dev/null || iptables -A PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181"
+    # prevent metadata service access on AWS
+    ExecStartPre=/bin/sh -e -c "iptables -C PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181 2> /dev/null || iptables -A PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181"
 <% end -%>
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --v=<%= scope['kubernetes::log_level'] %> \
@@ -38,13 +38,8 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% if @_node_labels_string and @_node_labels_string.length > 0 -%>
   "--node-labels=<%= @_node_labels_string %>" \
 <% end -%>
-  --cluster-dns=<%= @cluster_dns %> \
-  --cluster-domain=<%= @cluster_domain %> \
 <% if @hostname_override -%>
   --hostname-override=<%= @hostname_override %> \
-<% end -%>
-<% if @pod_cidr -%>
-  --pod-cidr=<%= @pod_cidr %> \
 <% end -%>
 <% if @network_plugin -%>
   --network-plugin=<%= @network_plugin %> \
@@ -58,6 +53,19 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% if @container_runtime -%>
   --container-runtime=<%= @container_runtime %> \
 <% end -%>
+  --logtostderr=true \
+<% if not @kernelversion.nil? and scope.function_versioncmp([scope['kubernetes::version'], '1.6.0']) >= 0 and scope.function_versioncmp([scope['kubernetes::version'], '1.7.0']) < 0 and scope.function_versioncmp([@kernelversion, '4.9']) >= 0 -%>
+  --cgroups-per-qos=false \
+  --enforce-node-allocatable= \
+<% end -%>
+<% if @post_1_11 -%>
+  --config=<%= @kubelet_config_file  %> \
+<% else -%>
+  --cluster-dns=<%= @cluster_dns %> \
+  --cluster-domain=<%= @cluster_domain %> \
+<% if @pod_cidr -%>
+  --pod-cidr=<%= @pod_cidr %> \
+<% end -%>
 <% if @client_ca_file and scope.function_versioncmp([scope['kubernetes::version'], '1.5.0']) >= 0 -%>
   --client-ca-file=<%= @client_ca_file %> \
   --anonymous-auth=false \
@@ -65,10 +73,6 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --authorization-mode=Webhook \
 <% end -%>
 <% # Kubernetes older than 1.7 has issues with kernel 4.9+ -%>
-<% if not @kernelversion.nil? and scope.function_versioncmp([scope['kubernetes::version'], '1.6.0']) >= 0 and scope.function_versioncmp([scope['kubernetes::version'], '1.7.0']) < 0 and scope.function_versioncmp([@kernelversion, '4.9']) >= 0 -%>
-  --cgroups-per-qos=false \
-  --enforce-node-allocatable= \
-<% end -%>
 <% if scope.function_versioncmp([scope['kubernetes::version'], '1.6.0']) >= 0 -%>
   --cgroup-driver=<%= @cgroup_driver %> \
   --cgroup-root=<%= @cgroup_root %> \
@@ -122,7 +126,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
     @eviction_soft << "nodefs.available<#{@_eviction_soft_nodefs_available_threshold}" unless @_eviction_soft_nodefs_available_threshold.nil? or @_eviction_soft_nodefs_available_threshold == 'nil'
     @eviction_soft << "nodefs.inodesFree<#{@_eviction_soft_nodefs_inodes_free_threshold}" unless @_eviction_soft_nodefs_inodes_free_threshold.nil? or @_eviction_soft_nodefs_inodes_free_threshold == 'nil'
 -%>
-<%    if @eviction_soft.length > 0 -%>
+<%if @eviction_soft.length > 0 -%>
 <%
     # build eviction soft grace period command line
     @eviction_soft_grace_period = []
@@ -136,24 +140,25 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --eviction-soft-grace-period=<%= @eviction_soft_grace_period.join(',') %> \
   --eviction-max-pod-grace-period=<%= @eviction_max_pod_grace_period %> \
   --eviction-pressure-transition-period=<%= @eviction_pressure_transition_period %> \
-<%        end -%>
-<%    end -%>
+<% end -%>
+<% end -%>
 <% end -%>
 <%
-  # build minumum reclaim command line
-  @eviction_minimum_reclaim = []
+    # build minumum reclaim command line
+    @eviction_minimum_reclaim = []
 
-  @eviction_minimum_reclaim << "memory.available=#{@eviction_minimum_reclaim_memory_available}" unless @eviction_minimum_reclaim_memory_available.nil? or @eviction_minimum_reclaim_memory_available == 'nil'
-  @eviction_minimum_reclaim << "nodefs.available=#{@eviction_minimum_reclaim_nodefs_available}" unless @eviction_minimum_reclaim_nodefs_available.nil? or @eviction_minimum_reclaim_nodefs_available == 'nil'
-  @eviction_minimum_reclaim << "nodefs.inodesFree=#{@eviction_minimum_reclaim_nodefs_inodes_free}" unless @eviction_minimum_reclaim_nodefs_inodes_free.nil? or @eviction_minimum_reclaim_nodefs_inodes_free == 'nil'
+    @eviction_minimum_reclaim << "memory.available=#{@eviction_minimum_reclaim_memory_available}" unless @eviction_minimum_reclaim_memory_available.nil? or @eviction_minimum_reclaim_memory_available == 'nil'
+    @eviction_minimum_reclaim << "nodefs.available=#{@eviction_minimum_reclaim_nodefs_available}" unless @eviction_minimum_reclaim_nodefs_available.nil? or @eviction_minimum_reclaim_nodefs_available == 'nil'
+    @eviction_minimum_reclaim << "nodefs.inodesFree=#{@eviction_minimum_reclaim_nodefs_inodes_free}" unless @eviction_minimum_reclaim_nodefs_inodes_free.nil? or @eviction_minimum_reclaim_nodefs_inodes_free == 'nil'
 -%>
 <% if @eviction_minimum_reclaim.length > 0 -%>
   "--eviction-minimum-reclaim=<%= @eviction_minimum_reclaim.join(',') %>" \
 <% end -%>
+
 <% if @_feature_gates != [] -%>
-  --feature-gates=<%= @_feature_gates.join(',') %> \
+  --feature-gates=<%= @_feature_gates.join(',') %>
 <% end -%>
-  --logtostderr=true
+<% end -%>
 
 Restart=on-failure
 KillMode=process

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -154,7 +154,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   "--eviction-minimum-reclaim=<%= @eviction_minimum_reclaim.join(',') %>" \
 <% end -%>
 <% if @_feature_gates != [] -%>
-  --feature-gates=<%= @_feature_gates.join(',') %>
+  --feature-gates=<%= @_feature_gates.join(',') %> \
 <% end -%>
 <% end -%>
   --logtostderr=true

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -7,8 +7,8 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Slice=podruntime.slice
 WorkingDirectory=<%= @kubelet_dir %>
 <% if @cloud_provider == 'aws' -%>
-    # prevent metadata service access on AWS
-    ExecStartPre=/bin/sh -e -c "iptables -C PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181 2> /dev/null || iptables -A PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181"
+# prevent metadata service access on AWS
+ExecStartPre=/bin/sh -e -c "iptables -C PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181 2> /dev/null || iptables -A PREROUTING -p tcp --destination 169.254.169.254 --dport 80 --in-interface <%= @container_interface %> --jump DNAT --table nat --to-destination 127.0.0.1:8181"
 <% end -%>
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --v=<%= scope['kubernetes::log_level'] %> \
@@ -53,13 +53,12 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% if @container_runtime -%>
   --container-runtime=<%= @container_runtime %> \
 <% end -%>
-  --logtostderr=true \
 <% if not @kernelversion.nil? and scope.function_versioncmp([scope['kubernetes::version'], '1.6.0']) >= 0 and scope.function_versioncmp([scope['kubernetes::version'], '1.7.0']) < 0 and scope.function_versioncmp([@kernelversion, '4.9']) >= 0 -%>
   --cgroups-per-qos=false \
   --enforce-node-allocatable= \
 <% end -%>
 <% if @post_1_11 -%>
-  --config=<%= @kubelet_config_file  %> \
+  --config=<%= @config_file  %> \
 <% else -%>
   --cluster-dns=<%= @cluster_dns %> \
   --cluster-domain=<%= @cluster_domain %> \
@@ -159,6 +158,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --feature-gates=<%= @_feature_gates.join(',') %>
 <% end -%>
 <% end -%>
+  --logtostderr=true
 
 Restart=on-failure
 KillMode=process

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -153,7 +153,6 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% if @eviction_minimum_reclaim.length > 0 -%>
   "--eviction-minimum-reclaim=<%= @eviction_minimum_reclaim.join(',') %>" \
 <% end -%>
-
 <% if @_feature_gates != [] -%>
   --feature-gates=<%= @_feature_gates.join(',') %>
 <% end -%>


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for kubelet and kube-proxy config files for Kubernetes clusters >= 1.11

fixes #424 
fixes #423 

```release-note
Adds configuration file for Kubelet and Kube-Proxy for Kubrnetes clusters >= 1.11 
```

/assign @simonswine