### PR TITLE
Copy docker files even when start fails

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,7 +32,7 @@ docker_html:
 	# start documentaion build
 	$(eval CONTAINER_ID := $(shell docker create $(IMAGE_ID)))
 	(git ls-files && git ls-files --others --exclude-standard) | tar cf -  -T - | docker cp - $(CONTAINER_ID):/site
-	docker start -a $(CONTAINER_ID)
+	- docker start -a $(CONTAINER_ID)
 	docker cp $(CONTAINER_ID):/site/_build - | tar xf -
 	docker rm $(CONTAINER_ID)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,9 +32,11 @@ docker_html:
 	# start documentaion build
 	$(eval CONTAINER_ID := $(shell docker create $(IMAGE_ID)))
 	(git ls-files && git ls-files --others --exclude-standard) | tar cf -  -T - | docker cp - $(CONTAINER_ID):/site
-	- docker start -a $(CONTAINER_ID)
-	docker cp $(CONTAINER_ID):/site/_build - | tar xf -
-	docker rm $(CONTAINER_ID)
+	docker start -a $(CONTAINER_ID);\
+	EXITCODE=$$?;\
+	docker cp $(CONTAINER_ID):/site/_build - | tar xf -;\
+	docker rm $(CONTAINER_ID);\
+	exit $$EXITCODE
 
 .venv:
 	virtualenv -p $(shell which python3) $(VENV_PATH)


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures that even if `docker start` fails when trying to build the docs, the output build files are copied out. This helps to get build error messages.

```release-note
NONE
```

/assign @simonswine 