### PR TITLE
WIP: Default to public pre-built AMI images if none exist

### DIFF
--- a/pkg/packer/image.go
+++ b/pkg/packer/image.go
@@ -92,7 +92,7 @@ func (i *image) Build() (amiID string, err error) {
 
 	envVars, err := i.tarmak.Provider().Environment()
 	if err != nil {
-		return "", fmt.Errorf("faild to get provider credentials: %v", err)
+		return "", fmt.Errorf("failed to get provider credentials: %v", err)
 	}
 
 	var result *multierror.Error

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -360,14 +360,14 @@ func (c *Cluster) verifyHubState() error {
 func (c *Cluster) VerifyInstancePools() (result error) {
 	imageIDs, err := c.ImageIDs()
 	if err != nil {
-		return fmt.Errorf("error getting image IDs: %s]", err)
+		return fmt.Errorf("error getting image IDs: %s", err)
 	}
 
 	for _, instancePool := range c.InstancePools() {
 		image := instancePool.Image()
 		_, ok := imageIDs[image]
 		if !ok {
-			return fmt.Errorf("error getting the image ID of %s", instancePool.TFName())
+			return fmt.Errorf("could not find image ID of: %s", instancePool.TFName())
 		}
 	}
 	return nil

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -298,6 +298,10 @@ func (t *Tarmak) Validate() error {
 }
 
 func (t *Tarmak) Verify() error {
+	if err := t.verifyImageExists(); err != nil {
+		return err
+	}
+
 	if err := t.Cluster().Environment().Verify(); err != nil {
 		return fmt.Errorf("failed to verify tarmak provider: %s", err)
 	}
@@ -305,11 +309,6 @@ func (t *Tarmak) Verify() error {
 	if err := t.Cluster().Verify(); err != nil {
 		return fmt.Errorf("failed to verify tarmak cluster: %s", err)
 	}
-
-	if err := t.verifyImageExists(); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Default to pre-built AMI images if the user has not build them yet.

fixes #415 

```release-note
Provide pre-built AMI images to fallback to 
```