### PR TITLE
Expose root volume sizes as tfvars

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -684,6 +684,8 @@ func (c *Cluster) Variables() map[string]interface{} {
 		}
 		output[fmt.Sprintf("%s_min_instance_count", instancePool.TFName())] = instancePool.Config().MinCount
 		output[fmt.Sprintf("%s_max_instance_count", instancePool.TFName())] = instancePool.Config().MaxCount
+		output[fmt.Sprintf("%s_root_volume_size", instancePool.TFName())] = instancePool.RootVolume().Size()
+		output[fmt.Sprintf("%s_root_volume_type", instancePool.TFName())] = instancePool.RootVolume().Type()
 	}
 
 	// set network cidr

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -246,6 +246,7 @@ type InstancePool interface {
 	Image() string
 	Role() *role.Role
 	Volumes() []Volume
+	RootVolume() Volume
 	Zones() []string
 	Validate() error
 	MinCount() int

--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -128,6 +128,8 @@ variable "bucket_prefix" {}
 {{ if or (eq .Role.Name "etcd") ( or (eq .Role.Name "worker") (eq .Role.Name "master") )  }}
 variable "{{.TFName}}_ami" {}
 {{ end }}
+variable "{{.TFName}}_root_volume_size" {}
+variable "{{.TFName}}_root_volume_type" {}
 {{ end }}
 variable "api_admin_cidrs" {
     type = "list"

--- a/terraform/amazon/templates/instance_pools/instance_pool_variables.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_variables.tf.template
@@ -1,4 +1,3 @@
-{{/* vim: set ft=tf: */}}
 variable "{{.TFName}}_instance_type" {
   default = "{{.InstanceType}}"
 }

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -122,12 +122,12 @@ module "vault" {
   private_zone_id = "${module.network.private_zone_id[0]}"
   secrets_bucket = "${module.state.secrets_bucket[0]}"
   secrets_kms_arn = "${module.state.secrets_kms_arn[0]}"
-  backups_bucket = "${module.state.backups_bucket[0]}"  
+  backups_bucket = "${module.state.backups_bucket[0]}"
   private_subnet_ids = ["${module.network.private_subnet_ids}"]
   private_subnets = ["${module.network.private_subnets}"]
   availability_zones = ["${var.availability_zones}"]
   bastion_security_group_id = "${module.bastion.bastion_security_group_id}"
-  vpc_id = "${module.network.vpc_id}" 
+  vpc_id = "${module.network.vpc_id}"
   bastion_instance_id = "${module.bastion.bastion_instance_id}"
   vault_cluster_name = "${var.vault_cluster_name}"
 }
@@ -150,9 +150,11 @@ module "kubernetes" {
   state_cluster_name = "${var.state_cluster_name}"
   vault_cluster_name = "${var.vault_cluster_name}"
   tools_cluster_name = "${var.tools_cluster_name}"
-{{range .InstancePools}}
+{{ range .InstancePools }}
 {{ if or (eq .Role.Name "etcd") ( or (eq .Role.Name "worker") (eq .Role.Name "master") )  }}
   {{.TFName}}_ami = "${var.{{.TFName}}_ami}"
+  {{.TFName}}_root_volume_size = "${var.{{.TFName}}_root_volume_size}"
+  {{.TFName}}_root_volume_type = "${var.{{.TFName}}_root_volume_type}"
 {{ end }}
 {{ end }}
   api_admin_cidrs = "${var.api_admin_cidrs}"
@@ -203,10 +205,12 @@ module "kubernetes" {
   environment = "${var.environment}"
   state_cluster_name = "${var.state_cluster_name}"
   vault_cluster_name = "${var.vault_cluster_name}"
-  tools_cluster_name = "${var.tools_cluster_name}"  
-{{range .InstancePools}}
+  tools_cluster_name = "${var.tools_cluster_name}"
+{{ range .InstancePools }}
 {{ if or (eq .Role.Name "etcd") ( or (eq .Role.Name "worker") (eq .Role.Name "master") )  }}
   {{.TFName}}_ami = "${var.{{.TFName}}_ami}"
+  {{.TFName}}_root_volume_size = "${var.{{.TFName}}_root_volume_size}"
+  {{.TFName}}_root_volume_type = "${var.{{.TFName}}_root_volume_type}"
 {{ end }}
 {{ end }}
   api_admin_cidrs = "${var.api_admin_cidrs}"


### PR DESCRIPTION
Before, these variables were never exposed and all root volumes got the
default for that variable, 32gb.

```release-note
Set root volume attribute variables, previously only default was used.
```
