### PR TITLE
Use core-dns over kube-dns for clusters >= 1.10

### DIFF
--- a/puppet/modules/kubernetes/manifests/apply.pp
+++ b/puppet/modules/kubernetes/manifests/apply.pp
@@ -95,8 +95,7 @@ define kubernetes::apply(
       Service[$service_apiserver],
     ]
   }
-
-  file{"${::kubernetes::systemd_dir}/${service_name_delete}.service":
+  -> file{"${::kubernetes::systemd_dir}/${service_name_delete}.service":
     ensure => absent,
   }
 }

--- a/puppet/modules/kubernetes/manifests/dns.pp
+++ b/puppet/modules/kubernetes/manifests/dns.pp
@@ -28,14 +28,62 @@ class kubernetes::dns(
     $version_before_1_6 = true
   }
 
-  kubernetes::apply{'kube-dns':
-    manifests => [
-      template('kubernetes/kube-dns-config-map.yaml.erb'),
-      template('kubernetes/kube-dns-service-account.yaml.erb'),
-      template('kubernetes/kube-dns-deployment.yaml.erb'),
-      template('kubernetes/kube-dns-svc.yaml.erb'),
-      template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
-      template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
-    ],
+  $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
+
+  if $post_1_10 {
+    kubernetes::apply{'core-dns':
+      manifests => [
+        template('kubernetes/core-dns-config-map.yaml.erb'),
+        template('kubernetes/core-dns-service-account.yaml.erb'),
+        template('kubernetes/core-dns-deployment.yaml.erb'),
+        template('kubernetes/core-dns-svc.yaml.erb'),
+        template('kubernetes/core-dns-horizontal-autoscaler-deployment.yaml.erb'),
+        template('kubernetes/core-dns-horizontal-autoscaler-rbac.yaml.erb'),
+        template('kubernetes/core-dns-cluster-role.yaml.erb'),
+        template('kubernetes/core-dns-cluster-role-binding.yaml.erb'),
+      ],
+    }
+
+    kubernetes::delete{'kube-dns':
+      manifests => [
+        template('kubernetes/kube-dns-config-map.yaml.erb'),
+        template('kubernetes/kube-dns-service-account.yaml.erb'),
+        template('kubernetes/kube-dns-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-svc.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role-binding.yaml.erb'),
+      ],
+    }
+
+  } else {
+
+    kubernetes::apply{'kube-dns':
+      manifests => [
+        template('kubernetes/kube-dns-config-map.yaml.erb'),
+        template('kubernetes/kube-dns-service-account.yaml.erb'),
+        template('kubernetes/kube-dns-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-svc.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role-binding.yaml.erb'),
+      ],
+    }
+
+    kubernetes::delete{'core-dns':
+      manifests => [
+        template('kubernetes/core-dns-config-map.yaml.erb'),
+        template('kubernetes/core-dns-service-account.yaml.erb'),
+        template('kubernetes/core-dns-deployment.yaml.erb'),
+        template('kubernetes/core-dns-svc.yaml.erb'),
+        template('kubernetes/core-dns-horizontal-autoscaler-deployment.yaml.erb'),
+        template('kubernetes/core-dns-horizontal-autoscaler-rbac.yaml.erb'),
+        template('kubernetes/core-dns-cluster-role.yaml.erb'),
+        template('kubernetes/core-dns-cluster-role-binding.yaml.erb'),
+      ],
+    }
   }
+
 }

--- a/puppet/modules/kubernetes/manifests/dns.pp
+++ b/puppet/modules/kubernetes/manifests/dns.pp
@@ -56,7 +56,6 @@ class kubernetes::dns(
       ],
     }
 
-
   } else {
 
     kubernetes::delete{'core-dns':

--- a/puppet/modules/kubernetes/manifests/dns.pp
+++ b/puppet/modules/kubernetes/manifests/dns.pp
@@ -31,6 +31,18 @@ class kubernetes::dns(
   $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
 
   if $post_1_10 {
+    kubernetes::delete{'kube-dns':
+      manifests => [
+        template('kubernetes/kube-dns-config-map.yaml.erb'),
+        template('kubernetes/kube-dns-service-account.yaml.erb'),
+        template('kubernetes/kube-dns-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-svc.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role-binding.yaml.erb'),
+      ],
+    }
     kubernetes::apply{'core-dns':
       manifests => [
         template('kubernetes/core-dns-config-map.yaml.erb'),
@@ -44,38 +56,12 @@ class kubernetes::dns(
       ],
     }
 
-    kubernetes::delete{'kube-dns':
-      manifests => [
-        template('kubernetes/kube-dns-config-map.yaml.erb'),
-        template('kubernetes/kube-dns-service-account.yaml.erb'),
-        template('kubernetes/kube-dns-deployment.yaml.erb'),
-        template('kubernetes/kube-dns-svc.yaml.erb'),
-        template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
-        template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
-        template('kubernetes/kube-dns-cluster-role.yaml.erb'),
-        template('kubernetes/kube-dns-cluster-role-binding.yaml.erb'),
-      ],
-    }
 
   } else {
-
-    kubernetes::apply{'kube-dns':
-      manifests => [
-        template('kubernetes/kube-dns-config-map.yaml.erb'),
-        template('kubernetes/kube-dns-service-account.yaml.erb'),
-        template('kubernetes/kube-dns-deployment.yaml.erb'),
-        template('kubernetes/kube-dns-svc.yaml.erb'),
-        template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
-        template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
-        template('kubernetes/kube-dns-cluster-role.yaml.erb'),
-        template('kubernetes/kube-dns-cluster-role-binding.yaml.erb'),
-      ],
-    }
 
     kubernetes::delete{'core-dns':
       manifests => [
         template('kubernetes/core-dns-config-map.yaml.erb'),
-        template('kubernetes/core-dns-service-account.yaml.erb'),
         template('kubernetes/core-dns-deployment.yaml.erb'),
         template('kubernetes/core-dns-svc.yaml.erb'),
         template('kubernetes/core-dns-horizontal-autoscaler-deployment.yaml.erb'),
@@ -84,6 +70,16 @@ class kubernetes::dns(
         template('kubernetes/core-dns-cluster-role-binding.yaml.erb'),
       ],
     }
+    kubernetes::apply{'kube-dns':
+      manifests => [
+        template('kubernetes/kube-dns-config-map.yaml.erb'),
+        template('kubernetes/kube-dns-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-svc.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-deployment.yaml.erb'),
+        template('kubernetes/kube-dns-horizontal-autoscaler-rbac.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role.yaml.erb'),
+        template('kubernetes/kube-dns-cluster-role-binding.yaml.erb'),
+      ],
+    }
   }
-
 }

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -8,6 +8,7 @@ class kubernetes (
   $systemd_dir = $::kubernetes::params::systemd_dir,
   $run_dir = $::kubernetes::params::run_dir,
   $apply_dir = $::kubernetes::params::apply_dir,
+  $delete_dir = $::kubernetes::params::delete_dir,
   $uid = $::kubernetes::params::uid,
   $gid = $::kubernetes::params::gid,
   $user = $::kubernetes::params::user,
@@ -169,6 +170,14 @@ class kubernetes (
   }
 
   file {$::kubernetes::params::apply_dir:
+    ensure  => directory,
+    owner   => $user,
+    group   => $group,
+    mode    => '0750',
+    require => User[$user],
+  }
+
+  file {$::kubernetes::params::delete_dir:
     ensure  => directory,
     owner   => $user,
     group   => $group,

--- a/puppet/modules/kubernetes/manifests/params.pp
+++ b/puppet/modules/kubernetes/manifests/params.pp
@@ -6,6 +6,7 @@ class kubernetes::params {
   $config_dir = '/etc/kubernetes'
   $run_dir = '/var/run/kubernetes'
   $apply_dir = '/etc/kubernetes/apply'
+  $delete_dir = '/etc/kubernetes/delete'
   $download_dir = '/tmp'
   $systemd_dir = '/etc/systemd/system'
   $download_url = 'https://storage.googleapis.com/kubernetes-release/release/v#VERSION#/bin/linux/amd64/hyperkube'

--- a/puppet/modules/kubernetes/manifests/rbac.pp
+++ b/puppet/modules/kubernetes/manifests/rbac.pp
@@ -6,6 +6,7 @@ class kubernetes::rbac{
   if member($authorization_mode, 'RBAC') and versioncmp($::kubernetes::version, '1.6.0') < 0 {
     kubernetes::apply{'puppernetes-rbac':
       manifests => [
+        template('kubernetes/kube-dns-service-account.yaml.erb'),
         template('kubernetes/rbac-namespace-kube-public.yaml.erb'),
         template('kubernetes/rbac-cluster-roles.yaml.erb'),
         template('kubernetes/rbac-cluster-role-bindings.yaml.erb'),

--- a/puppet/modules/kubernetes/spec/classes/dns_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/dns_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
 describe 'kubernetes::dns' do
-  let(:pre_condition) do
-    [
-      'include kubernetes::apiserver'
-    ]
-  end
-
   let :kube_service_file_apply do
     '/etc/systemd/system/kubectl-apply-kube-dns.service'
   end
@@ -40,38 +34,45 @@ describe 'kubernetes::dns' do
   end
 
   context 'with default values for all parameters' do
+    let(:pre_condition) {[
+        """
+      include kubernetes::apiserver,
+      class{'kubernetes': version => '1.9.0'}
+        """
+    ]}
 
     it { should contain_class('kubernetes::dns') }
+    it { should contain_class('kubernetes::apiserver') }
 
     it 'should write systemd unit for applying' do
-      should contain_file(kube_service_file_apply).with_content(/User=kubernetes/)
-      should contain_file(core_service_file_delete).with_content(/User=kubernetes/)
+      should contain_file(kube_service_file_apply)
+      should contain_file(core_service_file_delete)
     end
 
     it 'should write manifests' do
       should contain_file(kube_apply_manifests_file).with_content(/--domain=cluster\.local\./)
       should contain_file(kube_apply_manifests_file).with_content(/clusterIP: 10\.254\.0\.10/)
       should contain_file(core_delete_manifests_file)
-      should contain_file(core_delete_manifests_file)
     end
   end
 
   context 'with version 1.11' do
+    let(:pre_condition) {[
+        """
+      include kubernetes::apiserver,
+      class{'kubernetes': version => '1.11.0'}
+        """
+    ]}
+
     it { should contain_class('kubernetes::dns') }
+    it { should contain_class('kubernetes::apiserver') }
 
     it 'should write systemd unit for applying' do
       should contain_file(core_service_file_apply).with_content(/User=kubernetes/)
       should contain_file(kube_service_file_delete).with_content(/User=kubernetes/)
     end
 
-    let(:pre_condition) {[
-        """
-      class{'kubernetes': version => '1.11.0'}
-      include kubernetes::apiserver
-        """
-    ]}
     it 'should write manifests' do
-      should contain_file(core_apply_manifests_file)
       should contain_file(core_apply_manifests_file)
       should contain_file(kube_delete_manifests_file).with_content(/--domain=cluster\.local\./)
       should contain_file(kube_delete_manifests_file).with_content(/clusterIP: 10\.254\.0\.10/)

--- a/puppet/modules/kubernetes/spec/classes/dns_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/dns_spec.rb
@@ -7,12 +7,36 @@ describe 'kubernetes::dns' do
     ]
   end
 
-  let :service_file do
+  let :kube_service_file_apply do
     '/etc/systemd/system/kubectl-apply-kube-dns.service'
   end
 
-  let :manifests_file do
+  let :kube_service_file_delete do
+    '/etc/systemd/system/kubectl-delete-kube-dns.service'
+  end
+
+  let :core_service_file_apply do
+    '/etc/systemd/system/kubectl-apply-core-dns.service'
+  end
+
+  let :core_service_file_delete do
+    '/etc/systemd/system/kubectl-delete-core-dns.service'
+  end
+
+  let :kube_apply_manifests_file do
     '/etc/kubernetes/apply/kube-dns.yaml'
+  end
+
+  let :core_apply_manifests_file do
+    '/etc/kubernetes/apply/core-dns.yaml'
+  end
+
+  let :kube_delete_manifests_file do
+    '/etc/kubernetes/delete/kube-dns.yaml'
+  end
+
+  let :core_delete_manifests_file do
+    '/etc/kubernetes/delete/core-dns.yaml'
   end
 
   context 'with default values for all parameters' do
@@ -20,12 +44,37 @@ describe 'kubernetes::dns' do
     it { should contain_class('kubernetes::dns') }
 
     it 'should write systemd unit for applying' do
-      should contain_file(service_file).with_content(/User=kubernetes/)
+      should contain_file(kube_service_file_apply).with_content(/User=kubernetes/)
+      should contain_file(core_service_file_delete).with_content(/User=kubernetes/)
     end
 
     it 'should write manifests' do
-      should contain_file(manifests_file).with_content(/--domain=cluster\.local\./)
-      should contain_file(manifests_file).with_content(/clusterIP: 10\.254\.0\.10/)
+      should contain_file(kube_apply_manifests_file).with_content(/--domain=cluster\.local\./)
+      should contain_file(kube_apply_manifests_file).with_content(/clusterIP: 10\.254\.0\.10/)
+      should contain_file(core_delete_manifests_file)
+      should contain_file(core_delete_manifests_file)
+    end
+  end
+
+  context 'with version 1.11' do
+    it { should contain_class('kubernetes::dns') }
+
+    it 'should write systemd unit for applying' do
+      should contain_file(core_service_file_apply).with_content(/User=kubernetes/)
+      should contain_file(kube_service_file_delete).with_content(/User=kubernetes/)
+    end
+
+    let(:pre_condition) {[
+        """
+      class{'kubernetes': version => '1.11.0'}
+      include kubernetes::apiserver
+        """
+    ]}
+    it 'should write manifests' do
+      should contain_file(core_apply_manifests_file)
+      should contain_file(core_apply_manifests_file)
+      should contain_file(kube_delete_manifests_file).with_content(/--domain=cluster\.local\./)
+      should contain_file(kube_delete_manifests_file).with_content(/clusterIP: 10\.254\.0\.10/)
     end
   end
 end

--- a/puppet/modules/kubernetes/templates/core-dns-cluster-role-binding.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-cluster-role-binding.yaml.erb
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system

--- a/puppet/modules/kubernetes/templates/core-dns-cluster-role.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-cluster-role.yaml.erb
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch

--- a/puppet/modules/kubernetes/templates/core-dns-config-map.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-config-map.yaml.erb
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        proxy . /etc/resolv.conf
+        cache 30
+        reload
+        loadbalance
+    }

--- a/puppet/modules/kubernetes/templates/core-dns-config-map.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-config-map.yaml.erb
@@ -8,7 +8,7 @@ data:
     .:53 {
         errors
         health
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+        kubernetes <%= @cluster_domain %> in-addr.arpa ip6.arpa {
           pods insecure
           upstream
           fallthrough in-addr.arpa ip6.arpa

--- a/puppet/modules/kubernetes/templates/core-dns-deployment.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-deployment.yaml.erb
@@ -4,7 +4,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    k8s-app: kube-dns
+    k8s-app: core-dns
     kubernetes.io/name: "CoreDNS"
 spec:
   replicas: 2
@@ -15,11 +15,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      k8s-app: kube-dns
+      k8s-app: core-dns
   template:
     metadata:
       labels:
-        k8s-app: kube-dns
+        k8s-app: core-dns
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
 <%- if @version_before_1_6 -%>

--- a/puppet/modules/kubernetes/templates/core-dns-deployment.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-deployment.yaml.erb
@@ -1,0 +1,86 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: "CoreDNS"
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+<%- if @version_before_1_6 -%>
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+<%- end -%>
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+      containers:
+      - name: coredns
+        image: coredns/coredns:1.2.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      dnsPolicy: Default
+<%- if @rbac_enabled -%>
+      serviceAccountName: coredns
+<%- end -%>

--- a/puppet/modules/kubernetes/templates/core-dns-horizontal-autoscaler-deployment.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-horizontal-autoscaler-deployment.yaml.erb
@@ -18,13 +18,13 @@ metadata:
   name: core-dns-autoscaler
   namespace: kube-system
   labels:
-    k8s-app: kube-dns-autoscaler
+    k8s-app: core-dns-autoscaler
     kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
-        k8s-app: kube-dns-autoscaler
+        k8s-app: core-dns-autoscaler
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
 <%- if @version_before_1_6 -%>

--- a/puppet/modules/kubernetes/templates/core-dns-horizontal-autoscaler-deployment.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-horizontal-autoscaler-deployment.yaml.erb
@@ -1,0 +1,59 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: core-dns-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns-autoscaler
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+<%- if @version_before_1_6 -%>
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+<%- end -%>
+    spec:
+      containers:
+      - name: autoscaler
+        image: <%= @autoscaler_image %>:<%= @autoscaler_version %>
+        resources:
+            requests:
+                cpu: "20m"
+                memory: "10Mi"
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace=kube-system
+          - --configmap=core-dns-autoscaler
+          # Should keep target in sync with cluster/addons/dns/kubedns-controller.yaml.base
+          - --target=Deployment/coredns
+          # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+          # If using small nodes, "nodesPerReplica" should dominate.
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":<%= @min_replicas %>,"preventSinglePointFailure":true}}
+          - --logtostderr=true
+          - --v=2
+<%- unless @version_before_1_6 -%>
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+<%- end -%>
+<%- if @rbac_enabled -%>
+      serviceAccountName: core-dns-autoscaler
+<%- end -%>

--- a/puppet/modules/kubernetes/templates/core-dns-horizontal-autoscaler-rbac.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-horizontal-autoscaler-rbac.yaml.erb
@@ -1,0 +1,62 @@
+<%- if @rbac_enabled -%>
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: core-dns-autoscaler
+  namespace: kube-system
+---
+kind: ClusterRole
+<%- if @version_before_1_6 -%>
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+<%- else -%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+<%- end -%>
+metadata:
+  name: system:core-dns-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+<%- if @version_before_1_6 -%>
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+<%- else -%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+<%- end -%>
+metadata:
+  name: system:core-dns-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: core-dns-autoscaler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:core-dns-autoscaler
+  apiGroup: rbac.authorization.k8s.io
+<%- end -%>

--- a/puppet/modules/kubernetes/templates/core-dns-service-account.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-service-account.yaml.erb
@@ -1,0 +1,7 @@
+<%- if @rbac_enabled -%>
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+<%- end -%>

--- a/puppet/modules/kubernetes/templates/core-dns-svc.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-svc.yaml.erb
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: <%= @cluster_dns %>
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP

--- a/puppet/modules/kubernetes/templates/core-dns-svc.yaml.erb
+++ b/puppet/modules/kubernetes/templates/core-dns-svc.yaml.erb
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-dns
+  name: core-dns
   namespace: kube-system
   annotations:
     prometheus.io/port: "9153"
     prometheus.io/scrape: "true"
   labels:
-    k8s-app: kube-dns
+    k8s-app: core-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
   selector:
-    k8s-app: kube-dns
+    k8s-app: core-dns
   clusterIP: <%= @cluster_dns %>
   ports:
   - name: dns

--- a/puppet/modules/kubernetes/templates/kube-dns-cluster-role-binding.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kube-dns-cluster-role-binding.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   annotations:

--- a/puppet/modules/kubernetes/templates/kube-dns-cluster-role-binding.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kube-dns-cluster-role-binding.yaml.erb
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:kube-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-dns
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system

--- a/puppet/modules/kubernetes/templates/kube-dns-cluster-role.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kube-dns-cluster-role.yaml.erb
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:kube-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - list
+  - watch

--- a/puppet/modules/kubernetes/templates/kube-dns-cluster-role.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kube-dns-cluster-role.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   annotations:

--- a/puppet/modules/kubernetes/templates/kube-dns-deployment.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kube-dns-deployment.yaml.erb
@@ -21,10 +21,6 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
   strategy:
     rollingUpdate:
       maxSurge: 10%
@@ -58,10 +54,6 @@ spec:
       - name: kubedns
         image: <%= @image %>:<%= @version %>
         resources:
-          # TODO: Set memory limits when we've profiled the container for large
-          # clusters, then set request = limit to keep this container in
-          # guaranteed class. Currently, this container falls into the
-          # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
             memory: 170Mi
           requests:
@@ -81,8 +73,6 @@ spec:
             path: /readiness
             port: 8081
             scheme: HTTP
-          # we poll on pod startup for the Kubernetes master service and
-          # only setup the /readiness HTTP server once that's available.
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:

--- a/puppet/modules/kubernetes/templates/kubectl-delete.service.erb
+++ b/puppet/modules/kubernetes/templates/kubectl-delete.service.erb
@@ -17,7 +17,7 @@ ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -k -w '%{h
 ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:<%= scope['kubernetes::_apiserver_insecure_port'] %>/healthz); if [ $STATUS -eq 200 ]; then break; fi; done"
 <%- end -%>
 # Apply template
-ExecStart=<%= @kubectl_path %> delete -f <%= @delete_file %>
+ExecStart=<%= @kubectl_path %> delete -f <%= @delete_file %> --ignore-not-found=true
 
 [Install]
 WantedBy=multi-user.target

--- a/puppet/modules/kubernetes/templates/kubectl-delete.service.erb
+++ b/puppet/modules/kubernetes/templates/kubectl-delete.service.erb
@@ -1,0 +1,23 @@
+[Unit]
+Description=kubectl delete <%= @name %>
+Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+<%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
+
+[Service]
+User=<%= scope['kubernetes::user'] %>
+Group=<%= scope['kubernetes::group'] %>
+Type=oneshot
+TimeoutStartSec=600
+Environment=KUBECONFIG=<%= scope['kubernetes::kubectl::kubeconfig_path'] %>
+RemainAfterExit=yes
+# Wait for API server to be healthy
+<%- if scope['kubernetes::_apiserver_insecure_port'] == 0 %>
+ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -k -w '%{http_code}' https://localhost:<%= scope['kubernetes::apiserver_secure_port'] %>/healthz); if [ $STATUS -eq 200 ]; then break; fi; done"
+<%- else -%>
+ExecStartPre=/bin/sh -c "while true; do STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:<%= scope['kubernetes::_apiserver_insecure_port'] %>/healthz); if [ $STATUS -eq 200 ]; then break; fi; done"
+<%- end -%>
+# Apply template
+ExecStart=<%= @kubectl_path %> delete -f <%= @delete_file %>
+
+[Install]
+WantedBy=multi-user.target

--- a/puppet/modules/kubernetes/templates/rbac-cluster-role-bindings.yaml.erb
+++ b/puppet/modules/kubernetes/templates/rbac-cluster-role-bindings.yaml.erb
@@ -85,23 +85,6 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
-    name: system:kube-dns
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:kube-dns
-  subjects:
-  - kind: ServiceAccount
-    name: kube-dns
-    namespace: kube-system
-- apiVersion: rbac.authorization.k8s.io/v1alpha1
-  kind: ClusterRoleBinding
-  metadata:
-    annotations:
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
-    labels:
-      kubernetes.io/bootstrapping: rbac-defaults
     name: system:kube-scheduler
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/puppet/modules/kubernetes/templates/rbac-cluster-roles.yaml.erb
+++ b/puppet/modules/kubernetes/templates/rbac-cluster-roles.yaml.erb
@@ -563,24 +563,6 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
-    name: system:kube-dns
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - endpoints
-    - services
-    verbs:
-    - list
-    - watch
-- apiVersion: rbac.authorization.k8s.io/v1alpha1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
-    labels:
-      kubernetes.io/bootstrapping: rbac-defaults
     name: system:kube-scheduler
   rules:
   - apiGroups:

--- a/puppet/modules/tarmak/spec/acceptance/single_node_spec.rb
+++ b/puppet/modules/tarmak/spec/acceptance/single_node_spec.rb
@@ -111,15 +111,15 @@ class{'tarmak::single_node':
     end
 
     it 'should have three ready dns pods', :retry => 20, :retry_wait => 5 do
-      result = shell('kubectl get pods --namespace kube-system -l k8s-app=kube-dns')
+      result = shell('kubectl get pods --namespace kube-system -l k8s-app=core-dns')
       logger.notify "kubectl get pods:\n#{result.stdout}"
       expect(result.exit_code).to eq(0)
       expect(result.stdout.scan(/Running/m).size).to eq(3)
       expect(result.stdout.scan(/(4\/4|3\/3)/m).size).to eq(3)
     end
 
-    it 'should have a ready dns autoscaler pod', :retry => 20, :retry_wait => 5 do
-      result = shell('kubectl get pods --namespace kube-system -l k8s-app=kube-dns-autoscaler')
+    it 'should have a ready core autoscaler pod', :retry => 20, :retry_wait => 5 do
+      result = shell('kubectl get pods --namespace kube-system -l k8s-app=core-dns-autoscaler')
       logger.notify "kubectl get pods:\n#{result.stdout}"
       expect(result.exit_code).to eq(0)
       expect(result.stdout.scan(/Running/m).size).to eq(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use core-dns instead of kube-dns by default for clusters >= 1.10


Ensures that kube-dns is replaced by core-dns when upgrading >= 1.10 and visa-versa.

fixes #422 

```release-note
Default to core-dns over kube-dns for clusters >= 1.10
```
