### PR TITLE
Adds spot-pricing flag for quick best effort calculation + docs

### DIFF
--- a/cmd/tarmak/cmd/cluster.go
+++ b/cmd/tarmak/cmd/cluster.go
@@ -34,6 +34,15 @@ func clusterApplyFlags(fs *flag.FlagSet) {
 		false,
 		"apply changes to infrastructure only, by running only terraform",
 	)
+
+	fs.BoolVarP(
+		&store.SpotPricing,
+		"spot-pricing",
+		"P",
+		false,
+		"Use a best effort spot pricing based on last 3 days pricing for instance pools",
+	)
+
 }
 
 func clusterDestroyFlags(fs *flag.FlagSet) {

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -700,6 +700,39 @@ policy permissions. `Information on how to correctly set these permissions can
 be found here
 <https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy>`_.
 
+Spot Instances
+~~~~~~~~~~~~~~
+Tarmak gives the ability to attempt to request spot instances for use in
+instance pools. Spot instances are very cheap, spare AWS instances that can be
+revoked by AWS at any time, given a 2 minute notification. `More information
+here <https://aws.amazon.com/ec2/spot/>`_.
+
+Spot instances can be requested cluster-wide by giving the ``--spot-pricing``
+flag to ``cluster apply``. Tarmak will then attempt a best effort spot price for
+each instance pool in the cluster, calculated as the average spot price in the
+last 3 days for that instance type in each zone plus 25%.
+
+Manual spot prices can be applied to each instance pool within the
+``tarmak.yaml`` which will override the Tarmak best effort for that instance
+pool. This is done through the ``spotPrice`` attribute under the instance pool,
+given as a number in USD. This can be added like so:
+
+.. code-block:: yaml
+
+  - image: centos-puppet-agent
+    maxCount: 3
+    metadata:
+      creationTimestamp: "2018-07-27T09:33:15Z"
+      name: worker
+    minCount: 3
+    size: medium
+    spotPrice: 0.015
+
+
+Note that Tarmak will only attempt to create spot instances for instance pools
+with the ``spotPrice`` attribute or spot pricing flag during a cluster apply.
+
+
 Cluster Services
 ----------------
 
@@ -721,3 +754,4 @@ Do the following steps to access Grafana:
 .. code-block:: none
 
   http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/
+

--- a/pkg/apis/tarmak/v1alpha1/types.go
+++ b/pkg/apis/tarmak/v1alpha1/types.go
@@ -143,6 +143,8 @@ type ClusterApplyFlags struct {
 	InfrastructureOnly   bool     // only run terraform
 
 	ConfigurationOnly bool // only run puppet
+
+	SpotPricing bool // Use spot pricing for all applied instances at best effort according to last 3 days pricing. Spot prices in config will override this option per instance pool.
 }
 
 // Contains the cluster destroy flags

--- a/pkg/tarmak/instance_pool/instance_pool.go
+++ b/pkg/tarmak/instance_pool/instance_pool.go
@@ -173,7 +173,7 @@ func (n *InstancePool) SpotPrice() string {
 }
 
 func (n *InstancePool) CalculateSpotPrice() error {
-	if n.spotPrice != "" {
+	if n.spotPrice == "" {
 		p, err := n.cluster.Environment().Provider().SpotPrice(n)
 		if err != nil {
 			return err

--- a/pkg/tarmak/instance_pool/instance_pool.go
+++ b/pkg/tarmak/instance_pool/instance_pool.go
@@ -33,6 +33,7 @@ type InstancePool struct {
 	rootVolume *Volume
 
 	instanceType string
+	spotPrice    string
 
 	role *role.Role
 }
@@ -77,7 +78,7 @@ func NewFromConfig(cluster interfaces.Cluster, conf *clusterv1alpha1.InstancePoo
 		return nil, fmt.Errorf("minCount does not equal maxCount but role is stateful. minCount=%d maxCount=%d", instancePool.Config().MinCount, instancePool.Config().MaxCount)
 	}
 
-	var result error
+	var result *multierror.Error
 
 	count := 0
 	for pos, _ := range conf.Volumes {
@@ -98,7 +99,9 @@ func NewFromConfig(cluster interfaces.Cluster, conf *clusterv1alpha1.InstancePoo
 		return nil, errors.New("no root volume given")
 	}
 
-	return instancePool, result
+	instancePool.spotPrice = conf.SpotPrice
+
+	return instancePool, result.ErrorOrNil()
 }
 
 func (n *InstancePool) Role() *role.Role {
@@ -166,7 +169,20 @@ func (n *InstancePool) InstanceType() string {
 }
 
 func (n *InstancePool) SpotPrice() string {
-	return n.conf.SpotPrice
+	return n.spotPrice
+}
+
+func (n *InstancePool) CalculateSpotPrice() error {
+	if n.spotPrice != "" {
+		p, err := n.cluster.Environment().Provider().SpotPrice(n)
+		if err != nil {
+			return err
+		}
+
+		n.spotPrice = fmt.Sprint(p)
+	}
+
+	return nil
 }
 
 func (n *InstancePool) AmazonAdditionalIAMPolicies() string {

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -127,6 +127,7 @@ type Provider interface {
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
 	VerifyInstanceTypes(intstancePools []InstancePool) error
+	SpotPrice(instancePool InstancePool) (float64, error)
 }
 
 type Tarmak interface {
@@ -254,6 +255,7 @@ type InstancePool interface {
 	InstanceType() string
 	Labels() (string, error)
 	Taints() (string, error)
+	CalculateSpotPrice() error
 }
 
 type Volume interface {

--- a/pkg/tarmak/provider/amazon/spot_price.go
+++ b/pkg/tarmak/provider/amazon/spot_price.go
@@ -1,0 +1,74 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package amazon
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
+)
+
+func (a *Amazon) SpotPrice(instancePool interfaces.InstancePool) (float64, error) {
+	sess, err := a.Session()
+	if err != nil {
+		return 0, err
+	}
+
+	svc := ec2.New(sess)
+
+	instanceType, err := a.InstanceType(instancePool.Config().Size)
+	if err != nil {
+		return 0, err
+	}
+
+	timeToColect := time.Now().Add(-24 * 3 * time.Hour)
+
+	var result *multierror.Error
+	var prices []float64
+	for _, zone := range instancePool.Zones() {
+		spotPriceRequestInput := &ec2.DescribeSpotPriceHistoryInput{
+			InstanceTypes: []*string{
+				aws.String(instanceType),
+			},
+			ProductDescriptions: []*string{
+				aws.String("Linux/UNIX"),
+			},
+			AvailabilityZone: aws.String(zone),
+			StartTime:        &timeToColect,
+		}
+
+		output, err := svc.DescribeSpotPriceHistory(spotPriceRequestInput)
+		if err != nil {
+			result = multierror.Append(result, fmt.Errorf("failed to get current spot price of instance type '%s': %v", instanceType, err))
+			continue
+		}
+
+		for _, entry := range output.SpotPriceHistory {
+			price, err := strconv.ParseFloat(*entry.SpotPrice, 64)
+			if err != nil {
+				result = multierror.Append(result, fmt.Errorf("failed to parse spot price '%s': %v", *entry.SpotPrice, err))
+				continue
+			}
+
+			prices = append(prices, price)
+		}
+	}
+
+	var total float64
+	for _, price := range prices {
+		total += price
+	}
+
+	if len(prices) != 0 {
+		total /= float64(len(prices))
+	}
+
+	total *= 1.10
+
+	return total, result.ErrorOrNil()
+}

--- a/pkg/tarmak/provider/amazon/spot_price.go
+++ b/pkg/tarmak/provider/amazon/spot_price.go
@@ -68,7 +68,7 @@ func (a *Amazon) SpotPrice(instancePool interfaces.InstancePool) (float64, error
 		total /= float64(len(prices))
 	}
 
-	total *= 1.10
+	total *= 1.25
 
 	return total, result.ErrorOrNil()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds spot-pricing flag to cluster apply command. This will apply a best effort spot price to each instance pool based on an average of the last 3 days pricing + 25%.

Adds documentation for spot pricing.

fixes #451 
fixes #452 

```release-note
Adds spot-pricing flag to cluster apply
```
