### PR TITLE
Change root url for Grafana

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -84,3 +84,4 @@ preempted
 millicores
 yaml
 autoscale
+Grafana

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -674,3 +674,25 @@ You add labels and taints in the tarmak yaml like this:
 **Note**, these are only applied when the node is first registered. Changes to
 these values will not remove taints and labels from nodes that are already
 registered.
+
+Cluster Services
+----------------
+
+Grafana
+~~~~~~~
+
+Grafana is deployed as part of Tarmak. You can access Grafana through a
+`Kubernetes cluster service <https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/>`_.
+Do the following steps to access Grafana:
+
+1. Create a proxy
+
+.. code-block:: bash
+
+    tarmak kubectl proxy
+
+2. In the browser go to
+
+.. code-block:: none
+
+  http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/

--- a/puppet/modules/kubernetes_addons/templates/grafana-deployment.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/grafana-deployment.yaml.erb
@@ -37,7 +37,7 @@ spec:
         - name: GF_AUTH_ANONYMOUS_ORG_ROLE
           value: Admin
         - name: GF_SERVER_ROOT_URL
-          value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+          value: /api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/
         image: <%= @grafana_image %>:<%= @grafana_version %>
         imagePullPolicy: IfNotPresent
         name: grafana


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The place of the proxy got changed in the root url. Kubernetes reports grafana to be available at https://127.0.0.1:54240/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy. This brings the Grafana config to the same level.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #450

**Special notes for your reviewer**:
I tested this on `1.10.5` and `1.9.10`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix grafana in cluster service
```
