### PR TITLE
Validate Jenkins as a valid instance pool for hub

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -129,6 +129,7 @@ func (c *Cluster) validateClusterInstancePoolTypes() error {
 		poolMap = map[string]bool{
 			clusterv1alpha1.InstancePoolTypeVault:   true,
 			clusterv1alpha1.InstancePoolTypeBastion: true,
+			clusterv1alpha1.InstancePoolTypeJenkins: true,
 		}
 
 		break

--- a/pkg/tarmak/cluster/cluster_test.go
+++ b/pkg/tarmak/cluster/cluster_test.go
@@ -238,12 +238,12 @@ func TestCluster_ValidateClusterInstancePoolTypesHub(t *testing.T) {
 	passTypes := []string{
 		clusterv1alpha1.InstancePoolTypeBastion,
 		clusterv1alpha1.InstancePoolTypeVault,
+		clusterv1alpha1.InstancePoolTypeJenkins,
 	}
 	failTypes := []string{
 		clusterv1alpha1.InstancePoolTypeMaster,
 		clusterv1alpha1.InstancePoolTypeWorker,
 		clusterv1alpha1.InstancePoolTypeEtcd,
-		clusterv1alpha1.InstancePoolTypeJenkins,
 	}
 	tryInstancePoolTypes(c, passTypes, failTypes, t)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It needs to be possible to setup a Jenkins server in the hub.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Jenkins is a valid instancepool for hub
```
