### PR TITLE
Applies hot fix for class loop in airworthy module

### DIFF
--- a/puppet/hieradata/role/etcd.yaml
+++ b/puppet/hieradata/role/etcd.yaml
@@ -1,6 +1,6 @@
 ---
 classes:
 - tarmak::etcd
-- airworthy::install
+- airworthy
 
 tarmak::hostname: "%{::tarmak_hostname}"

--- a/puppet/modules/airworthy/manifests/init.pp
+++ b/puppet/modules/airworthy/manifests/init.pp
@@ -30,4 +30,5 @@ class airworthy (
   }
 
   class { '::airworthy::install': }
+  -> Class['::airworthy']
 }

--- a/puppet/modules/airworthy/manifests/init.pp
+++ b/puppet/modules/airworthy/manifests/init.pp
@@ -30,5 +30,4 @@ class airworthy (
   }
 
   class { '::airworthy::install': }
-  -> Class['::airworthy']
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Airworthy puppet module had a class loop which this PR fixes

```release-note
NONE
```

/assign @dippynark @simonswine 
