### PR TITLE
Add metrics server

### DIFF
--- a/puppet/hieradata/role/master.yaml
+++ b/puppet/hieradata/role/master.yaml
@@ -3,6 +3,7 @@ classes:
 - tarmak::worker
 - tarmak::overlay_calico
 - kubernetes_addons::heapster
+- kubernetes_addons::metrics_server
 - kubernetes_addons::influxdb
 - kubernetes_addons::grafana
 

--- a/puppet/modules/kubernetes_addons/manifests/metrics_server.pp
+++ b/puppet/modules/kubernetes_addons/manifests/metrics_server.pp
@@ -1,0 +1,54 @@
+class kubernetes_addons::metrics_server(
+  Optional[String] $version=undef,
+  String $image='gcr.io/google_containers/metrics-server-amd64',
+  String $cpu='40m',
+  String $mem='100Mi',
+  String $extra_cpu='0.5m',
+  String $extra_mem='4Mi',
+  String $nanny_version='1.8.1',
+  String $nanny_image='gcr.io/google_containers/addon-resizer',
+  String $nanny_request_cpu='5m',
+  String $nanny_request_mem='50Mi',
+  String $nanny_limit_cpu='100m',
+  String $nanny_limit_mem='300Mi',
+) inherits ::kubernetes_addons::params {
+  require ::kubernetes
+
+  if $version == undef {
+    if versioncmp($::kubernetes::version, '1.8.0') >= 0 {
+      $_version = '0.3.0'
+    } else {
+      $_version = '0.1.0'
+    }
+  } else {
+    $_version = $version
+  }
+
+  if versioncmp($::kubernetes::version, '1.8.0') >= 0 {
+    $version_before_1_8 = false
+  } else {
+    $version_before_1_8 = true
+  }
+
+  if versioncmp($::kubernetes::version, '1.9.0') >= 0 {
+    $version_before_1_9 = false
+  } else {
+    $version_before_1_9 = true
+  }
+
+  $authorization_mode = $::kubernetes::_authorization_mode
+  if member($authorization_mode, 'RBAC'){
+    $rbac_enabled = true
+  } else {
+    $rbac_enabled = false
+  }
+
+  if versioncmp($::kubernetes::version, '1.7.0') >= 0 {
+    kubernetes::apply{'metrics-server':
+      manifests => [
+        template('kubernetes_addons/metrics-server.yaml.erb'),
+        template('kubernetes_addons/metrics-server-rbac.yaml.erb'),
+      ],
+    }
+  }
+}

--- a/puppet/modules/kubernetes_addons/spec/classes/metrics_server_spec.rb
+++ b/puppet/modules/kubernetes_addons/spec/classes/metrics_server_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+describe 'kubernetes_addons::metrics_server' do
+  let(:pre_condition) do
+    "
+      class kubernetes{
+        $_authorization_mode = ['RBAC']
+        $version = '1.8.0'
+      }
+      define kubernetes::apply(
+        $manifests,
+      ){}
+    "
+  end
+
+  let(:manifests) do
+    catalogue.resource('Kubernetes::Apply', 'metrics-server').send(:parameters)[:manifests]
+  end
+
+  context 'with defaults' do
+    it 'be valid yaml' do
+      manifests.each do |manifest|
+        YAML.parse manifest
+      end
+    end
+
+    it 'have image set' do
+      expect(manifests[0]).to match(%{^[-\s].*image: [^:]+:[^:]+$})
+    end
+
+    it 'have resources set' do
+      expect(manifests[0]).to match(%{^[-\s].*cpu: [0-9]+})
+      expect(manifests[0]).to match(%{^[-\s].*memory: [0-9]+})
+    end
+
+    it 'have nanny options set' do
+      expect(manifests[0]).to match(%{^[-\s].*- --cpu=[0-9]+})
+      expect(manifests[0]).to match(%{^[-\s].*- --memory=[0-9]+})
+      expect(manifests[0]).to match(%{^[-\s].*- --extra-cpu=[0-9]+})
+      expect(manifests[0]).to match(%{^[-\s].*- --extra-memory=[0-9]+})
+    end
+    context 'minikube tests' do
+      after(:each) do
+          kubectl_delete(manifests) if @minikube_cleanup
+      end
+
+      it 'deploy healthy app', :minikube => true do
+        skip "minikube unstable"
+        @minikube_cleanup = true
+        expect(
+          minikube_apply(manifests)
+        ).to eq(0)
+
+        retries = 10
+        begin
+          ready_replicas = kubectl_get('deployment','kube-system', 'metrics-server')['status']['readyReplicas']
+          raise "deployment not healthy" if ready_replicas != 1
+        rescue Exception => e
+          retries -= 1
+          raise e if retries == 0
+          sleep 5
+          retry
+        end
+      end
+    end
+  end
+end

--- a/puppet/modules/kubernetes_addons/templates/metrics-server-rbac.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/metrics-server-rbac.yaml.erb
@@ -1,0 +1,93 @@
+# This file should be kept in sync with https://github.com/kubernetes-incubator/metrics-server/tree/master/deploy
+<% if @rbac_enabled -%>
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+---
+<% if @version_before_1_8 -%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+<% else -%>
+apiVersion: rbac.authorization.k8s.io/v1
+<% end -%>
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+<% if @version_before_1_8 -%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+<% else -%>
+apiVersion: rbac.authorization.k8s.io/v1
+<% end -%>
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+<% unless @version_before_1_8 -%>
+<% if @version_before_1_8 -%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+<% else -%>
+apiVersion: rbac.authorization.k8s.io/v1
+<% end -%>
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+<% if @version_before_1_8 -%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+<% else -%>
+apiVersion: rbac.authorization.k8s.io/v1
+<% end -%>
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+<% end -%>
+<% end -%>

--- a/puppet/modules/kubernetes_addons/templates/metrics-server.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/metrics-server.yaml.erb
@@ -1,0 +1,138 @@
+# This file should be kept in sync with https://github.com/kubernetes-incubator/metrics-server/tree/master/deploy
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+<% if @version_before_1_8 -%>
+  name: v1alpha1.metrics
+<% else -%>
+  name: v1beta1.metrics.k8s.io
+<% end -%>
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+<% if @version_before_1_8 -%>
+  group: metrics
+  version: v1alpha1
+<% else -%>
+  group: metrics.k8s.io
+  version: v1beta1
+<% end -%>
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+<% if @version_before_1_9 -%>
+apiVersion: extensions/v1beta1
+<% else -%>
+apiVersion: apps/v1
+<% end -%>
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+<% if @rbac_enabled -%>
+      serviceAccountName: metrics-server
+<% end -%>
+      containers:
+      - name: metrics-server-nanny
+        image: <%= @nanny_image %>:<%= @nanny_version %>
+        command:
+        - /pod_nanny
+        - --config-dir=/etc/config
+        - --cpu=<%= @cpu %>
+        - --extra-cpu=<%= @extra_cpu %>
+        - --memory=<%= @mem %>
+        - --extra-memory=<%= @extra_mem %>
+        - --threshold=5
+        - --deployment=metrics-server
+        - --container=metrics-server
+        - --poll-period=300000
+        - --estimator=exponential
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          limits:
+            cpu: <%= @nanny_limit_cpu %>
+            memory: <%= @nanny_limit_mem %>
+          requests:
+            cpu: <%= @nanny_request_cpu %>
+            memory: <%= @nanny_request_mem %>
+        volumeMounts:
+        - mountPath: /etc/config
+          name: metrics-server-config-volume
+      - name: metrics-server
+        image: <%= @image %>:v<%= @_version %> 
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: <%= @cpu %>
+            memory: <%= @mem %>
+          requests:
+            cpu: <%= @cpu %>
+            memory: <%= @mem %>
+<% unless @version_before_1_8 -%>
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+<% end -%>
+      volumes:
+      - name: metrics-server-config-volume
+        configMap:
+          name: metrics-server-config
+<% unless @version_before_1_8 -%>
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
+<% end -%>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Metrics-server"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-server-config
+  namespace: kube-system
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration


### PR DESCRIPTION
**What this PR does / why we need it**: Adds metrics server as a default add-on from Kubernetes 1.7 onwards

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: related to #427 

```release-note
Add metrics-server add-on from Kubernetes version 1.7 onwards
```
