### PR TITLE
Only converge on wing when not in infrastructure only

### DIFF
--- a/cmd/tarmak/cmd/cluster.go
+++ b/cmd/tarmak/cmd/cluster.go
@@ -55,6 +55,14 @@ func clusterApplyFlags(fs *flag.FlagSet) {
 		consts.DefaultPlanLocationPlaceholder,
 		"location of stored terraform plan executable file to be used",
 	)
+
+	fs.BoolVarP(
+		&store.WaitForConvergence,
+		"wait-for-convergence",
+		"W",
+		true,
+		"wait for wing convergence on applied instances",
+	)
 }
 
 func clusterDestroyFlags(fs *flag.FlagSet) {

--- a/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
+++ b/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
@@ -27,6 +27,7 @@ Options
   -h, --help                         help for apply
   -I, --infrastructure-only          apply changes to infrastructure only, by running only terraform
   -P, --plan-file-location string    location of stored terraform plan executable file to be used (default "${TARMAK_CONFIG}/${CURRENT_CLUSTER}/terraform/tarmak.plan")
+  -W, --wait-for-convergence         wait for wing convergence on applied instances (default true)
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/generated/reference/output/api-docs.html
+++ b/docs/generated/reference/output/api-docs.html
@@ -538,6 +538,10 @@ Appears In:
 <td><code>planFileLocation</code><br /> <em>string</em></td>
 <td></td>
 </tr>
+<tr>
+<td><code>waitForConvergence</code><br /> <em>boolean</em></td>
+<td>file location where plan file is to be used</td>
+</tr>
 </tbody>
 </table>
 <h2 id="clusterdestroyflags-v1alpha1">ClusterDestroyFlags v1alpha1</h2>

--- a/pkg/apis/tarmak/v1alpha1/types.go
+++ b/pkg/apis/tarmak/v1alpha1/types.go
@@ -161,8 +161,8 @@ type ClusterApplyFlags struct {
 	AutoApprove             bool `json:"autoApprove,omitempty"`             // auto approve apply queries
 	AutoApproveDeletingData bool `json:"autoApproveDeletingData,omitempty"` // auto approve apply queries about deleting data
 
-	PlanFileLocation   string `json:"planFileLocation,omitempty"`  // file location where plan file is to be used
-	WaitForConvergence bool   `json"waitForConvergence,omitempty"` // wait for wing convergence when applying
+	PlanFileLocation   string `json:"planFileLocation,omitempty"`   // file location where plan file is to be used
+	WaitForConvergence bool   `json:"waitForConvergence,omitempty"` // wait for wing convergence when applying
 }
 
 // Contains the cluster destroy flags

--- a/pkg/apis/tarmak/v1alpha1/types.go
+++ b/pkg/apis/tarmak/v1alpha1/types.go
@@ -161,7 +161,8 @@ type ClusterApplyFlags struct {
 	AutoApprove             bool `json:"autoApprove,omitempty"`             // auto approve apply queries
 	AutoApproveDeletingData bool `json:"autoApproveDeletingData,omitempty"` // auto approve apply queries about deleting data
 
-	PlanFileLocation string `json:"planFileLocation,omitempty"` // file location where plan file is to be used
+	PlanFileLocation   string `json:"planFileLocation,omitempty"`  // file location where plan file is to be used
+	WaitForConvergence bool   `json"waitForConvergence,omitempty"` // wait for wing convergence when applying
 }
 
 // Contains the cluster destroy flags

--- a/pkg/tarmak/cmd.go
+++ b/pkg/tarmak/cmd.go
@@ -53,7 +53,8 @@ func (c *CmdTarmak) Apply() error {
 		return err
 	}
 
-	hasChanged := false
+	// assume a change so that we wait for convergence in configuration only
+	hasChanged := true
 	// run terraform apply always, do not run it when in configuration only mode
 	if !c.flags.Cluster.Apply.ConfigurationOnly {
 		hasChanged, err = c.terraform.Apply(c.Cluster())

--- a/pkg/tarmak/cmd.go
+++ b/pkg/tarmak/cmd.go
@@ -82,10 +82,12 @@ func (c *CmdTarmak) Apply() error {
 	default:
 	}
 
-	// wait for convergance in every mode
-	err := c.Cluster().WaitForConvergance()
-	if err != nil {
-		return err
+	// wait for convergance if not in infrastructure only
+	if !c.flags.Cluster.Apply.InfrastructureOnly {
+		err := c.cluster.WaitForConvergance()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/tarmak/cmd.go
+++ b/pkg/tarmak/cmd.go
@@ -48,13 +48,15 @@ func (c *CmdTarmak) Plan() (returnCode int, err error) {
 }
 
 func (c *CmdTarmak) Apply() error {
-	if err := c.setup(); err != nil {
+	err := c.setup()
+	if err != nil {
 		return err
 	}
 
+	hasChanged := false
 	// run terraform apply always, do not run it when in configuration only mode
 	if !c.flags.Cluster.Apply.ConfigurationOnly {
-		err := c.terraform.Apply(c.Cluster())
+		hasChanged, err = c.terraform.Apply(c.Cluster())
 		if err != nil {
 			return err
 		}
@@ -82,9 +84,9 @@ func (c *CmdTarmak) Apply() error {
 	default:
 	}
 
-	// wait for convergance if flag enabled
-	if c.flags.Cluster.Apply.WaitForConvergence {
-		err := c.cluster.WaitForConvergance()
+	// wait for convergance if flag enabled and has changed
+	if hasChanged && c.flags.Cluster.Apply.WaitForConvergence {
+		err := c.Cluster().WaitForConvergance()
 		if err != nil {
 			return err
 		}

--- a/pkg/tarmak/cmd.go
+++ b/pkg/tarmak/cmd.go
@@ -82,8 +82,8 @@ func (c *CmdTarmak) Apply() error {
 	default:
 	}
 
-	// wait for convergance if not in infrastructure only
-	if !c.flags.Cluster.Apply.InfrastructureOnly {
+	// wait for convergance if flag enabled
+	if c.flags.Cluster.Apply.WaitForConvergence {
 		err := c.cluster.WaitForConvergance()
 		if err != nil {
 			return err

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -462,15 +462,9 @@ func (t *Terraform) Plan(cluster interfaces.Cluster, preApply bool) (changesNeed
 
 func (t *Terraform) Apply(cluster interfaces.Cluster) (hasChanged bool, err error) {
 	// generate a plan
-<<<<<<< HEAD
 	changesNeeded, err := t.Plan(cluster, true)
 	if err != nil || !changesNeeded {
 		return false, err
-=======
-	changesNeeded, err := t.Plan(cluster)
-	if err != nil || !changesNeeded {
-		return changesNeeded, err
->>>>>>> Uses variable when returning
 	}
 
 	// break after sigterm

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -462,15 +462,21 @@ func (t *Terraform) Plan(cluster interfaces.Cluster, preApply bool) (changesNeed
 
 func (t *Terraform) Apply(cluster interfaces.Cluster) (hasChanged bool, err error) {
 	// generate a plan
+<<<<<<< HEAD
 	changesNeeded, err := t.Plan(cluster, true)
 	if err != nil || !changesNeeded {
 		return false, err
+=======
+	changesNeeded, err := t.Plan(cluster)
+	if err != nil || !changesNeeded {
+		return changesNeeded, err
+>>>>>>> Uses variable when returning
 	}
 
 	// break after sigterm
 	select {
 	case <-t.ctx.Done():
-		return false, t.ctx.Err()
+		return changesNeeded, t.ctx.Err()
 	default:
 	}
 
@@ -480,7 +486,7 @@ func (t *Terraform) Apply(cluster interfaces.Cluster) (hasChanged bool, err erro
 	}
 
 	// apply necessary at this point
-	return true, t.terraformWrapper(
+	return changesNeeded, t.terraformWrapper(
 		cluster,
 		"apply",
 		[]string{planFilePath},

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -460,27 +460,27 @@ func (t *Terraform) Plan(cluster interfaces.Cluster, preApply bool) (changesNeed
 	return changesNeeded, nil
 }
 
-func (t *Terraform) Apply(cluster interfaces.Cluster) error {
+func (t *Terraform) Apply(cluster interfaces.Cluster) (hasChanged bool, err error) {
 	// generate a plan
 	changesNeeded, err := t.Plan(cluster, true)
 	if err != nil || !changesNeeded {
-		return err
+		return false, err
 	}
 
 	// break after sigterm
 	select {
 	case <-t.ctx.Done():
-		return t.ctx.Err()
+		return false, t.ctx.Err()
 	default:
 	}
 
 	planFilePath, err := t.planFileLocation(cluster)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// apply necessary at this point
-	return t.terraformWrapper(
+	return true, t.terraformWrapper(
 		cluster,
 		"apply",
 		[]string{planFilePath},


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't wait for wing to converge when we're not in infrastructure only

fixes #475

```release-note
Don't wait for wing conversion when we're not in infrastructure only
```
