### PR TITLE
Change threshold to greater than or equal to

### DIFF
--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -206,7 +206,7 @@ resource "aws_cloudwatch_metric_alarm" "autorecover_{{.TFName}}" {
   alarm_description   = "This metric auto recovers EC2 instances"
   alarm_actions       = ["arn:aws:automate:${var.region}:ec2:recover"]
   statistic           = "Minimum"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "1"
   metric_name         = "StatusCheckFailed_System"
 

--- a/terraform/amazon/templates/vault_instances.tf.template
+++ b/terraform/amazon/templates/vault_instances.tf.template
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "vault-autorecover" {
   alarm_description   = "This metric auto recovers Vault instances for the ${var.environment} cluster"
   alarm_actions       = ["arn:aws:automate:${var.region}:ec2:recover"]
   statistic           = "Minimum"
-  comparison_operator = "GreaterThanThreshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "1"
   metric_name         = "StatusCheckFailed_System"
 


### PR DESCRIPTION
**What this PR does / why we need it**: The `StatusCheckFailed_System` is a binary value so we must check for when the metric equals one

```release-note
Fix autorecovery threshold for cloudwatch alarms
```
