### PR TITLE
KMS encrypt terraform remote state

### DIFF
--- a/pkg/packer/image.go
+++ b/pkg/packer/image.go
@@ -43,7 +43,7 @@ func (i *image) tags() map[string]string {
 	return map[string]string{
 		tarmakv1alpha1.ImageTagEnvironment:   i.environment,
 		tarmakv1alpha1.ImageTagBaseImageName: i.imageName,
-		"region": i.tarmak.Provider().Region(),
+		"region":                             i.tarmak.Provider().Region(),
 	}
 }
 

--- a/pkg/packer/image.go
+++ b/pkg/packer/image.go
@@ -43,7 +43,7 @@ func (i *image) tags() map[string]string {
 	return map[string]string{
 		tarmakv1alpha1.ImageTagEnvironment:   i.environment,
 		tarmakv1alpha1.ImageTagBaseImageName: i.imageName,
-		"region":                             i.tarmak.Provider().Region(),
+		"region": i.tarmak.Provider().Region(),
 	}
 }
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -34,6 +34,7 @@ type Amazon struct {
 	tarmak interfaces.Tarmak
 
 	availabilityZones *[]string
+	remoteStateKMS    string
 
 	session  *session.Session
 	ec2      EC2
@@ -352,7 +353,15 @@ func (a *Amazon) Verify() error {
 
 	// These checks only make sense with an environment given
 	if a.tarmak.Environment() != nil {
+		if err := a.verifyRemoteStateKMS(); err != nil {
+			result = multierror.Append(result, err)
+		}
+
 		if err := a.verifyRemoteStateBucket(); err != nil {
+			result = multierror.Append(result, err)
+		}
+
+		if err := a.verifyRemoteStateBucketEncrytion(); err != nil {
 			result = multierror.Append(result, err)
 		}
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -54,6 +54,7 @@ type S3 interface {
 	PutBucketVersioning(input *s3.PutBucketVersioningInput) (*s3.PutBucketVersioningOutput, error)
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 	PutBucketEncryption(input *s3.PutBucketEncryptionInput) (*s3.PutBucketEncryptionOutput, error)
+	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 }
 
 type EC2 interface {
@@ -300,7 +301,7 @@ func (a *Amazon) Variables() map[string]interface{} {
 	output["public_zone"] = a.conf.Amazon.PublicZone
 	output["public_zone_id"] = a.conf.Amazon.PublicHostedZoneID
 	output["bucket_prefix"] = a.conf.Amazon.BucketPrefix
-	output["remote_kms_key_id"] = a.RemoteStateKMSName()
+	output["remote_kms_key_id"] = a.remoteStateKMS
 
 	return output
 }

--- a/pkg/tarmak/provider/amazon/amazon_test.go
+++ b/pkg/tarmak/provider/amazon/amazon_test.go
@@ -52,7 +52,7 @@ func newFakeAmazon(t *testing.T) *fakeAmazon {
 	return f
 }
 
-func TestAmazon_validateAvailabilityZonesNoneGiven(t *testing.T) {
+func TestAmazon_verifyAvailabilityZonesNoneGiven(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -79,7 +79,7 @@ func TestAmazon_validateAvailabilityZonesNoneGiven(t *testing.T) {
 		},
 	}, nil)
 
-	err := a.validateAvailabilityZones()
+	err := a.verifyAvailabilityZones()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -89,7 +89,7 @@ func TestAmazon_validateAvailabilityZonesNoneGiven(t *testing.T) {
 	}
 }
 
-func TestAmazon_validateAvailabilityZonesCorrectGiven(t *testing.T) {
+func TestAmazon_verifyAvailabilityZonesCorrectGiven(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -123,7 +123,7 @@ func TestAmazon_validateAvailabilityZonesCorrectGiven(t *testing.T) {
 		},
 	}, nil)
 
-	err := a.validateAvailabilityZones()
+	err := a.verifyAvailabilityZones()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -133,7 +133,7 @@ func TestAmazon_validateAvailabilityZonesCorrectGiven(t *testing.T) {
 	}
 }
 
-func TestAmazon_validateAvailabilityZonesFalseGiven(t *testing.T) {
+func TestAmazon_verifyAvailabilityZonesFalseGiven(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -171,7 +171,7 @@ func TestAmazon_validateAvailabilityZonesFalseGiven(t *testing.T) {
 		},
 	}, nil)
 
-	err := a.validateAvailabilityZones()
+	err := a.verifyAvailabilityZones()
 	if err == nil {
 		t.Error("expected an error")
 	} else if !strings.Contains(err.Error(), "specified invalid availability zone") {

--- a/pkg/tarmak/provider/amazon/key_pair.go
+++ b/pkg/tarmak/provider/amazon/key_pair.go
@@ -40,7 +40,7 @@ func fingerprintAWSStyle(signer interface{}) (string, error) {
 	}
 }
 
-func (a *Amazon) validateAWSKeyPair() error {
+func (a *Amazon) verifyAWSKeyPair() error {
 	svc, err := a.EC2()
 	if err != nil {
 		return err

--- a/pkg/tarmak/provider/amazon/key_pair_test.go
+++ b/pkg/tarmak/provider/amazon/key_pair_test.go
@@ -47,7 +47,7 @@ var fakeSSHKeyInsecureFingerprint = "c7:15:68:10:e9:39:6c:ab:99:fe:d0:8b:e8:ec:f
 var fakeSSHKeyInsecurePublic = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==\n"
 
 // test the happy path, local key matches the one existing in Amazon
-func TestAmazon_validateAmazonKeyPairExistingHappyPath(t *testing.T) {
+func TestAmazon_verifyAmazonKeyPairExistingHappyPath(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -71,13 +71,13 @@ func TestAmazon_validateAmazonKeyPairExistingHappyPath(t *testing.T) {
 	}
 	a.fakeEnvironment.EXPECT().SSHPrivateKey().Return(signer)
 
-	err = a.Amazon.validateAWSKeyPair()
+	err = a.Amazon.verifyAWSKeyPair()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
 }
 
-func TestAmazon_validateAmazonKeyPairExistingMismatch(t *testing.T) {
+func TestAmazon_verifyAmazonKeyPairExistingMismatch(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -101,7 +101,7 @@ func TestAmazon_validateAmazonKeyPairExistingMismatch(t *testing.T) {
 	}
 	a.fakeEnvironment.EXPECT().SSHPrivateKey().Return(signer)
 
-	err = a.Amazon.validateAWSKeyPair()
+	err = a.Amazon.verifyAWSKeyPair()
 	if err == nil {
 		t.Errorf("expected an error: %s", err)
 	} else if !strings.Contains(err.Error(), "key pair does not match") {
@@ -109,7 +109,7 @@ func TestAmazon_validateAmazonKeyPairExistingMismatch(t *testing.T) {
 	}
 }
 
-func TestAmazon_validateAmazonKeyPairNotExisting(t *testing.T) {
+func TestAmazon_verifyAmazonKeyPairNotExisting(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -140,7 +140,7 @@ func TestAmazon_validateAmazonKeyPairNotExisting(t *testing.T) {
 	}
 	a.fakeEnvironment.EXPECT().SSHPrivateKey().Return(signer)
 
-	err = a.Amazon.validateAWSKeyPair()
+	err = a.Amazon.verifyAWSKeyPair()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}

--- a/pkg/tarmak/provider/amazon/route53.go
+++ b/pkg/tarmak/provider/amazon/route53.go
@@ -47,7 +47,7 @@ func (a *Amazon) initPublicZone() (*route53.HostedZone, error) {
 	return result.HostedZone, err
 }
 
-func (a *Amazon) validatePublicZone() error {
+func (a *Amazon) verifyPublicZone() error {
 	svc, err := a.Route53()
 	if err != nil {
 		return err

--- a/pkg/tarmak/provider/amazon/tf_remote_state.go
+++ b/pkg/tarmak/provider/amazon/tf_remote_state.go
@@ -128,7 +128,7 @@ func (a *Amazon) initRemoteStateBucket() error {
 	}
 
 	_, err = svc.PutBucketEncryption(&s3.PutBucketEncryptionInput{
-		Bucket:                            aws.String(a.RemoteStateName()),
+		Bucket: aws.String(a.RemoteStateName()),
 		ServerSideEncryptionConfiguration: encConf,
 	})
 	if err != nil {

--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -42,6 +42,8 @@ variable "secrets_bucket" {
   default = ""
 }
 
+variable "remote_kms_key_id" {}
+
 {{ if or (eq .ClusterType .ClusterTypeClusterSingle) (eq .ClusterType .ClusterTypeHub)}}
 
 

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -197,7 +197,7 @@ data "terraform_remote_state" "hub_state" {
     bucket     = "${var.state_bucket}"
     key        = "${var.environment}/${var.state_cluster_name}/main.tfstate"
     kms_key_id = "${var.remote_kms_key_id}"
-    encrypt    = true
+    encrypt    = "true"
   }
 }
 

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -193,9 +193,10 @@ data "terraform_remote_state" "hub_state" {
   backend = "s3"
 
   config {
-    region = "${var.region}"
-    bucket = "${var.state_bucket}"
-    key    = "${var.environment}/${var.state_cluster_name}/main.tfstate"
+    region     = "${var.region}"
+    bucket     = "${var.state_bucket}"
+    key        = "${var.environment}/${var.state_cluster_name}/main.tfstate"
+    kms_key_id = "${var.remote_kms_key_id}"
   }
 }
 

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -197,6 +197,7 @@ data "terraform_remote_state" "hub_state" {
     bucket     = "${var.state_bucket}"
     key        = "${var.environment}/${var.state_cluster_name}/main.tfstate"
     kms_key_id = "${var.remote_kms_key_id}"
+    encrypt    = true
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Generate a KMS key and alias for the provider. This is used to encrypt the terraform remote state.

fixes #467 

```release-note
KMS encrypt terraform remote S3 state data.
```
