### PR TITLE
Implement Vault runcmd commands as systemd units

### DIFF
--- a/terraform/amazon/modules/vault/templates/vault_user_data.yaml
+++ b/terraform/amazon/modules/vault/templates/vault_user_data.yaml
@@ -367,6 +367,57 @@ write_files:
     export PATH=$PATH:/usr/local/bin
     export VAULT_ADDR=https://localhost:8200
     export VAULT_CACERT=/etc/vault/tls/ca.pem
+- path: /etc/systemd/system/download-vault-consul.service
+  permissions: '0644'
+  content: |
+    [Unit]
+    Description=Download Vault and Consul
+    After=network-online.target
+    Requires=network-online.target
+
+    [Service]
+    Type=simple
+    Restart=on-failure
+    RestartSec=10
+    ExecStart=/usr/local/bin/download-vault-consul.sh
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target
+- path: /etc/systemd/system/download-vault-unsealer.service
+  permissions: '0644'
+  content: |
+    [Unit]
+    Description=Download Vault Unsealer
+    After=network-online.target
+    Requires=network-online.target
+
+    [Service]
+    Type=simple
+    Restart=on-failure
+    RestartSec=10
+    ExecStart=/usr/local/bin/download-vault-unsealer.sh
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target
+- path: /etc/systemd/system/download-consul-backinator.service
+  permissions: '0644'
+  content: |
+    [Unit]
+    Description=Download Consul Backinator
+    After=network-online.target
+    Requires=network-online.target
+
+    [Service]
+    Type=simple
+    Restart=on-failure
+    RestartSec=10
+    ExecStart=/usr/local/bin/download-consul-backinator.sh
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - chown consul:consul /etc/consul/consul.json
@@ -374,8 +425,5 @@ runcmd:
 - hostnamectl set-hostname "${fqdn}"
 - yum -y install epel-release
 - yum -y install unzip jq curl gpg
-- /usr/local/bin/download-vault-consul.sh
-- /usr/local/bin/download-vault-unsealer.sh
-- /usr/local/bin/download-consul-backinator.sh
-- systemctl enable consul.service vault.service vault-unsealer.service consul-backup.timer
-- systemctl start consul.service vault.service vault-unsealer.service consul-backup.timer
+- systemctl enable download-vault-consul.service download-vault-unsealer.service download-consul-backinator.service consul.service vault.service vault-unsealer.service consul-backup.timer
+- systemctl start download-vault-consul.service download-vault-unsealer.service download-consul-backinator.service consul.service vault.service vault-unsealer.service consul-backup.timer


### PR DESCRIPTION
Signed-off-by: Luke Addison <luke.addison@jetstack.io>

**What this PR does / why we need it**: Intermittent issues (e.g. network) can cause Vault's runcmd userdata commands to fail. This PR fixes this by automatically restarting them if they fail

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #506 

**Release note**:
```release-note
Run Vault userdata runcmd commands as systemd units
```
