### PR TITLE
Fix API ELBs SSL healthcheck endpoint

### DIFF
--- a/terraform/amazon/templates/instance_pools/role_elb.tf.template
+++ b/terraform/amazon/templates/instance_pools/role_elb.tf.template
@@ -21,7 +21,7 @@ resource "aws_elb" "{{.Role.TFName}}" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:6443"
+    target              = "SSL:6443"
     interval            = 30
   }
 
@@ -76,7 +76,7 @@ resource "aws_elb" "{{.Role.TFName}}_public" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:6443"
+    target              = "SSL:6443"
     interval            = 30
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We were observing thousands of `TLS handshake error` in the `kube-apiserver` logs coming from ELB ENIs. Updating the ELB's healthcheck fixes it.

```
Sep 14 02:06:54 ip-10-1-31-80.eu-west-2.compute.internal apiserver[18739]: I0914 02:06:54.699402   18739 logs.go:41] http: TLS handshake error from 10.1.20.13:50152: EOF
Sep 14 02:06:57 ip-10-1-31-80.eu-west-2.compute.internal apiserver[18739]: I0914 02:06:57.644306   18739 logs.go:41] http: TLS handshake error from 10.1.10.208:56402: EOF
Sep 14 02:07:14 ip-10-1-31-80.eu-west-2.compute.internal apiserver[18739]: I0914 02:07:14.207835   18739 logs.go:41] http: TLS handshake error from 10.1.21.214:24194: EOF
Sep 14 02:07:14 ip-10-1-31-80.eu-west-2.compute.internal apiserver[18739]: I0914 02:07:14.209522   18739 logs.go:41] http: TLS handshake error from 10.1.31.220:2698: EOF
```

```release-note
Use SSL protocol for API server health checks
```