### PR TITLE
Ensure validate/verify is run during a debug shell

### DIFF
--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -128,6 +128,7 @@ type Provider interface {
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
 	VerifyInstanceTypes(intstancePools []InstancePool) error
+	EnsureRemoteResources() error
 }
 
 type Tarmak interface {
@@ -159,6 +160,7 @@ type Tarmak interface {
 	ProviderByName(string) (Provider, error)
 	// get an environment by name
 	EnvironmentByName(string) (Environment, error)
+	EnsureRemoteResources() error
 }
 
 type Config interface {

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -354,6 +354,23 @@ func (a *Amazon) Verify() error {
 
 	// These checks only make sense with an environment given
 	if a.tarmak.Environment() != nil {
+		if err := a.verifyAvailabilityZones(); err != nil {
+			result = multierror.Append(result, err)
+		}
+
+	}
+
+	if err := a.verifyPublicZone(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (a *Amazon) EnsureRemoteResources() error {
+	var result *multierror.Error
+
+	if a.tarmak.Environment() != nil {
 		if err := a.verifyRemoteStateKMS(); err != nil {
 			result = multierror.Append(result, err)
 		}
@@ -370,17 +387,9 @@ func (a *Amazon) Verify() error {
 			result = multierror.Append(result, err)
 		}
 
-		if err := a.verifyAvailabilityZones(); err != nil {
-			result = multierror.Append(result, err)
-		}
-
 		if err := a.verifyAWSKeyPair(); err != nil {
 			result = multierror.Append(result, err)
 		}
-	}
-
-	if err := a.verifyPublicZone(); err != nil {
-		result = multierror.Append(result, err)
 	}
 
 	return result.ErrorOrNil()

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -371,23 +371,23 @@ func (a *Amazon) EnsureRemoteResources() error {
 	var result *multierror.Error
 
 	if a.tarmak.Environment() != nil {
-		if err := a.verifyRemoteStateKMS(); err != nil {
+		if err := a.ensureRemoteStateKMS(); err != nil {
 			result = multierror.Append(result, err)
 		}
 
-		if err := a.verifyRemoteStateBucket(); err != nil {
+		if err := a.ensureRemoteStateBucket(); err != nil {
 			result = multierror.Append(result, err)
 		}
 
-		if err := a.verifyRemoteStateBucketEncrytion(); err != nil {
+		if err := a.ensureRemoteStateBucketEncrytion(); err != nil {
 			result = multierror.Append(result, err)
 		}
 
-		if err := a.verifyRemoteStateDynamoDB(); err != nil {
+		if err := a.ensureRemoteStateDynamoDB(); err != nil {
 			result = multierror.Append(result, err)
 		}
 
-		if err := a.verifyAWSKeyPair(); err != nil {
+		if err := a.ensureAWSKeyPair(); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/pkg/tarmak/provider/amazon/key_pair.go
+++ b/pkg/tarmak/provider/amazon/key_pair.go
@@ -40,7 +40,7 @@ func fingerprintAWSStyle(signer interface{}) (string, error) {
 	}
 }
 
-func (a *Amazon) verifyAWSKeyPair() error {
+func (a *Amazon) ensureAWSKeyPair() error {
 	svc, err := a.EC2()
 	if err != nil {
 		return err

--- a/pkg/tarmak/provider/amazon/key_pair_test.go
+++ b/pkg/tarmak/provider/amazon/key_pair_test.go
@@ -47,7 +47,7 @@ var fakeSSHKeyInsecureFingerprint = "c7:15:68:10:e9:39:6c:ab:99:fe:d0:8b:e8:ec:f
 var fakeSSHKeyInsecurePublic = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==\n"
 
 // test the happy path, local key matches the one existing in Amazon
-func TestAmazon_verifyAmazonKeyPairExistingHappyPath(t *testing.T) {
+func TestAmazon_ensureAmazonKeyPairExistingHappyPath(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -71,13 +71,13 @@ func TestAmazon_verifyAmazonKeyPairExistingHappyPath(t *testing.T) {
 	}
 	a.fakeEnvironment.EXPECT().SSHPrivateKey().Return(signer)
 
-	err = a.Amazon.verifyAWSKeyPair()
+	err = a.Amazon.ensureAWSKeyPair()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
 }
 
-func TestAmazon_verifyAmazonKeyPairExistingMismatch(t *testing.T) {
+func TestAmazon_ensureAmazonKeyPairExistingMismatch(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -101,7 +101,7 @@ func TestAmazon_verifyAmazonKeyPairExistingMismatch(t *testing.T) {
 	}
 	a.fakeEnvironment.EXPECT().SSHPrivateKey().Return(signer)
 
-	err = a.Amazon.verifyAWSKeyPair()
+	err = a.Amazon.ensureAWSKeyPair()
 	if err == nil {
 		t.Errorf("expected an error: %s", err)
 	} else if !strings.Contains(err.Error(), "key pair does not match") {
@@ -109,7 +109,7 @@ func TestAmazon_verifyAmazonKeyPairExistingMismatch(t *testing.T) {
 	}
 }
 
-func TestAmazon_verifyAmazonKeyPairNotExisting(t *testing.T) {
+func TestAmazon_ensureAmazonKeyPairNotExisting(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -140,7 +140,7 @@ func TestAmazon_verifyAmazonKeyPairNotExisting(t *testing.T) {
 	}
 	a.fakeEnvironment.EXPECT().SSHPrivateKey().Return(signer)
 
-	err = a.Amazon.verifyAWSKeyPair()
+	err = a.Amazon.ensureAWSKeyPair()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}

--- a/pkg/tarmak/provider/amazon/tf_remote_state.go
+++ b/pkg/tarmak/provider/amazon/tf_remote_state.go
@@ -92,7 +92,7 @@ func (a *Amazon) RemoteStateAvailable(bucketName string) (bool, error) {
 	}
 }
 
-func (a *Amazon) verifyRemoteStateKMS() error {
+func (a *Amazon) ensureRemoteStateKMS() error {
 	svc, err := a.KMS()
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func (a *Amazon) verifyRemoteStateKMS() error {
 	return nil
 }
 
-func (a *Amazon) verifyRemoteStateBucket() error {
+func (a *Amazon) ensureRemoteStateBucket() error {
 	svc, err := a.S3()
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func (a *Amazon) verifyRemoteStateBucket() error {
 	return nil
 }
 
-func (a *Amazon) verifyRemoteStateDynamoDB() error {
+func (a *Amazon) ensureRemoteStateDynamoDB() error {
 	svc, err := a.DynamoDB()
 	if err != nil {
 		return err
@@ -196,7 +196,7 @@ func (a *Amazon) verifyRemoteStateDynamoDB() error {
 	return nil
 }
 
-func (a *Amazon) verifyRemoteStateBucketEncrytion() error {
+func (a *Amazon) ensureRemoteStateBucketEncrytion() error {
 	svc, err := a.S3()
 	if err != nil {
 		return err

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -328,6 +328,10 @@ func (t *Tarmak) Verify() error {
 	return nil
 }
 
+func (t *Tarmak) EnsureRemoteResources() error {
+	return t.Provider().EnsureRemoteResources()
+}
+
 func (t *Tarmak) Cleanup() {
 	// clean up assets directory
 	if t.rootPath != nil {

--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -114,7 +114,7 @@ func (c *CmdTerraform) Destroy() error {
 
 func (c *CmdTerraform) Shell() error {
 	if err := c.setup(); err != nil {
-		c.log.Warnf("error during validate/verify steps: %v", err)
+		c.log.Warnf("error setting up tarmak for terrafrom shell: %v", err)
 	}
 
 	if err := c.verifyTerraformBinaryVersion(); err != nil {

--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -40,26 +40,8 @@ func (t *Tarmak) NewCmdTerraform(args []string) *CmdTerraform {
 }
 
 func (c *CmdTerraform) Plan() error {
-	c.log.Info("validate steps")
-	if err := c.tarmak.Validate(); err != nil {
-		return fmt.Errorf("failed to validate tarmak: %s", err)
-	}
-
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
-	}
-
-	c.log.Info("verify steps")
-	if err := c.tarmak.Verify(); err != nil {
+	if err := c.validateVerify(); err != nil {
 		return err
-	}
-
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
 	}
 
 	c.log.Info("write SSH config")
@@ -77,25 +59,8 @@ func (c *CmdTerraform) Plan() error {
 }
 
 func (c *CmdTerraform) Apply() error {
-	c.log.Info("validate steps")
-	if err := c.tarmak.Validate(); err != nil {
-		return fmt.Errorf("failed to validate tarmak: %s", err)
-	}
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
-	}
-
-	c.log.Info("verify steps")
-	if err := c.tarmak.Verify(); err != nil {
+	if err := c.validateVerify(); err != nil {
 		return err
-	}
-
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
 	}
 
 	c.log.Info("write SSH config")
@@ -144,26 +109,8 @@ func (c *CmdTerraform) Apply() error {
 }
 
 func (c *CmdTerraform) Destroy() error {
-	c.log.Info("validate steps")
-	if err := c.tarmak.Validate(); err != nil {
-		return fmt.Errorf("failed to validate tarmak: %s", err)
-	}
-
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
-	}
-
-	c.log.Info("verify steps")
-	if err := c.tarmak.Verify(); err != nil {
+	if err := c.validateVerify(); err != nil {
 		return err
-	}
-
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
 	}
 
 	c.log.Info("write SSH config")
@@ -183,6 +130,10 @@ func (c *CmdTerraform) Destroy() error {
 }
 
 func (c *CmdTerraform) Shell() error {
+	if err := c.validateVerify(); err != nil {
+		c.log.Warnf("error during validate/verify steps: %v", err)
+	}
+
 	if err := c.verifyTerraformBinaryVersion(); err != nil {
 		return err
 	}
@@ -247,6 +198,32 @@ func (t *Tarmak) verifyImageExists() error {
 
 	if len(images) == 0 {
 		return errors.New("no images found")
+	}
+
+	return nil
+}
+
+func (c *CmdTerraform) validateVerify() error {
+	c.log.Info("validate steps")
+	if err := c.tarmak.Validate(); err != nil {
+		return fmt.Errorf("failed to validate tarmak: %s", err)
+	}
+
+	select {
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	default:
+	}
+
+	c.log.Info("verify steps")
+	if err := c.tarmak.Verify(); err != nil {
+		return err
+	}
+
+	select {
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	default:
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Validate / Verify was not being run on a `cluster debug terraform shell` meaning that the remote KMS for the lock was never being retrieved.

```release-note
NONE
```

