### PR TITLE
Bump node-exporter to 0.16.0 and update rules

### DIFF
--- a/puppet/modules/prometheus/README.md
+++ b/puppet/modules/prometheus/README.md
@@ -154,7 +154,7 @@ exporter_# Sets up a blackbox exporter to forward etcd metrics from etcd nodes
 ##### `version`
 
 * Type: `String`
-* Default: `'0.15.2'`
+* Default: `'0.16.0'`
 
 ##### `download_url`
 

--- a/puppet/modules/prometheus/manifests/node_exporter.pp
+++ b/puppet/modules/prometheus/manifests/node_exporter.pp
@@ -1,6 +1,6 @@
 class prometheus::node_exporter (
   String $image = 'prom/node-exporter',
-  String $version = '0.15.2',
+  String $version = '0.16.0',
   String $download_url = 'https://github.com/prometheus/node_exporter/releases/download/v#VERSION#/node_exporter-#VERSION#.linux-amd64.tar.gz',
   String $sha256sums_url = 'https://github.com/prometheus/node_exporter/releases/download/v#VERSION#/sha256sums.txt',
   String $signature_url = 'https://releases.tarmak.io/signatures/node_exporter/#VERSION#/sha256sums.txt.asc',
@@ -19,14 +19,14 @@ class prometheus::node_exporter (
     $kubernetes_ca_file = $::prometheus::server::kubernetes_ca_file
 
     prometheus::rule { 'NodeHighCPUUsage':
-      expr        => '(100 - (avg(irate(node_cpu{mode="idle"}[5m])) WITHOUT (cpu) * 100)) > 80',
+      expr        => '(100 - (avg(irate(node_cpu_seconds_total{mode="idle"}[5m])) WITHOUT (cpu) * 100)) > 80',
       for         => '5m',
       summary     => '{{$labels.instance}}: High CPU usage detected',
       description => '{{$labels.instance}}: CPU usage is above 80% (current value is: {{ $value }})',
     }
 
     prometheus::rule { 'NodeHighLoadAverage':
-      expr        => '((node_load5 / count without (cpu, mode) (node_cpu{mode="system"})) > 3)',
+      expr        => '((node_load5 / count without (cpu, mode) (node_cpu_seconds_total{mode="system"})) > 3)',
       for         => '5m',
       summary     => '{{$labels.instance}}: High load average detected',
       description => '{{$labels.instance}}: 5 minute load average is {{$value}}',
@@ -34,7 +34,7 @@ class prometheus::node_exporter (
 
     # TODO: Alert if diskspace is running out in x hours
     prometheus::rule { 'NodeLowDiskSpace':
-      expr        => '((node_filesystem_size - node_filesystem_free ) / node_filesystem_size * 100) > 75',
+      expr        => '((node_filesystem_size_bytes - node_filesystem_free_bytes ) / node_filesystem_size_bytes * 100) > 75',
       for         => '2m',
       summary     => '{{$labels.instance}}: Low disk space',
       description => '{{$labels.instance}}: Disk usage is above 75% (current value is: {{ $value }}%)',
@@ -42,14 +42,14 @@ class prometheus::node_exporter (
 
     # TODO: Alert when swap is in use
     prometheus::rule { 'NodeSwapEnabled':
-      expr        => '(((node_memory_SwapTotal-node_memory_SwapFree)/node_memory_SwapTotal)*100) > 75',
+      expr        => '(((node_memory_SwapTotal_bytes-node_memory_SwapFree_bytes)/node_memory_SwapTotal_bytes)*100) > 75',
       for         => '2m',
       summary     => '{{$labels.instance}}: Swap usage detected',
       description => '{{$labels.instance}}: Swap usage usage is above 75% (current value is: {{ $value }})',
     }
 
     prometheus::rule { 'NodeHighMemoryUsage':
-      expr        => '(((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 80',
+      expr        => '(((node_memory_MemTotal_bytes-node_memory_MemFree_bytes-node_memory_Cached_bytes)/(node_memory_MemTotal_bytes)*100)) > 80',
       for         => '5m',
       summary     => '{{$labels.instance}}: High memory usage detected',
       description => '{{$labels.instance}}: Memory usage usage is above 80% (current value is: {{ $value }})',

--- a/puppet/modules/prometheus/spec/defines/rule_spec.rb
+++ b/puppet/modules/prometheus/spec/defines/rule_spec.rb
@@ -10,7 +10,7 @@ describe 'prometheus::rule', :type => :define do
 
   let :params do
     {
-      :expr        => '(100 - (avg by (instance) (irate(node_cpu{name="node-exporter",mode="idle"}[5m])) * 100)) > 75',
+      :expr        => '(100 - (avg by (instance) (irate(node_cpu_seconds_total{name="node-exporter",mode="idle"}[5m])) * 100)) > 75',
       :for         => "2m",
       :summary     => '{{$labels.instance}}: High CPU usage detected',
       :description => '{{$labels.instance}}: CPU usage is above 75% (current value is: {{ $value }})',
@@ -28,7 +28,7 @@ describe 'prometheus::rule', :type => :define do
   context 'specified alert_label severity' do
     let :params do
       {
-        :expr => '(100 - (avg by (instance) (irate(node_cpu{name="node-exporter",mode="idle"}[5m])) * 100)) > 75',
+        :expr => '(100 - (avg by (instance) (irate(node_cpu_seconds_total{name="node-exporter",mode="idle"}[5m])) * 100)) > 75',
         :for         => "2m",
         :summary     => '{{$labels.instance}}: High CPU usage detected',
         :description => '{{$labels.instance}}: CPU usage is above 75% (current value is: {{ $value }})',


### PR DESCRIPTION
**What this PR does / why we need it**:
• Bump node-exporter to 0.16.0
• Migrate rules to 0.16.0 format

**Which issue this PR fixes**:
Most of our infra now exports series with `0.16.0`, we could get rid of `0.15.2` duplication rules altogether if we bump tarmak's node-exporter as well.

**Release note:**
```release-note
Bump node-exporter to 0.16.0 and update rules (breaking changes in metric names https://github.com/prometheus/node_exporter/releases/tag/v0.16.0)
```