### PR TITLE
Fix etcd metrics not being discovered by prometheus

### DIFF
--- a/puppet/modules/prometheus/README.md
+++ b/puppet/modules/prometheus/README.md
@@ -38,6 +38,11 @@ This module is part of [Tarmak](http://docs.tarmak.io) and should currently be c
 * Type: `Any`
 * Default: `$::prometheus::params::etcd_cluster_exporters`
 
+##### `etcd_cluster_node_exporters`
+
+* Type: `Any`
+* Default: `$::prometheus::params::etcd_cluster_node_exporters`
+
 ##### `etcd_k8s_main_port`
 
 * Type: `Integer[1025,65535]`

--- a/puppet/modules/prometheus/manifests/init.pp
+++ b/puppet/modules/prometheus/manifests/init.pp
@@ -3,6 +3,7 @@ class prometheus(
   String $namespace = 'monitoring',
   Optional[Enum['etcd','master','worker']] $role = $::prometheus::params::role,
   $etcd_cluster_exporters = $::prometheus::params::etcd_cluster_exporters,
+  $etcd_cluster_node_exporters = $::prometheus::params::etcd_cluster_node_exporters,
   Integer[1025,65535] $etcd_k8s_main_port = $::prometheus::params::etcd_k8s_main_port,
   Integer[1025,65535] $etcd_k8s_events_port = $::prometheus::params::etcd_k8s_events_port,
   Integer[1024,65535] $etcd_overlay_port = $::prometheus::params::etcd_overlay_port,

--- a/puppet/modules/prometheus/manifests/node_exporter.pp
+++ b/puppet/modules/prometheus/manifests/node_exporter.pp
@@ -55,13 +55,12 @@ class prometheus::node_exporter (
       description => '{{$labels.instance}}: Memory usage usage is above 80% (current value is: {{ $value }})',
     }
 
-
     # scrape node exporter running on etcd nodes
     prometheus::scrape_config { 'etcd-nodes-exporter':
       order  =>  135,
       config => {
         'dns_sd_configs'  => [{
-          'names' => $tarmak::etcd_cluster_exporters,
+          'names' => $tarmak::etcd_cluster_node_exporters,
         }],
       }
     }

--- a/puppet/modules/prometheus/manifests/params.pp
+++ b/puppet/modules/prometheus/manifests/params.pp
@@ -1,15 +1,17 @@
 class prometheus::params {
   if defined('::tarmak') {
-    $etcd_cluster_exporters = $::tarmak::etcd_cluster_exporters
-    $etcd_k8s_main_port     = $::tarmak::etcd_k8s_main_client_port
-    $etcd_k8s_events_port   = $::tarmak::etcd_k8s_events_client_port
-    $etcd_overlay_port      = $::tarmak::etcd_overlay_client_port
-    $role                   = $::tarmak::role
+    $etcd_cluster_exporters      = $::tarmak::etcd_cluster_exporters
+    $etcd_cluster_node_exporters = $::tarmak::etcd_cluster_node_exporters
+    $etcd_k8s_main_port          = $::tarmak::etcd_k8s_main_client_port
+    $etcd_k8s_events_port        = $::tarmak::etcd_k8s_events_client_port
+    $etcd_overlay_port           = $::tarmak::etcd_overlay_client_port
+    $role                        = $::tarmak::role
   } else {
-    $etcd_cluster_exporters = undef
-    $etcd_k8s_main_port     = 2379
-    $etcd_k8s_events_port   = 2369
-    $etcd_overlay_port      = 2359
-    $role                   = undef
+    $etcd_cluster_exporters      = undef
+    $etcd_cluster_node_exporters = undef
+    $etcd_k8s_main_port          = 2379
+    $etcd_k8s_events_port        = 2369
+    $etcd_overlay_port           = 2359
+    $role                        = undef
   }
 }

--- a/puppet/modules/prometheus/spec/classes/blackbox_exporter_etcd_spec.rb
+++ b/puppet/modules/prometheus/spec/classes/blackbox_exporter_etcd_spec.rb
@@ -9,6 +9,7 @@ describe 'prometheus::blackbox_exporter_etcd' do
       '  $etcd_k8s_events_client_port = 1235',
       '  $etcd_overlay_client_port = 1236',
       "  $etcd_cluster_exporters = ['etcd-exporters.example.tarmak.local']",
+      "  $etcd_cluster_node_exporters = ['etcd-node-exporters.example.tarmak.local']",
       '}',
       'include tarmak',
     ]}
@@ -24,6 +25,7 @@ describe 'prometheus::blackbox_exporter_etcd' do
       '  $etcd_k8s_events_client_port = 1235',
       '  $etcd_overlay_client_port = 1236',
       "  $etcd_cluster_exporters = ['etcd-exporters.example.tarmak.local']",
+      "  $etcd_cluster_node_exporters = ['etcd-node-exporters.example.tarmak.local']",
       '}',
       'include tarmak',
       'class kubernetes::apiserver{}',

--- a/puppet/modules/prometheus/spec/classes/node_exporter_spec.rb
+++ b/puppet/modules/prometheus/spec/classes/node_exporter_spec.rb
@@ -9,6 +9,7 @@ describe 'prometheus::node_exporter' do
       '  $etcd_k8s_events_client_port = 1235',
       '  $etcd_overlay_client_port = 1236',
       "  $etcd_cluster_exporters = ['etcd-exporters.example.tarmak.local']",
+      "  $etcd_cluster_node_exporters = ['etcd-node-exporters.example.tarmak.local']",
       '}',
       'include tarmak',
     ]}
@@ -24,6 +25,7 @@ describe 'prometheus::node_exporter' do
       '  $etcd_k8s_events_client_port = 1235',
       '  $etcd_overlay_client_port = 1236',
       "  $etcd_cluster_exporters = ['etcd-exporters.example.tarmak.local']",
+      "  $etcd_cluster_node_exporters = ['etcd-node-exporters.example.tarmak.local']",
       '}',
       'include tarmak',
       'class kubernetes::apiserver{}',

--- a/puppet/modules/prometheus/spec/classes/rules_spec.rb
+++ b/puppet/modules/prometheus/spec/classes/rules_spec.rb
@@ -8,6 +8,7 @@ describe 'prometheus' do
     '  $etcd_k8s_events_client_port = 1235',
     '  $etcd_overlay_client_port = 1236',
     "  $etcd_cluster_exporters = ['etcd-exporters.example.tarmak.local']",
+    "  $etcd_cluster_node_exporters = ['etcd-node-exporters.example.tarmak.local']",
     '}',
     'include tarmak',
     'class kubernetes::apiserver{}',

--- a/puppet/modules/prometheus/spec/defines/scrape_config_spec.rb
+++ b/puppet/modules/prometheus/spec/defines/scrape_config_spec.rb
@@ -22,7 +22,7 @@ describe 'prometheus::scrape_config', :type => :define do
             'regex' => '(.*)',
             'target_label' => '__param_target',
             'replacement' => 'https://127.0.0.1:1234/metrics',
-           }],
+          }],
         },
         :order             => 02,
       }

--- a/puppet/modules/tarmak/manifests/init.pp
+++ b/puppet/modules/tarmak/manifests/init.pp
@@ -102,6 +102,7 @@ class tarmak (
   }
 
   $etcd_cluster_exporters = ["etcd-exporters.${cluster_name}.${dns_root}"]
+  $etcd_cluster_node_exporters = ["etcd-node-exporters.${cluster_name}.${dns_root}"]
 
   $kubernetes_pod_network_host = split($kubernetes_pod_network, '/')[0]
   $kubernetes_pod_network_mask = Integer(split($kubernetes_pod_network, '/')[1], 10)

--- a/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_instance.tf.template
@@ -251,6 +251,16 @@ resource "aws_route53_record" "{{.TFName}}-exporter-srv" {
     "${formatlist("1 10 9115 %s.%s", aws_route53_record.{{.TFName}}.*.name, var.private_zone)}"
   ]
 }
+
+resource "aws_route53_record" "{{.TFName}}-node-exporter-srv" {
+  zone_id = "${var.private_zone_id}"
+  name    = "{{.Role.Name}}-node-exporters.${data.template_file.stack_name.rendered}"
+  type    = "SRV"
+  ttl     = "300"
+  records = [
+    "${formatlist("1 10 9100 %s.%s", aws_route53_record.{{.TFName}}.*.name, var.private_zone)}"
+  ]
+}
 {{ end -}}
 
 {{ end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
• Expose node-exporter metrics for all etcd nodes as an SRV record
• Update prometheus discovery to make sure that etcd node-exporter metrics are correctly scrapped

**Which issue this PR fixes**:
node-exporter metrics are not being exposed to prometheus, the current config scrapes blackbox exporter metrics instead of the ones coming from node-exporter:
```
- job_name: etcd-nodes-exporter
  scrape_interval: 15s
  scrape_timeout: 10s
  metrics_path: /metrics
  scheme: http
  dns_sd_configs:
  - names:
    - etcd-exporters.xxx.tarmak.local
    refresh_interval: 30s
    type: SRV
    port: 0
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
