### PR TITLE
Fix bug when running tarmak init with empty .tarmak directory

### DIFF
--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -366,8 +366,11 @@ func (a *Amazon) Verify() error {
 		result = multierror.Append(result, err)
 	}
 
-	if err := a.verifyInstanceTypes(); err != nil {
-		result = multierror.Append(result, err)
+	// if no cluster exists (i.e. tarmak init has not yet been run), skip this verification check
+	if a.tarmak.Cluster() != nil {
+		if err := a.verifyInstanceTypes(); err != nil {
+			result = multierror.Append(result, err)
+		}
 	}
 
 	return result.ErrorOrNil()


### PR DESCRIPTION
Signed-off-by: Aled James <aledjms@gmail.com>

**What this PR does / why we need it**:
`tarmak init` panics when ~/.tarmak directory is empty

This PR wraps the invocation of the panicking function in a check for `nil`

**Release note**:
```release-note
NONE
```