### PR TITLE
Adds auto-approve and auto-approve-deleting-data flags to cluster apply

### DIFF
--- a/cmd/tarmak/cmd/cluster.go
+++ b/cmd/tarmak/cmd/cluster.go
@@ -35,14 +35,14 @@ func clusterApplyFlags(fs *flag.FlagSet) {
 	fs.BoolVar(
 		&store.AutoApprove,
 		"auto-approve",
-		false,
+		true,
 		"auto approve to responses when applying cluster",
 	)
 
 	fs.BoolVar(
 		&store.AutoApproveDeletingData,
 		"auto-approve-deleting-data",
-		false,
+		true,
 		"auto approve deletion of any data as a cause from applying cluster",
 	)
 }

--- a/cmd/tarmak/cmd/cluster.go
+++ b/cmd/tarmak/cmd/cluster.go
@@ -40,7 +40,7 @@ func clusterApplyFlags(fs *flag.FlagSet) {
 	)
 
 	fs.BoolVar(
-		&store.AutoApprove,
+		&store.AutoApproveDeletingData,
 		"auto-approve-deleting-data",
 		false,
 		"auto approve deletion of any data as a cause from applying cluster",

--- a/cmd/tarmak/cmd/cluster.go
+++ b/cmd/tarmak/cmd/cluster.go
@@ -31,6 +31,20 @@ func clusterApplyFlags(fs *flag.FlagSet) {
 		false,
 		"apply changes to infrastructure only, by running only terraform",
 	)
+
+	fs.BoolVar(
+		&store.AutoApprove,
+		"auto-approve",
+		false,
+		"auto approve to responses when applying cluster",
+	)
+
+	fs.BoolVar(
+		&store.AutoApprove,
+		"auto-approve-deleting-data",
+		false,
+		"auto approve deletion of any data as a cause from applying cluster",
+	)
 }
 
 func clusterDestroyFlags(fs *flag.FlagSet) {

--- a/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
+++ b/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
@@ -20,10 +20,12 @@ Options
 
 ::
 
-  -C, --configuration-only    apply changes to configuration only, by running only puppet
-      --dry-run               don't actually change anything, just show changes that would occur
-  -h, --help                  help for apply
-  -I, --infrastructure-only   apply changes to infrastructure only, by running only terraform
+      --auto-approve                 auto approve to responses when applying cluster
+      --auto-approve-deleting-data   auto approve deletion of any data as a cause from applying cluster
+  -C, --configuration-only           apply changes to configuration only, by running only puppet
+      --dry-run                      don't actually change anything, just show changes that would occur
+  -h, --help                         help for apply
+  -I, --infrastructure-only          apply changes to infrastructure only, by running only terraform
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
+++ b/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
@@ -20,8 +20,8 @@ Options
 
 ::
 
-      --auto-approve                 auto approve to responses when applying cluster
-      --auto-approve-deleting-data   auto approve deletion of any data as a cause from applying cluster
+      --auto-approve                 auto approve to responses when applying cluster (default true)
+      --auto-approve-deleting-data   auto approve deletion of any data as a cause from applying cluster (default true)
   -C, --configuration-only           apply changes to configuration only, by running only puppet
       --dry-run                      don't actually change anything, just show changes that would occur
   -h, --help                         help for apply

--- a/docs/generated/reference/output/api-docs.html
+++ b/docs/generated/reference/output/api-docs.html
@@ -515,6 +515,14 @@ Appears In:
 </thead>
 <tbody>
 <tr>
+<td><code>autoApprove</code><br /> <em>boolean</em></td>
+<td></td>
+</tr>
+<tr>
+<td><code>autoApproveDeletingData</code><br /> <em>boolean</em></td>
+<td>auto approve apply queries</td>
+</tr>
+<tr>
 <td><code>configurationOnly</code><br /> <em>boolean</em></td>
 <td></td>
 </tr>

--- a/pkg/apis/tarmak/v1alpha1/types.go
+++ b/pkg/apis/tarmak/v1alpha1/types.go
@@ -151,6 +151,9 @@ type ClusterApplyFlags struct {
 	InfrastructureOnly bool `json:"infrastructureOnly,omitempty"` // only run terraform
 
 	ConfigurationOnly bool `json:"configurationOnly,omitempty"` // only run puppet
+
+	AutoApprove             bool `json:"autoApprove,omitempty"`             // auto approve apply queries
+	AutoApproveDeletingData bool `json:"autoApproveDeletingData,omitempty"` // auto approve apply queries about deleting data
 }
 
 // Contains the cluster destroy flags

--- a/pkg/tarmak/cmd.go
+++ b/pkg/tarmak/cmd.go
@@ -39,7 +39,7 @@ func (c *CmdTarmak) Plan() (returnCode int, err error) {
 		return 1, err
 	}
 
-	changesNeeded, err := c.terraform.Plan(c.Cluster())
+	changesNeeded, err := c.terraform.Plan(c.Cluster(), false)
 	if changesNeeded {
 		return 2, err
 	} else {

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -143,6 +143,7 @@ type Tarmak interface {
 
 	Clusters() []Cluster
 	Cluster() Cluster
+	ClusterFlags() tarmakv1alpha1.ClusterFlags
 	Environments() []Environment
 	Environment() Environment
 	Providers() []Provider

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -388,3 +388,7 @@ func (t *Tarmak) verifyImageExists() error {
 
 	return nil
 }
+
+func (t *Tarmak) ClusterFlags() tarmakv1alpha1.ClusterFlags {
+	return t.flags.Cluster
+}


### PR DESCRIPTION
auto-approve will auto approve all query responses to a cluster apply
auto-approve-deleting-data will auto approve all query responses about
data deletion to a cluster apply

fixes #549 

```release-note
Adds flags --auto-approve and --auto-approve-deleting-data to `cluster apply`
```

/hold
/assign
