### PR TITLE
Instance verify too eager for AWS API when all instances customised

### DIFF
--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -585,6 +586,8 @@ func (a *Amazon) verifyInstanceTypes() error {
 		if err := a.verifyInstanceType(instanceType, instance.Zones(), svc); err != nil {
 			result = multierror.Append(result, err)
 		}
+
+		time.Sleep(200 * time.Millisecond)
 
 	}
 


### PR DESCRIPTION
**If you customise multiple image types in instance pools, without using the "tiny,small,etc." shorthand, installation fails because your requests for available instance types exceed their rate limit**:
