### PR TITLE
Slow down verification of AWS instance types due to rate limit

### DIFF
--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+        "time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -585,6 +586,8 @@ func (a *Amazon) verifyInstanceTypes() error {
 		if err := a.verifyInstanceType(instanceType, instance.Zones(), svc); err != nil {
 			result = multierror.Append(result, err)
 		}
+
+		time.Sleep(200 * time.Millisecond)
 
 	}
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-        "time"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"


### PR DESCRIPTION
Signed-off-by: Sean Turner <sean@secops.ltd>

**When you customise multiple instance types, tarmak fails due to trying to verify these types are available in your region faster than the AWS API will allow**:

```release-note
Slows down verification of AWS instance types so we don't hit the rate limit for these requests
```
