### PR TITLE
Improve consul and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 |-------------|-------------------:|---------:|
 | Packer      |                    | `1.0.2`  |
 | Terraform   |                    | `0.11.8` |
-| Consul      |                    | `1.0.6`  |
+| Consul      |                    | `1.2.3`  |
 | Vault       |                    | `0.9.5`  |
 | Kubernetes  | `>= 1.7 && < 1.11` | `1.10.6` |
 | Calico      |                    | `3.1.3`  |

--- a/puppet/modules/consul/manifests/config.pp
+++ b/puppet/modules/consul/manifests/config.pp
@@ -58,6 +58,7 @@ class consul::config (
       default =>  1,
     },
     server              => $consul::server,
+    leave_on_terminate  => true,
     disable_remote_exec => true,
     retry_join          => $consul::cloud_provider ? {
       'aws'   => ["provider=aws tag_key=VaultCluster tag_value=${environment}"],

--- a/puppet/modules/consul/manifests/config.pp
+++ b/puppet/modules/consul/manifests/config.pp
@@ -53,10 +53,7 @@ class consul::config (
       true    => $consul::_consul_encrypt,
       default =>  undef,
     },
-    bootstrap_expect    => defined('$consul::_consul_bootstrap_expect') ? {
-      true    =>  $consul::_consul_bootstrap_expect.scanf('%i')[0],
-      default =>  1,
-    },
+    bootstrap_expect    => $consul::_consul_bootstrap_expect,
     server              => $consul::server,
     leave_on_terminate  => true,
     disable_remote_exec => true,

--- a/puppet/modules/consul/manifests/init.pp
+++ b/puppet/modules/consul/manifests/init.pp
@@ -18,7 +18,7 @@
 class consul(
   Optional[String] $consul_master_token = undef,
   Optional[String] $consul_encrypt = undef,
-  Optional[String] $consul_bootstrap_expect = undef,
+  Optional[Integer] $consul_bootstrap_expect = undef,
   String $fqdn = '',
   String $private_ip = '127.0.0.1',
   String $region = '',
@@ -90,7 +90,10 @@ class consul(
   }
 
   $_consul_bootstrap_expect = $consul_bootstrap_expect ? {
-    undef   => $::consul_bootstrap_expect,
+    undef => defined('$::consul_bootstrap_expect') ? {
+      true    =>  $::consul_bootstrap_expect.scanf('%i')[0],
+      default =>  1,
+    },
     default => $consul_bootstrap_expect,
   }
 

--- a/puppet/modules/consul/manifests/params.pp
+++ b/puppet/modules/consul/manifests/params.pp
@@ -5,7 +5,7 @@
 #
 class consul::params {
   $app_name = 'consul'
-  $version = '1.2.1'
+  $version = '1.2.3'
   $exporter_version = '0.3.0'
   $backinator_version = '1.3'
   $download_dir = '/tmp'

--- a/puppet/modules/consul/manifests/service.pp
+++ b/puppet/modules/consul/manifests/service.pp
@@ -25,6 +25,7 @@ class consul::service(
 
   $consul_encrypt = $consul::_consul_encrypt
   $consul_master_token = $consul::_consul_master_token
+  $consul_bootstrap_expect = $consul::_consul_bootstrap_expect
 
   $user = $consul::user
   $group = $consul::group

--- a/puppet/modules/consul/spec/acceptance/single_node_spec.rb
+++ b/puppet/modules/consul/spec/acceptance/single_node_spec.rb
@@ -46,6 +46,13 @@ class{'consul':}
         apply_manifest(pp, :catch_failures => true)
         expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
       end
+
+      hosts_as('consul').each do |host|
+        it "test consul node output on host #{host.name}" do
+          nodes = host.shell("eval \"$(cat /etc/consul/master-token) /opt/bin/consul members -detailed\"").stdout.split("\n").drop(1)
+          expect(nodes.length).to eq(1)
+        end
+      end
     end
   end
 end

--- a/puppet/modules/consul/spec/classes/config_spec.rb
+++ b/puppet/modules/consul/spec/classes/config_spec.rb
@@ -6,7 +6,7 @@ describe 'consul::config' do
       class{'consul':
         cloud_provider => 'aws',
         consul_master_token => 'master_token',
-        consul_bootstrap_expect => '3',
+        consul_bootstrap_expect => 3,
         consul_encrypt => 'enc',
         environment => 'env',
       }

--- a/puppet/modules/consul/spec/classes/install_spec.rb
+++ b/puppet/modules/consul/spec/classes/install_spec.rb
@@ -8,7 +8,7 @@ describe 'consul::install' do
   end
 
   let :version do
-    '1.2.1'
+    '1.2.3'
   end
 
   context 'with default values for all parameters' do
@@ -23,7 +23,7 @@ describe 'consul::install' do
       )
       should contain_file('/opt/bin/consul').with(
         :ensure => 'link',
-        :target => '/opt/consul-1.2.1/consul',
+        :target => "/opt/consul-#{version}/consul",
       )
     end
 
@@ -42,13 +42,13 @@ describe 'consul::install' do
     end
 
     it 'should install consul backup script' do
-      should contain_file('/opt/consul-1.2.1/consul-backup.sh').with(
+      should contain_file("/opt/consul-#{version}/consul-backup.sh").with(
         :ensure => 'file',
         :mode => '0755',
       )
       should contain_file('/opt/bin/consul-backup.sh').with(
         :ensure => 'link',
-        :target => '/opt/consul-1.2.1/consul-backup.sh',
+        :target => "/opt/consul-#{version}/consul-backup.sh",
       )
     end
 

--- a/puppet/modules/consul/spec/classes/service_spec.rb
+++ b/puppet/modules/consul/spec/classes/service_spec.rb
@@ -6,7 +6,7 @@ describe 'consul::service' do
       class{'consul':
         cloud_provider => 'aws',
         consul_master_token => 'master_token',
-        consul_bootstrap_expect => '3',
+        consul_bootstrap_expect => 3,
         consul_encrypt => 'enc',
         environment => 'env',
       }

--- a/puppet/modules/consul/templates/consul.service.erb
+++ b/puppet/modules/consul/templates/consul.service.erb
@@ -16,6 +16,8 @@ Requires=<%= @_systemd_requires.join(' ') %>
 [Service]
 User=<%= @user %>
 Group=<%= @group %>
+Type=notify
+TimeoutStartSec=600s
 PermissionsStartOnly=true
 ExecStartPre=/bin/mkdir -p <%= @data_dir %>/data
 ExecStartPre=/bin/chown -c root:<%= @group %> <%= @data_dir %>

--- a/puppet/modules/consul/templates/consul.service.erb
+++ b/puppet/modules/consul/templates/consul.service.erb
@@ -16,8 +16,10 @@ Requires=<%= @_systemd_requires.join(' ') %>
 [Service]
 User=<%= @user %>
 Group=<%= @group %>
+<% if @consul_bootstrap_expect > 1 -%>
 Type=notify
 TimeoutStartSec=600s
+<% end -%>
 PermissionsStartOnly=true
 ExecStartPre=/bin/mkdir -p <%= @data_dir %>/data
 ExecStartPre=/bin/chown -c root:<%= @group %> <%= @data_dir %>

--- a/terraform/amazon/modules/vault/templates/vault_user_data.yaml
+++ b/terraform/amazon/modules/vault/templates/vault_user_data.yaml
@@ -188,6 +188,7 @@ write_files:
       "acl_default_policy" : "deny",
       "acl_down_policy" : "deny",
       "acl_master_token" : "${consul_master_token}",
+      "acl_agent_token" : "${consul_master_token}",
       "acl_datacenter" : "${region}",
       "datacenter" : "${region}",
       "log_level" : "INFO",

--- a/terraform/amazon/modules/vault/templates/vault_user_data.yaml
+++ b/terraform/amazon/modules/vault/templates/vault_user_data.yaml
@@ -194,6 +194,7 @@ write_files:
       "bind_addr" : "0.0.0.0",
       "encrypt" : "${consul_encrypt}",
       "server" : true,
+      "leave_on_terminate" : true,
       "bootstrap_expect" : ${instance_count},
       "retry_join": [
         "provider=aws tag_key=VaultCluster tag_value=${environment}"

--- a/terraform/amazon/modules/vault/templates/vault_user_data.yaml
+++ b/terraform/amazon/modules/vault/templates/vault_user_data.yaml
@@ -102,6 +102,8 @@ write_files:
     [Service]
     User=consul
     Group=consul
+    Type=notify
+    TimeoutStartSec=600s
     PermissionsStartOnly=true
     ExecStartPre=/bin/mkdir -p /var/lib/consul/data
     ExecStartPre=/bin/chown -c root:consul /var/lib/consul

--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -104,7 +104,7 @@ variable "bastion_admin_cidrs" {
 
 # vault
 variable "consul_version" {
-  default = "1.0.6"
+  default = "1.2.3"
 }
 variable "vault_version" {
   default = "0.9.5"


### PR DESCRIPTION
This addresses a couple of consul improvement

* Updating consul to v1.2.3 (puppet module and terraform)
* Consul puppet acceptance health checks (puppet)
* Use `Type=notify` to wait for a ready consul to progress (puppet/terraform)
* Leave the cluster on terminate (puppet/terraform)
* Configure the correct agent token (terraform)
```release-note
Update consul to v1.2.3
Fixes: Consul nodes leave the cluster on terminate
Fixes: Consul agent status now having a proper token
```
