### PR TITLE
Ensure ssh key file holds correct permissions and can be parsed

### DIFF
--- a/pkg/tarmak/environment/environment.go
+++ b/pkg/tarmak/environment/environment.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -119,29 +118,6 @@ func (e *Environment) Cluster(name string) (interfaces.Cluster, error) {
 		}
 	}
 	return nil, fmt.Errorf("cluster '%s' in environment '%s' not found", name, e.Name())
-}
-
-func (e *Environment) validateSSHKey() error {
-	if err := e.tarmak.SSH().Validate(); err != nil {
-		return err
-	}
-
-	bytes, err := ioutil.ReadFile(e.SSHPrivateKeyPath())
-	if err != nil {
-		return fmt.Errorf("unable to read ssh private key: %s", err)
-	}
-
-	block, _ := pem.Decode(bytes)
-	if block == nil {
-		return errors.New("failed to parse PEM block containing the ssh private key")
-	}
-
-	e.sshKeyPrivate, err = x509.ParsePKCS1PrivateKey(block.Bytes)
-	if err != nil {
-		return fmt.Errorf("unable to parse private key: %s", err)
-	}
-
-	return nil
 }
 
 func (e *Environment) Variables() map[string]interface{} {
@@ -291,7 +267,7 @@ func (e *Environment) Validate() error {
 		result = multierror.Append(result, err)
 	}
 
-	if err := e.validateSSHKey(); err != nil {
+	if err := e.tarmak.SSH().Validate(); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/pkg/tarmak/environment/environment.go
+++ b/pkg/tarmak/environment/environment.go
@@ -122,24 +122,8 @@ func (e *Environment) Cluster(name string) (interfaces.Cluster, error) {
 }
 
 func (e *Environment) validateSSHKey() error {
-	f, err := os.Stat(e.SSHPrivateKeyPath())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return fmt.Errorf("failed to read ssh file status: %v", err)
-	}
-
-	if f.IsDir() {
-		return fmt.Errorf("expected ssh file location '%s' is directory", e.SSHPrivateKeyPath())
-	}
-
-	if f.Mode() != os.FileMode(0600) && f.Mode() != os.FileMode(0400) {
-		e.log.Warnf("ssh file '%s' holds incorrect permissions (%v), setting to 0600", e.SSHPrivateKeyPath(), f.Mode())
-		if err := os.Chmod(e.SSHPrivateKeyPath(), os.FileMode(0600)); err != nil {
-			return fmt.Errorf("failed to set ssh private key file permissions: %v", err)
-		}
+	if err := e.tarmak.SSH().Validate(); err != nil {
+		return err
 	}
 
 	bytes, err := ioutil.ReadFile(e.SSHPrivateKeyPath())

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -208,6 +208,7 @@ type SSH interface {
 	PassThrough([]string)
 	Tunnel(hostname string, destination string, destinationPort int) Tunnel
 	Execute(host string, cmd string, args []string) (returnCode int, err error)
+	Validate() error
 }
 
 type Tunnel interface {

--- a/pkg/tarmak/ssh.go
+++ b/pkg/tarmak/ssh.go
@@ -13,5 +13,10 @@ func (t *Tarmak) SSHPassThrough(argsAdditional []string) {
 	if err := t.ssh.WriteConfig(t.Cluster()); err != nil {
 		t.log.Fatal(err)
 	}
+
+	if err := t.ssh.Validate(); err != nil {
+		t.log.Fatal(err)
+	}
+
 	t.ssh.PassThrough(argsAdditional)
 }

--- a/pkg/tarmak/ssh/ssh.go
+++ b/pkg/tarmak/ssh/ssh.go
@@ -3,6 +3,8 @@ package ssh
 
 import (
 	"bytes"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -136,6 +138,16 @@ func (s *SSH) Validate() error {
 		if err := os.Chmod(keyPath, os.FileMode(0600)); err != nil {
 			return fmt.Errorf("failed to set ssh private key file permissions: %v", err)
 		}
+	}
+
+	bytes, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("unable to read ssh private key: %s", err)
+	}
+
+	block, _ := pem.Decode(bytes)
+	if block == nil {
+		return errors.New("failed to parse PEM block containing the ssh private key")
 	}
 
 	return nil

--- a/pkg/tarmak/ssh/ssh.go
+++ b/pkg/tarmak/ssh/ssh.go
@@ -115,3 +115,28 @@ func (s *SSH) Execute(host string, command string, argsAdditional []string) (ret
 	return 0, nil
 
 }
+
+func (s *SSH) Validate() error {
+	keyPath := s.tarmak.Environment().SSHPrivateKeyPath()
+	f, err := os.Stat(keyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to read ssh file status: %v", err)
+	}
+
+	if f.IsDir() {
+		return fmt.Errorf("expected ssh file location '%s' is directory", keyPath)
+	}
+
+	if f.Mode() != os.FileMode(0600) && f.Mode() != os.FileMode(0400) {
+		s.log.Warnf("ssh file '%s' holds incorrect permissions (%v), setting to 0600", keyPath, f.Mode())
+		if err := os.Chmod(keyPath, os.FileMode(0600)); err != nil {
+			return fmt.Errorf("failed to set ssh private key file permissions: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -172,7 +172,8 @@ func (t *Tarmak) writeSSHConfigForClusterHosts() error {
 		}
 		return fmt.Errorf("failed to write ssh config for current cluster '%s': %v", clusterName, err)
 	}
-	return nil
+
+	return t.ssh.Validate()
 }
 
 // This initializes a new tarmak cluster


### PR DESCRIPTION
fixes #567 

SSH key is able to hold 0400 or 0600 permissions. If it doesn't match tarmak will attempt to set to 0600.
SSH key file will be tested if it can be correctly parsed.

```release-note
NONE
```

/assign @simonswine 
