### PR TITLE
Improve error when remote state is destroyed

### DIFF
--- a/pkg/tarmak/terraform.go
+++ b/pkg/tarmak/terraform.go
@@ -43,7 +43,6 @@ func (c *CmdTerraform) Plan() (returnCode int, err error) {
 		return 1, err
 	}
 
-	c.log.Info("running plan")
 	changesNeeded, err := c.tarmak.terraform.Plan(c.tarmak.Cluster())
 	if changesNeeded {
 		return 2, err
@@ -57,7 +56,6 @@ func (c *CmdTerraform) Apply() error {
 		return err
 	}
 
-	c.log.Info("running apply")
 	// run terraform apply always, do not run it when in configuration only mode
 	if !c.tarmak.flags.Cluster.Apply.ConfigurationOnly {
 		err := c.tarmak.terraform.Apply(c.tarmak.Cluster())
@@ -102,7 +100,6 @@ func (c *CmdTerraform) Destroy() error {
 		return err
 	}
 
-	c.log.Info("running destroy")
 	err := c.tarmak.terraform.Destroy(c.tarmak.Cluster())
 	if err != nil {
 		return err

--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -11,7 +11,8 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
+
 	clusterv1alpha1 "github.com/jetstack/tarmak/pkg/apis/cluster/v1alpha1"
 	"github.com/jetstack/tarmak/pkg/tarmak/cluster"
 	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
@@ -20,6 +21,8 @@ import (
 )
 
 func (t *Terraform) GenerateCode(c interfaces.Cluster) (err error) {
+	t.log.Info("generating terraform code")
+
 	terraformCodePath := t.codePath(c)
 	if err := utils.EnsureDirectory(
 		terraformCodePath,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds extra context to the error when the remote state is destroyed. This also enabled us to check for further errors in the future to give more context/advise

fixes #528 

```release-note
Provide advise when remote state has been destroyed
```
/assign @simonswine 
