### PR TITLE
Rate limit aws verify (to avoid RequestLimitExceeded error)

### DIFF
--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+        "time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -585,6 +586,8 @@ func (a *Amazon) verifyInstanceTypes() error {
 		if err := a.verifyInstanceType(instanceType, instance.Zones(), svc); err != nil {
 			result = multierror.Append(result, err)
 		}
+
+		time.Sleep(200 * time.Millisecond)
 
 	}
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-        "time"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"

--- a/pkg/tarmak/utils/networks.go
+++ b/pkg/tarmak/utils/networks.go
@@ -3,10 +3,19 @@ package utils
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"net"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 )
+
+// Jitter allows for exponential backoff
+type Jitter struct {
+	Min, Max float64
+	Interval time.Duration
+}
 
 func UnusedPort() int {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
@@ -35,4 +44,29 @@ func NetworkOverlap(netCIDRs []*net.IPNet) error {
 		}
 	}
 	return result
+}
+
+// BackoffInterval takes
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#api-request-rate
+// https://docs.aws.amazon.com/general/latest/gr/api-retries.html
+func BackoffInterval(jitter *Jitter, attempt int) time.Duration {
+	fmt.Printf("REACHED BackoffInterval()\n")
+	fmt.Printf("interval: %v\n", jitter.Interval)
+	fmt.Printf("attempt currently at: %2d\n", attempt)
+
+	// <LOGIC>
+
+	r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	duration := float64(jitter.Min * math.Pow(2.0, float64(attempt)))
+	if duration > jitter.Max {
+		duration = jitter.Max
+	}
+
+	jitter.Interval = time.Duration(r1.Float64()*(duration-jitter.Min) + jitter.Min)
+
+	// </LOGIC>
+
+	fmt.Printf("sleeping for: %v\n", jitter.Interval)
+	return jitter.Interval
 }

--- a/pkg/tarmak/utils/networks.go
+++ b/pkg/tarmak/utils/networks.go
@@ -3,19 +3,10 @@ package utils
 
 import (
 	"fmt"
-	"math"
-	"math/rand"
 	"net"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 )
-
-// Jitter allows for exponential backoff
-type Jitter struct {
-	Min, Max float64
-	Interval time.Duration
-}
 
 func UnusedPort() int {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{
@@ -44,29 +35,4 @@ func NetworkOverlap(netCIDRs []*net.IPNet) error {
 		}
 	}
 	return result
-}
-
-// BackoffInterval takes
-// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#api-request-rate
-// https://docs.aws.amazon.com/general/latest/gr/api-retries.html
-func BackoffInterval(jitter *Jitter, attempt int) time.Duration {
-	fmt.Printf("REACHED BackoffInterval()\n")
-	fmt.Printf("interval: %v\n", jitter.Interval)
-	fmt.Printf("attempt currently at: %2d\n", attempt)
-
-	// <LOGIC>
-
-	r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	duration := float64(jitter.Min * math.Pow(2.0, float64(attempt)))
-	if duration > jitter.Max {
-		duration = jitter.Max
-	}
-
-	jitter.Interval = time.Duration(r1.Float64()*(duration-jitter.Min) + jitter.Min)
-
-	// </LOGIC>
-
-	fmt.Printf("sleeping for: %v\n", jitter.Interval)
-	return jitter.Interval
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When a large number of AWS 'describe' API calls are made within a short period of time, AWS can return a RequestLimitExceeded error. This PR deals with this by implementing a retry with backoff.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #565 

**Special notes for your reviewer**:
Uses backoff library instead of a hard-coded sleep
github.com/cenkalti/backoff - this library is already used elsewhere in the Tarmak source code 

**Release note**:
```release-note
Retry backoff implemented when verifying instance types to prevent RequestLimitExceeded error from AWS API
```