### PR TITLE
Enables additional policies for bastion and vault instance pools

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -72,8 +72,8 @@ type Cluster struct {
 
 // ClusterAmazon offers Amazon-specific settings for that instance pool
 type ClusterAmazon struct {
-	// This fields contains ARNs for additional IAM policies to be added to this
-	// instance pool
+	// This fields contains ARNs for additional IAM policies to be added to
+	// this instance pool
 	AdditionalIAMPolicies []string `json:"additionalIAMPolicies,omitempty"`
 	// When set to true, AWS Elastic Block Storage volumes are encrypted
 	EBSEncrypted *bool `json:"ebsEncrypted,omitempty"`

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -80,6 +80,10 @@ func SetDefaults_Cluster(obj *Cluster) {
 		obj.Amazon.EBSEncrypted = boolPointer(false)
 	}
 
+	if obj.Amazon.AdditionalIAMPolicies == nil {
+		obj.Amazon.AdditionalIAMPolicies = []string{}
+	}
+
 	// logging
 	if obj.LoggingSinks == nil {
 		obj.LoggingSinks = []*LoggingSink{}
@@ -177,6 +181,13 @@ func SetDefaults_InstancePool(obj *InstancePool) {
 		if obj.Volumes[pos].Type == "" {
 			obj.Volumes[pos].Type = VolumeTypeSSD
 		}
+	}
+
+	if obj.Amazon == nil {
+		obj.Amazon = new(InstancePoolAmazon)
+	}
+	if obj.Amazon.AdditionalIAMPolicies == nil {
+		obj.Amazon.AdditionalIAMPolicies = []string{}
 	}
 }
 

--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -736,6 +736,7 @@ func (c *Cluster) Variables() map[string]interface{} {
 		output[fmt.Sprintf("%s_max_instance_count", instancePool.TFName())] = instancePool.Config().MaxCount
 		output[fmt.Sprintf("%s_root_volume_size", instancePool.TFName())] = instancePool.RootVolume().Size()
 		output[fmt.Sprintf("%s_root_volume_type", instancePool.TFName())] = instancePool.RootVolume().Type()
+		output[fmt.Sprintf("%s_iam_additional_policy_arns", instancePool.TFName())] = instancePool.Config().Amazon.AdditionalIAMPolicies
 	}
 
 	// set network cidr

--- a/terraform/amazon/modules/bastion/bastion.tf
+++ b/terraform/amazon/modules/bastion/bastion.tf
@@ -31,6 +31,7 @@ resource "aws_instance" "bastion" {
   subnet_id              = "${var.public_subnet_ids[0]}"
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${aws_security_group.bastion.0.id}"]
+  iam_instance_profile   = "${aws_iam_instance_profile.bastion.name}"
 
   root_block_device = {
     volume_type = "gp2"

--- a/terraform/amazon/modules/bastion/bastion_iam.tf
+++ b/terraform/amazon/modules/bastion/bastion_iam.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_role" "bastion" {
+  name               = "${data.template_file.stack_name.rendered}-bastion"
+  count              = "${var.bastion_min_instance_count}"
+  path               = "/bastion-${var.environment}/"
+  assume_role_policy = "${file("${path.module}/templates/role.json")}"
+}
+
+resource "aws_iam_instance_profile" "bastion" {
+  name  = "${data.template_file.stack_name.rendered}-bastion"
+  count = "${var.bastion_min_instance_count}"
+  role  = "${aws_iam_role.bastion.name}"
+}
+
+resource "aws_iam_policy_attachment" "bastion_additional_policy" {
+  name       = "${data.template_file.stack_name.rendered}-bastion-additional-policy-${count.index+1}"
+  roles      = ["${aws_iam_role.bastion.name}"]
+  count      = "${length(var.bastion_iam_additional_policy_arns)}"
+  policy_arn = "${element(var.bastion_iam_additional_policy_arns, count.index)}"
+}

--- a/terraform/amazon/modules/bastion/inputs.tf
+++ b/terraform/amazon/modules/bastion/inputs.tf
@@ -12,6 +12,7 @@ variable "project" {}
 variable "contact" {}
 variable "bastion_ami" {}
 variable "bastion_instance_type" {}
+variable "bastion_min_instance_count" {}
 
 # data.terraform_remote_state.network.public_subnet_ids
 variable "public_subnet_ids" {
@@ -31,3 +32,7 @@ variable "public_zone_id" {}
 
 # data.terraform_remote_state.network.private_zone_id.0
 variable "private_zone_id" {}
+
+variable "bastion_iam_additional_policy_arns" {
+  type = "list"
+}

--- a/terraform/amazon/modules/bastion/templates/role.json
+++ b/terraform/amazon/modules/bastion/templates/role.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}

--- a/terraform/amazon/modules/vault/inputs.tf
+++ b/terraform/amazon/modules/vault/inputs.tf
@@ -83,3 +83,7 @@ data "template_file" "stack_name" {
 data "template_file" "vault_unseal_key_name" {
   template = "vault-${var.environment}-"
 }
+
+variable "vault_iam_additional_policy_arns" {
+  type = "list"
+}

--- a/terraform/amazon/modules/vault/vault_iam.tf
+++ b/terraform/amazon/modules/vault/vault_iam.tf
@@ -39,3 +39,10 @@ data "template_file" "vault_policy" {
     vault_unsealer_ssm_key_prefix = "${data.template_file.vault_unseal_key_name.rendered}"
   }
 }
+
+resource "aws_iam_policy_attachment" "vault_additional_policies" {
+  name       = "${data.template_file.stack_name.rendered}-vault-additional-policy-${count.index+1}"
+  roles      = ["${aws_iam_role.vault.*.name}"]
+  count      = "${length(var.vault_iam_additional_policy_arns)}"
+  policy_arn = "${element(var.vault_iam_additional_policy_arns, count.index)}"
+}

--- a/terraform/amazon/templates/inputs.tf.template
+++ b/terraform/amazon/templates/inputs.tf.template
@@ -99,6 +99,8 @@ variable "bastion_root_size" {
   default = "16"
 }
 
+variable "bastion_min_instance_count" {}
+
 {{ if .JenkinsInstall -}}
 variable "jenkins_ami" {}
 
@@ -120,6 +122,10 @@ variable "jenkins_admin_cidrs" {
 {{ end -}}
 
 variable "bastion_admin_cidrs" {
+  type = "list"
+}
+
+variable "bastion_iam_additional_policy_arns" {
   type = "list"
 }
 
@@ -150,6 +156,10 @@ variable "vault_ami" {}
 
 # state
 variable "bucket_prefix" {}
+
+variable vault_iam_additional_policy_arns {
+  type = "list"
+}
 {{ end -}}
 {{ if or (eq .ClusterType .ClusterTypeClusterSingle) (eq .ClusterType .ClusterTypeClusterMulti) -}}
 {{ range .InstancePools -}}

--- a/terraform/amazon/templates/modules.tf.template
+++ b/terraform/amazon/templates/modules.tf.template
@@ -68,6 +68,9 @@ module "bastion" {
   bastion_admin_cidrs   = ["${var.bastion_admin_cidrs}"]
   public_zone_id        = "${module.state.public_zone_id}"
   private_zone_id       = "${module.network.private_zone_id[0]}"
+
+  bastion_min_instance_count         = "${var.bastion_min_instance_count}"
+  bastion_iam_additional_policy_arns = ["${var.bastion_iam_additional_policy_arns}"]
 }
 
 {{ if .JenkinsInstall -}}
@@ -130,6 +133,8 @@ module "vault" {
   vpc_id                    = "${module.network.vpc_id}"
   bastion_instance_id       = "${module.bastion.bastion_instance_id}"
   vault_cluster_name        = "${var.vault_cluster_name}"
+
+  vault_iam_additional_policy_arns = ["${var.vault_iam_additional_policy_arns}"]
 }
 {{- end -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Additional IAM policies from the tarmak config were not enabled for vault and bastion instance pools. This PR creates a instance profile to the bastion instance to attach policies to. 
Bastion and vault instance pools now attach policies from arns in the config

fixes #519 

```release-note
Bastion and Vault instance pools now support additional policies declared in the config
```

/assign @simonswine @dippynark 
