### PR TITLE
Move tarmak sock to /tmp and ensure cleanup

### DIFF
--- a/cmd/tarmak/cmd/cluster_force-unlock.go
+++ b/cmd/tarmak/cmd/cluster_force-unlock.go
@@ -12,11 +12,8 @@ var clusterForceUnlockCmd = &cobra.Command{
 	Short: "Remove remote lock using lock ID",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
-		defer t.Cleanup()
 
-		forceUnlockCmd := t.NewCmdTerraform(args)
-
-		t.CancellationContext().WaitOrCancel(forceUnlockCmd.ForceUnlock)
+		t.CancellationContext().WaitOrCancel(t.NewCmdTerraform(args).ForceUnlock)
 	},
 }
 

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -157,13 +157,13 @@ type Tarmak interface {
 	HomeDir() string
 	KeepContainers() bool
 	CancellationContext() CancellationContext
+	Cleanup()
 
 	// get a provider by name
 	ProviderByName(string) (Provider, error)
 	// get an environment by name
 	EnvironmentByName(string) (Environment, error)
 	EnsureRemoteResources() error
-	Cleanup()
 }
 
 type Config interface {

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -328,12 +328,18 @@ func (t *Tarmak) EnsureRemoteResources() error {
 }
 
 func (t *Tarmak) Cleanup() {
+	plugin.CleanupClients()
+
 	// clean up assets directory
 	if t.rootPath != nil {
 		if err := os.RemoveAll(*t.rootPath); err != nil {
 			t.log.Warnf("error cleaning up assets directory: %s", err)
 		}
 		t.rootPath = nil
+	}
+
+	if err := t.terraform.Cleanup(); err != nil {
+		t.log.Warnf("error cleaning up terraform assets: %s", err)
 	}
 }
 
@@ -346,7 +352,6 @@ func (t *Tarmak) Variables() map[string]interface{} {
 
 func (t *Tarmak) Perform(err error) {
 	t.Cleanup()
-	plugin.CleanupClients()
 	t.Must(err)
 }
 

--- a/pkg/tarmak/utils/context.go
+++ b/pkg/tarmak/utils/context.go
@@ -121,15 +121,15 @@ func (c *CancellationContext) WaitOrCancelReturnCode(f func() (int, error)) {
 	switch err {
 	case nil:
 		log.Info("Tarmak performed all tasks successfully.")
-		c.cleanup()
+		c.tarmak.Cleanup()
 		log.Exit(retCode)
 	case context.Canceled:
 		log.Errorf("Tarmak was canceled (%s). Re-run to complete any remaining tasks.", c.sig)
-		c.cleanup()
+		c.tarmak.Cleanup()
 		log.Exit(1)
 	default:
 		log.Errorf("Tarmak exited with an error: %s", err)
-		c.cleanup()
+		c.tarmak.Cleanup()
 		log.Exit(1)
 	}
 }

--- a/pkg/terraform/templating.go
+++ b/pkg/terraform/templating.go
@@ -97,6 +97,7 @@ func (t *Terraform) GenerateCode(c interfaces.Cluster) (err error) {
 
 	// generate templates
 	templ := &terraformTemplate{
+		terraform:   t,
 		cluster:     c,
 		destDir:     terraformCodePath,
 		rootPath:    rootPath,
@@ -112,6 +113,7 @@ func (t *Terraform) GenerateCode(c interfaces.Cluster) (err error) {
 }
 
 type terraformTemplate struct {
+	terraform   *Terraform
 	cluster     interfaces.Cluster
 	destDir     string
 	rootPath    string
@@ -180,7 +182,7 @@ func (t *terraformTemplate) data(module string) map[string]interface{} {
 		"ExistingVPC":              existingVPC,
 		// cluster.Roles() returns a list of roles based off of the types of instancePools in tarmak.yaml
 		"Roles":                 t.cluster.Roles(),
-		"SocketPath":            tarmakSocketPath(t.cluster.ConfigPath()),
+		"SocketPath":            t.terraform.socketPath,
 		"JenkinsCertificateARN": jenkinsCertificateARN,
 		"JenkinsInstall":        jenkinsInstall,
 		"Module":                module,


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a maximum limit to the path name of sockets. This caused problems with config files in deep file paths. This moves the socket to /tmp so is never too long. This also ensures that all resources created in /tmp are now deleted at the end of run.

fixes #586 

```release-note
Move tarmak terraform provider socket to /tmp
```

/assign @MattiasGees 
/cc @MattiasGees @simonswine 
