### PR TITLE
Update cobra shorts with arguments for docs gen

### DIFF
--- a/cmd/tarmak/cmd/cluster_force-unlock.go
+++ b/cmd/tarmak/cmd/cluster_force-unlock.go
@@ -8,7 +8,7 @@ import (
 )
 
 var clusterForceUnlockCmd = &cobra.Command{
-	Use:   "force-unlock",
+	Use:   "force-unlock [lock ID]",
 	Short: "Remove remote lock using lock ID",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)

--- a/cmd/tarmak/cmd/cluster_instances_ssh.go
+++ b/cmd/tarmak/cmd/cluster_instances_ssh.go
@@ -8,7 +8,7 @@ import (
 )
 
 var clusterInstancesSshCmd = &cobra.Command{
-	Use:   "ssh",
+	Use:   "ssh [instance alias]",
 	Short: "Log into an instance with SSH",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)

--- a/cmd/tarmak/cmd/cluster_kubectl.go
+++ b/cmd/tarmak/cmd/cluster_kubectl.go
@@ -8,7 +8,7 @@ import (
 )
 
 var clusterKubectlCmd = &cobra.Command{
-	Use:   "kubectl",
+	Use:   "kubectl [kubectl command arguments]",
 	Short: "Run kubectl on the current cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)

--- a/cmd/tarmak/cmd/cluster_set-current.go
+++ b/cmd/tarmak/cmd/cluster_set-current.go
@@ -8,14 +8,14 @@ import (
 )
 
 var clusterSetCurrentCmd = &cobra.Command{
-	Use:   "set-current",
+	Use:   "set-current [environment-cluster]",
 	Short: "Set current cluster in config",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)
 		defer t.Cleanup()
 
 		if len(args) != 1 {
-			t.Log().Fatalf("Only one cluster can be set as current cluster")
+			t.Log().Fatal("Expecting a single environment-cluster argument to be set as current")
 		}
 
 		found := false

--- a/cmd/tarmak/cmd/cluster_ssh.go
+++ b/cmd/tarmak/cmd/cluster_ssh.go
@@ -8,7 +8,7 @@ import (
 )
 
 var clusterSshCmd = &cobra.Command{
-	Use:   "ssh",
+	Use:   "ssh [instance alias]",
 	Short: "Log into an instance with SSH",
 	Run: func(cmd *cobra.Command, args []string) {
 		t := tarmak.New(globalFlags)


### PR DESCRIPTION
**What this PR does / why we need it**:
We are going to automate generating command documentation. As such, we should add some more information about what arguments command take.

```release-note
NONE
```

/assign @MattiasGees @simonswine 
