### PR TITLE
Clean up ssh run time assets

### DIFF
--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -212,6 +212,7 @@ type SSH interface {
 	Tunnel(hostname string, destination string, destinationPort int) Tunnel
 	Execute(host string, cmd string, args []string) (returnCode int, err error)
 	Validate() error
+	Cleanup() error
 }
 
 type Tunnel interface {
@@ -233,6 +234,7 @@ type Host interface {
 	Roles() []string
 	SSHConfig() string
 	Parameters() map[string]string
+	SSHControlPath() string
 }
 
 type Puppet interface {

--- a/pkg/tarmak/provider/amazon/hosts.go
+++ b/pkg/tarmak/provider/amazon/hosts.go
@@ -4,6 +4,7 @@ package amazon
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -192,4 +193,9 @@ func (a *Amazon) ListHosts(c interfaces.Cluster) ([]interfaces.Host, error) {
 	}
 
 	return hostsInterfaces, nil
+}
+
+func (h *host) SSHControlPath() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf(
+		"ssh-control-%s@%s:22", h.user, h.hostname))
 }

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -338,13 +338,17 @@ func (t *Tarmak) Cleanup() {
 	// clean up assets directory
 	if t.rootPath != nil {
 		if err := os.RemoveAll(*t.rootPath); err != nil {
-			t.log.Warnf("error cleaning up assets directory: %s", err)
+			t.log.Warnf("error cleaning up tarmak run time assets: %s", err)
 		}
 		t.rootPath = nil
 	}
 
+	if err := t.SSH().Cleanup(); err != nil {
+		t.log.Warnf("error cleaning up ssh run time assets: %s", err)
+	}
+
 	if err := t.terraform.Cleanup(); err != nil {
-		t.log.Warnf("error cleaning up terraform assets: %s", err)
+		t.log.Warnf("error cleaning up terraform run time assets: %s", err)
 	}
 }
 


### PR DESCRIPTION
Cleans up ssh run time assets, specifically control paths in /tmp/.

Fixes #592 

```release-note
Clean up ssh run time assets
```

/assign @MattiasGees 