### PR TITLE
Adds restart on failure to consul service

### DIFF
--- a/terraform/amazon/modules/vault/templates/vault_user_data.yaml
+++ b/terraform/amazon/modules/vault/templates/vault_user_data.yaml
@@ -115,6 +115,8 @@ write_files:
        -server \
        -config-dir=/etc/consul \
        -advertise=${private_ip}
+    Restart=on-failure
+    RestartSec=10
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
**What this PR does / why we need it**:
If for whatever reason consul exited, the systemd unit would not attempt to restart it. 
This PR adds a 10 second cool off before restarting, in-line with our upstream.

```release-note
Adds restart on failure to the consul service
```
