### PR TITLE
Do not auto-approve state deletes by default

### DIFF
--- a/cmd/tarmak/cmd/cluster.go
+++ b/cmd/tarmak/cmd/cluster.go
@@ -44,7 +44,7 @@ func clusterApplyFlags(fs *flag.FlagSet) {
 	fs.BoolVar(
 		&store.AutoApproveDeletingData,
 		"auto-approve-deleting-data",
-		true,
+		false,
 		"auto approve deletion of any data as a cause from applying cluster",
 	)
 

--- a/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
+++ b/docs/generated/cmd/tarmak/tarmak_clusters_apply.rst
@@ -21,7 +21,7 @@ Options
 ::
 
       --auto-approve                 auto approve to responses when applying cluster (default true)
-      --auto-approve-deleting-data   auto approve deletion of any data as a cause from applying cluster (default true)
+      --auto-approve-deleting-data   auto approve deletion of any data as a cause from applying cluster
   -C, --configuration-only           apply changes to configuration only, by running only puppet
       --dry-run                      don't actually change anything, just show changes that would occur
   -h, --help                         help for apply

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -440,7 +440,7 @@ func (t *Terraform) Plan(cluster interfaces.Cluster, preApply bool) (changesNeed
 		return changesNeeded, errors.New(destroyStr)
 	}
 
-	if t.tarmak.ClusterFlags().Apply.AutoApproveDeletingData || t.tarmak.ClusterFlags().Apply.AutoApprove {
+	if t.tarmak.ClusterFlags().Apply.AutoApproveDeletingData && t.tarmak.ClusterFlags().Apply.AutoApprove {
 		t.log.Warnf("auto approved deleting, %s", destroyStr)
 		return changesNeeded, nil
 	}


### PR DESCRIPTION
This also fixes the condition under which the auto-approve happens.
Fixes #636

Signed-off-by: Christian Simon <simon@swine.de>

```release-note
NONE
```
