### PR TITLE
Kube bench proposed security fixes

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -108,11 +108,14 @@ class kubernetes::apiserver(
     $_oidc_signing_algs = []
   }
 
-  # Do not set insecure_port variable of the API server on kubernetes 1.11+
+  # Do not set etcd_qorum_read
   if !$post_1_11 {
-    $insecure_port = $::kubernetes::_apiserver_insecure_port
     $etcd_quorum_read = true
   }
+
+  # insecure_port variable of the API server (needs to be set to 0 at least up to 1.13)
+  $insecure_port = $::kubernetes::_apiserver_insecure_port
+
   $secure_port = $::kubernetes::apiserver_secure_port
 
   # Default to etcd3 for versions bigger than 1.5

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -52,7 +52,11 @@ class kubernetes::apiserver(
   $_systemd_after = ['network.target'] + $systemd_after
   $_systemd_before = $systemd_before
 
+  $tls_min_version = $::kubernetes::tls_min_version
+  $tls_cipher_suites = $::kubernetes::tls_cipher_suites
+
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
+  $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
   $post_1_9 = versioncmp($::kubernetes::version, '1.9.0') >= 0
   $post_1_8 = versioncmp($::kubernetes::version, '1.8.0') >= 0
   $post_1_7 = versioncmp($::kubernetes::version, '1.7.0') >= 0

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -33,6 +33,17 @@ class kubernetes (
   Integer[-1,65535] $apiserver_insecure_port = -1,
   Integer[0,65535] $apiserver_secure_port = 6443,
   Array[Enum['AlwaysAllow', 'ABAC', 'RBAC']] $authorization_mode = [],
+  String $tls_min_version = 'VersionTLS12',
+  Array[String] $tls_cipher_suites = [
+    'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',
+    'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
+    'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
+    'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
+    'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305',
+    'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
+    'TLS_RSA_WITH_AES_256_GCM_SHA384',
+    'TLS_RSA_WITH_AES_128_GCM_SHA256',
+  ],
 ) inherits ::kubernetes::params
 {
 

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -57,7 +57,11 @@ class kubernetes::kubelet(
 ) inherits kubernetes::params{
   require ::kubernetes
 
+  $tls_min_version = $::kubernetes::tls_min_version
+  $tls_cipher_suites = $::kubernetes::tls_cipher_suites
+
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
+  $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
 
   if ! $eviction_soft_memory_available_threshold or ! $eviction_soft_memory_available_grace_period {
     $_eviction_soft_memory_available_threshold = undef

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -245,14 +245,14 @@ describe 'kubernetes::apiserver' do
           it {should contain_file(service_file).with_content(/#{Regexp.escape('--insecure-port=')}/)}
         end
 
-        context 'should not exist after 1.11' do
+        context 'should exist after 1.11' do
           let(:pre_condition) {[
             """
             class{'kubernetes': version => '1.11.0'}
               """
           ]}
 
-          it {should_not contain_file(service_file).with_content(/#{Regexp.escape('--insecure-port=')}/)}
+          it {should contain_file(service_file).with_content(/#{Regexp.escape('--insecure-port=0')}/)}
         end
       end
 

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -17,6 +17,9 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% else -%>
   --allow-privileged=false \
 <% end -%>
+<% if not @post_1_11 -%>
+  --repair-malformed-updates=false \
+<% end -%>
 <% if @_audit_enabled -%>
   --audit-policy-file=<%= scope['kubernetes::apiserver::audit_policy_file'] %> \
   --audit-log-path=<%= scope['kubernetes::apiserver::audit_log_path'] %> \

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -138,6 +138,10 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
   "--oidc-username-prefix=<%= @oidc_username_prefix %>" \
 <% end -%>
   --profiling=false \
+<% if @post_1_10 -%>
+ "--tls-min-version=<%= @tls_min_version %>" \
+ "--tls-cipher-suites=<%= @tls_cipher_suites.join(',') %>" \
+<% end -%>
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -136,6 +136,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @oidc_username_prefix -%>
   "--oidc-username-prefix=<%= @oidc_username_prefix %>" \
 <% end -%>
+  --profiling=false \
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -88,6 +88,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% end -%>
 <%- if scope['kubernetes::_service_account_key_file'] -%>
   --service-account-key-file=<%= scope['kubernetes::_service_account_key_file'] %> \
+  --service-account-lookup \
 <% end -%>
 <% if @_feature_gates != [] -%>
   --feature-gates=<%= @_feature_gates.join(',') %> \

--- a/puppet/modules/kubernetes/templates/kube-controller-manager.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-controller-manager.service.erb
@@ -30,6 +30,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/controller-manager \
   --use-service-account-credentials \
 <% end -%>
   --leader-elect=true \
+  --profiling=false \
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kube-scheduler.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-scheduler.service.erb
@@ -14,6 +14,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/scheduler \
 <% if @_feature_gates != [] -%>
   --feature-gates=<%= @_feature_gates.join(',') %> \
 <% end -%>
+  --profiling=false \
   --logtostderr=true
 
 Restart=on-failure

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -1,5 +1,6 @@
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+readOnlyPort: 0
 clusterDNS:
     - <%= @cluster_dns %>
 clusterDomain: <%= @cluster_domain %>

--- a/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
+++ b/puppet/modules/kubernetes/templates/kubelet-config.yaml.erb
@@ -46,6 +46,8 @@ systemReserved:
 tlsCertFile: <%= @cert_file %>
 tlsPrivateKeyFile: <%= @key_file %>
 <% end -%>
+tlsCipherSuites: <%= @tls_cipher_suites.inspect %>
+tlsMinVersion: <%= @tls_min_version %>
 evictionHard:
 <% if !@eviction_hard_memory_available_threshold.nil? and @eviction_hard_memory_available_threshold != 'nil' -%>
     memory.available: <%= @eviction_hard_memory_available_threshold %>

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -12,6 +12,9 @@ ExecStartPre=/bin/sh -e -c "iptables -C PREROUTING -p tcp --destination 169.254.
 <% end -%>
 ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
   --v=<%= scope['kubernetes::log_level'] %> \
+<% if not @post_1_11 -%>
+  --cadvisor-port=0 \
+<% end -%>
 <% if scope.function_versioncmp([scope['kubernetes::version'], '1.6.0']) >= 0 -%>
 <% if @_node_taints_string and @_node_taints_string.length > 0 -%>
   "--register-with-taints=<%= @_node_taints_string %>" \
@@ -60,6 +63,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% if @post_1_11 -%>
   --config=<%= @config_file  %> \
 <% else -%>
+  --read-only-port=0 \
   --cluster-dns=<%= @cluster_dns %> \
   --cluster-domain=<%= @cluster_domain %> \
 <% if @pod_cidr -%>

--- a/puppet/modules/kubernetes/templates/kubelet.service.erb
+++ b/puppet/modules/kubernetes/templates/kubelet.service.erb
@@ -160,6 +160,10 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/kubelet \
 <% if @_feature_gates != [] -%>
   --feature-gates=<%= @_feature_gates.join(',') %> \
 <% end -%>
+<% if @post_1_10 -%>
+ "--tls-min-version=<%= @tls_min_version %>" \
+ "--tls-cipher-suites=<%= @tls_cipher_suites.join(',') %>" \
+<% end -%>
 <% end -%>
   --logtostderr=true
 


### PR DESCRIPTION
```release-note
Disable profiling endpoints for control plane components
Enable service account lookup in etcd
Disable kubelets read-only ports
Hardening TLS configuration for Kubernetes >= 1.10
Do not repair malformed updates in apiserver
Fix insecure API server port enabled in >= 1.11
```
