### PR TITLE
Fix panic when initing environment  and validating ssh

### DIFF
--- a/pkg/tarmak/ssh/ssh.go
+++ b/pkg/tarmak/ssh/ssh.go
@@ -124,6 +124,11 @@ func (s *SSH) Execute(host string, command string, argsAdditional []string) (ret
 }
 
 func (s *SSH) Validate() error {
+	// no environment in tarmak so we have no SSH to validate
+	if s.tarmak.Environment() == nil {
+		return nil
+	}
+
 	keyPath := s.tarmak.Environment().SSHPrivateKeyPath()
 	f, err := os.Stat(keyPath)
 	if err != nil {

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -207,6 +207,11 @@ func (t *Tarmak) CmdClusterInit() error {
 	}
 	t.log.Infof("successfully initialized cluster '%s'", cluster.ClusterName())
 
+	err = t.Config().SetCurrentCluster(cluster.ClusterName())
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When you init from a clean tarmak we would panic when trying to validate ssh through a nil pointer. We add a check here to make sure we actually have an environment to validate ssh against.

Also when we init a cluster we weren't setting it to the current cluster which meant operations such as `tarmak cluste list` would fail - bad first UX. When you now init a new cluster this will set it as current which makes sense to me.

/assign @simonswine 
fixes #640


```release-note
NONE
```
