### PR TITLE
Adds management of ssh_known_hosts file proposal

### DIFF
--- a/docs/proposals/ssh-known_hosts.rst
+++ b/docs/proposals/ssh-known_hosts.rst
@@ -101,6 +101,9 @@ Notable items
 
 Public DSA keys will not be tagged.
 
+Care must be taken to ensure that Terraform does not override tags set by the
+Lambda function.
+
 A start has been made on the code for the Lambda function:
 
 .. code-block:: go
@@ -206,6 +209,17 @@ A start has been made on the code for the Lambda function:
   func main() {
   	lambda.Start(HandleRequest)
   }
+
+
+Limitations
+-----------
+Whilst we can restrict permissions of access for both the Lambda function and
+EC2 instances, we do not have a cryptographic signature of the public keys
+coming from the EC2 instance.
+
+Whilst using Hashicorp's Vault to set up an SSH CA for the environment would be
+advantageous, bootstrapping this process requires SSH connections from the client
+to EC2 instances. This rules out this as an option.
 
 Out of scope
 ------------

--- a/docs/proposals/ssh-known_hosts.rst
+++ b/docs/proposals/ssh-known_hosts.rst
@@ -1,0 +1,93 @@
+.. vim:set ft=rst spell:
+
+Managing SSH Known Hosts
+========================
+
+This proposal suggests a method to more securely manage and ensure
+authentication of remote hosts through the SSH protocol within Tarmak
+environments on AWS.
+
+Background
+----------
+
+Currently we solely use the external OpenSHH SSH command line tool to connect to
+remote instances on EC2 for both interactive shell sessions as well as
+tunnelling and proxy commands for other services, including, connecting to the
+Vault cluster and the private Kubernetes API server endpoint. Currently in
+development is the replacement of our programmatic use cases of SSH in favour of
+the in package Go solution, a choice stemming from pain points developing more
+sophisticated utility functions for Tarmak and the desire for improvements in
+control of connections to remote hosts.
+
+During development of this replacement it became clear that proper care must be
+taken during authentication of host public keys during connection and manual
+management of our ``ssh_known_hosts`` cluster file. Our current implementation
+allows OpenSSH to maintain this file however, does not exit with an error if
+public keys do not match due to the flag ``StrictHostKeyChecking`` set to
+``no``. Not only does a miss-match in public keys not cause an error, the
+population of known public keys on different authenticated machines to the same
+EC2 hosts will always use the hosts presented public key, meaning the set of
+public keys could potentially be different for users accessing the same cluster.
+
+Objective
+---------
+
+By implementing stricter enforcement of the ``ssh_known_hosts`` file and passing
+it's management to Tarmak, we can improve the security of SSH connections to
+remote hosts. The key high level points to achieving this is as follows:
+
+ - Disable writes from the OpenSSH command to the ``ssh_known_hosts`` file and
+   enforce strict checking.
+ - Enforce that our in package implementation of SSH connections adheres to this
+   file also.
+ - Collect public keys during instance start up that are then stored, tightly
+   coupled with that host. These keys are able to be used as a source of truth
+   for other authenticated users attempting to connect to remote hosts on the
+   cluster that have empty or an incomplete ``ssh_known_hosts`` file.
+
+Changes
+-------
+
+Firstly, we must restrict the OpenSSH command line tool from editing the
+``ssh_known_hosts`` file and strictly enforce it by updating the generator for the
+``ssh_config`` file. This enables Tarmak to take control of the ``ssh_known_hosts``
+file management.
+
+In order to create a source of truth for each host's public key, each instance
+will have it's public key attached as a tag, shortly after boot time like the
+following:
+
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| public_key | ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPF+xkIGMUNVI0gElRaTLjfA4QMN/XGJhHswDyv59DNSOtG3KwZvDF3YkAb0PkTQAYo8N5fxoKqimGugOAaefPc= |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+The population of this tag will occur during a Terraform apply in which the
+instance was created. A new custom Terraform resource should be created -
+``tarmak_ssh_public_key_tag`` - that is dependant on the AWS instance Terraform
+resource. This new resource will be handled by the current Tarmak Terraform
+provider which is to be extended to consume it. Once called for creation, it
+shall attempt to create the initial SSH connection to this host which will
+provide Tarmak with it's public key. Once acquired, it will attach this public
+key to the AWS instance and add it to the ``ssh_known_hosts`` file.
+
+All other SSH connections will rely on the contents of the ``ssh_known_hosts``
+file however, in the case the host is not present in the file, will attempt to
+use the AWS instance's ``public_key`` tag to populate it's entry.
+
+Notable items
+-------------
+
+Care should be taken when waiting for the instance to become ready to create the
+initial SSH connection for each host. It is important not to make this a
+bottleneck during the Terraform apply.
+
+Out of scope
+------------
+
+We should not disrupt the current flow of key generation on the host instances
+such as using key injection. At no point should private keys be in flight.
+
+We should not store or rely on the public key being stored in the Terraform
+state as this would require all commands that rely on SSH, to also rely on
+fetching and updating the Terraform state - significantly increasing completion
+time for even trivial tasks.

--- a/docs/proposals/ssh-known_hosts.rst
+++ b/docs/proposals/ssh-known_hosts.rst
@@ -54,21 +54,21 @@ Firstly, we must restrict the OpenSSH command line tool from editing the
 file management.
 
 In order to create a source of truth for each host's public key, each instance
-will have it's public key's attached as a tags, shortly after boot time like the
+will have it's public key's attached as tags, shortly after boot time like the
 following:
 
-+-------------------------+---------------------------------------------------------------------------+
-| PublicKey_ssh-ed25519_0 | AAAAC3NzaC1lZDI1NTE5AAAAIE90XYYm6GSDlNGejM+aY5dZEe5vK4XyU++89WdGJcDc==EOF |
-+-------------------------+---------------------------------------------------------------------------+
++-----------------------------------+---------------------------------------------------------------------------+
+| tarmak.io/ssh-host-ed25519-host-0 | AAAAC3NzaC1lZDI1NTE5AAAAIE90XYYm6GSDlNGejM+aY5dZEe5vK4XyU++89WdGJcDc==EOF |
++-----------------------------------+---------------------------------------------------------------------------+
 
 The population of these tags will happen at boot time for all instances,
 regardless of whether they have been created from a direct Terraform apply or
 via an Amazon Auto Scaling Group. At execution time, Wing - present on every
 instance - will invoke an Amazon Lambda function for Instance Tagging. Passed to
-this function will be a collection of the instances public keys, it's Amazon
+this function will be a collection of the instance's public keys, it's Amazon
 identity document and matching PKCS7 document.
 
-Upon receiving this request, the lambda function will verify the authenticity
+Upon receiving this request, the Lambda function will verify the authenticity
 of the request and identity document by verifying the instance identity and
 PKCS7 document against the public AWS certificate. Further details on this can
 be found `here
@@ -86,12 +86,20 @@ three actions:
 Once an instance has requested for the creation of it's tags, all subsequent
 requests should succeed with no action.
 
+The Lambda function will have access to only resources within the Tarmak VPC.
+This provides the Lambda function with assurances that not only the request comes from an
+Amazon instance with permissions to access it, but also that the instance must
+reside in the Tarmak VPC as the Lambda function only has permissions to add tags
+to instances in it.
+
 All SSH connections will rely on the contents of the ``ssh_known_hosts``
 file however, in the case the host is not present in the file, will attempt to
-use the AWS instance's ``publicKey..`` tag to populate it's entry.
+use the AWS instance's public key tag to populate it's entry.
 
 Notable items
 -------------
+
+Public DSA keys will not be tagged.
 
 A start has been made on the code for the Lambda function:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -41,6 +41,7 @@ iam
 init
 initialize
 initializers
+io
 iptables
 isn
 Istio

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,6 +21,7 @@ CIDR
 config
 Config
 configmap
+cryptographic
 ctrl
 doesn
 EBS
@@ -36,6 +37,7 @@ golang
 Golang
 Grafana
 gz
+Hashicorp
 hostname
 iam
 init

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -25,6 +25,7 @@ ctrl
 doesn
 EBS
 ec
+ecdsa
 Elasticsearch
 env
 etcd
@@ -62,6 +63,7 @@ nameservers
 namespace
 namespaces
 namespacing
+nistp
 offline
 oneshot
 ons
@@ -80,6 +82,7 @@ ReplicaSet
 rolename
 runtime
 setup
+sha
 stateful
 stdin
 subcommand


### PR DESCRIPTION
**What this PR does / why we need it**:
As we are replacing the ssh command line tool for all programmatic use cases in favor of an in package solution, we have discovered some problems managing the ssh_known_hosts file correctly. This proposal aims to address these. 

```release-note
Management of SSH known_hosts file Proposal
```
