### PR TITLE
Fix centos aws cli again

### DIFF
--- a/packer/amazon/centos-puppet-agent-latest-kernel.json
+++ b/packer/amazon/centos-puppet-agent-latest-kernel.json
@@ -43,6 +43,7 @@
         "yum update -y",
         "yum install -y epel-release",
         "yum install -y git puppet-agent vim tmux socat python-pip at jq unzip awscli",
+        "aws help 2> /dev/null > /dev/null ||  { yum remove -y awscli && pip install awscli==1.16.68; }",
         "rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org",
         "rpm -ivh http://www.elrepo.org/elrepo-release-7.0-2.el7.elrepo.noarch.rpm",
         "yum --enablerepo=elrepo-kernel install -y kernel-ml",

--- a/packer/amazon/centos-puppet-agent.json
+++ b/packer/amazon/centos-puppet-agent.json
@@ -43,6 +43,7 @@
         "yum update -y",
         "yum install -y epel-release",
         "yum install -y git puppet-agent vim tmux socat python-pip at jq unzip awscli",
+        "aws help 2> /dev/null > /dev/null ||  { yum remove -y awscli && pip install awscli==1.16.68; }",
         "sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/sysconfig/grub",
         "sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/default/grub",
         "grub2-mkconfig -o /boot/grub2/grub.cfg",


### PR DESCRIPTION
The code tests if help of awscli is accessible and if that fails it removes the package awscli and installs it via pip.

```release-note
Fix centos 7.6 aws cli, download it through pip if it's not working
```
