### PR TITLE
Hardcode centos release

### DIFF
--- a/packer/amazon/centos-puppet-agent-latest-kernel.json
+++ b/packer/amazon/centos-puppet-agent-latest-kernel.json
@@ -5,7 +5,8 @@
     "region": "{{env `AWS_DEFAULT_REGION`}}",
     "tarmak_environment": "{{env `TARMAK_ENVIRONMENT`}}",
     "tarmak_base_image_name": "{{env `TARMAK_BASE_IMAGE_NAME`}}",
-    "ebs_volume_encrypted": "{{env `EBS_VOLUME_ENCRYPTED`}}"
+    "ebs_volume_encrypted": "{{env `EBS_VOLUME_ENCRYPTED`}}",
+    "scripts": "{{template_dir}}"
   },
   "builders": [
     {
@@ -38,22 +39,10 @@
     {
       "type": "shell",
       "execute_command": "sudo -E -S sh '{{ .Path }}'",
-      "inline": [
-        "rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm",
-        "yum update -y",
-        "yum install -y epel-release",
-        "yum install -y git puppet-agent vim tmux socat python-pip at jq unzip awscli",
-        "aws help 2> /dev/null > /dev/null ||  { yum remove -y awscli && pip install awscli==1.16.68; }",
-        "rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org",
-        "rpm -ivh http://www.elrepo.org/elrepo-release-7.0-2.el7.elrepo.noarch.rpm",
-        "yum --enablerepo=elrepo-kernel install -y kernel-ml",
-        "sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/sysconfig/grub",
-        "sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/default/grub",
-        "grub2-set-default 0",
-        "grub2-mkconfig -o /boot/grub2/grub.cfg",
-        "rm -f /etc/sysconfig/network-scripts/ifcfg-ens*",
-        "systemctl disable kdump.service",
-        "rm -f /etc/ssh/ssh_host_*"
+      "scripts": [
+          "{{user `scripts`}}/configure_for_tarmak.sh",
+          "{{user `scripts`}}/configure_latest_kernel.sh",
+          "{{user `scripts`}}/cleanup.sh"
       ]
     }
   ]

--- a/packer/amazon/centos-puppet-agent.json
+++ b/packer/amazon/centos-puppet-agent.json
@@ -5,7 +5,8 @@
     "region": "{{env `AWS_DEFAULT_REGION`}}",
     "tarmak_environment": "{{env `TARMAK_ENVIRONMENT`}}",
     "tarmak_base_image_name": "{{env `TARMAK_BASE_IMAGE_NAME`}}",
-    "ebs_volume_encrypted": "{{env `EBS_VOLUME_ENCRYPTED`}}"
+    "ebs_volume_encrypted": "{{env `EBS_VOLUME_ENCRYPTED`}}",
+    "scripts": "{{template_dir}}"
   },
   "builders": [
     {
@@ -38,18 +39,9 @@
     {
       "type": "shell",
       "execute_command": "sudo -E -S sh '{{ .Path }}'",
-      "inline": [
-        "rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm",
-        "yum update -y",
-        "yum install -y epel-release",
-        "yum install -y git puppet-agent vim tmux socat python-pip at jq unzip awscli",
-        "aws help 2> /dev/null > /dev/null ||  { yum remove -y awscli && pip install awscli==1.16.68; }",
-        "sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/sysconfig/grub",
-        "sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/default/grub",
-        "grub2-mkconfig -o /boot/grub2/grub.cfg",
-        "rm -f /etc/sysconfig/network-scripts/ifcfg-ens*",
-        "systemctl disable kdump.service",
-        "rm -f /etc/ssh/ssh_host_*"
+      "scripts": [
+          "{{user `scripts`}}/configure_for_tarmak.sh",
+          "{{user `scripts`}}/cleanup.sh"
       ]
     }
   ]

--- a/packer/amazon/cleanup.sh
+++ b/packer/amazon/cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright Jetstack Ltd. See LICENSE for details.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# cleanup existing network configs
+rm -f /etc/sysconfig/network-scripts/ifcfg-ens*
+
+# clearing out ssh host keys
+rm -f /etc/ssh/ssh_host_*

--- a/packer/amazon/configure_for_tarmak.sh
+++ b/packer/amazon/configure_for_tarmak.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Copyright Jetstack Ltd. See LICENSE for details.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# install puppet repositories
+rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
+
+# update all packages
+yum update -y
+
+# enable epel release
+yum install -y epel-release
+yum install -y git puppet-agent vim tmux socat python-pip at jq unzip awscli
+
+# ensure aws cli works
+aws help 2> /dev/null > /dev/null ||  { yum remove -y awscli && pip install awscli==1.16.68; }
+
+# setup kernel parameters
+sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/sysconfig/grub
+sed -i '/GRUB_CMDLINE_LINUX=/c\\GRUB_CMDLINE_LINUX=\"console=tty0 crashkernel=0 console=ttyS0,115200 biosdevname=0 net.ifnames=0\"' /etc/default/grub
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# disable kdump service
+systemctl disable kdump.service

--- a/packer/amazon/configure_for_tarmak.sh
+++ b/packer/amazon/configure_for_tarmak.sh
@@ -5,6 +5,36 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+centos_release=7.5.1804
+
+# hardcode centos release
+cat > /etc/yum.repos.d/CentOS-Base.repo <<EOF
+# CentOS-Base.repo
+
+[base]
+name=CentOS-${centos_release} - Base
+baseurl=http://mirror.centos.org/centos/${centos_release}/os/\$basearch/
+        http://vault.centos.org/centos/${centos_release}/os/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-${centos_release} - Updates
+baseurl=http://mirror.centos.org/centos/${centos_release}/updates/\$basearch/
+        http://vault.centos.org/centos/${centos_release}/updates/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-${centos_release} - Extras
+baseurl=http://mirror.centos.org/centos/${centos_release}/extras/\$basearch/
+        http://vault.centos.org/centos/${centos_release}/extras/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+EOF
+
 # install puppet repositories
 rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 

--- a/packer/amazon/configure_latest_kernel.sh
+++ b/packer/amazon/configure_latest_kernel.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright Jetstack Ltd. See LICENSE for details.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# configure elrepo
+rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
+rpm -ivh http://www.elrepo.org/elrepo-release-7.0-2.el7.elrepo.noarch.rpm
+
+# enable repo and install latest kernel
+yum --enablerepo=elrepo-kernel install -y kernel-ml


### PR DESCRIPTION
This will hardcode the minor release of centos, due to continued instabilities right after the release of a new minor version
 
```release-note
Hardcode centos image release to 7.5.1804
```
