### PR TITLE
Fix error when running kube commands with public API

### DIFF
--- a/pkg/tarmak/kubectl/kubectl.go
+++ b/pkg/tarmak/kubectl/kubectl.go
@@ -344,9 +344,8 @@ func (k *Kubectl) setupConfig(c *api.Config, publicAPIEndpoint bool) (*api.Confi
 	}
 
 	// check if certificates are set
-	if !publicAPIEndpoint &&
-		(len(authInfo.ClientCertificateData) == 0 || len(authInfo.ClientKeyData) == 0 ||
-			len(cluster.CertificateAuthorityData) == 0) {
+	if len(authInfo.ClientCertificateData) == 0 || len(authInfo.ClientKeyData) == 0 ||
+		len(cluster.CertificateAuthorityData) == 0 {
 
 		if err := k.tarmak.Terraform().Prepare(k.tarmak.Environment().Hub()); err != nil {
 			return nil, nil, fmt.Errorf("failed to prepare terraform: %s", err)


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When running tarmak kubeconfig/kubectl with a public ELB in front of apiserver, it gives errors. This comes down to not setting the certificate. This fixes that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #659 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix bug with kubectl/kubeconfig and public apiserver
```
