### PR TITLE
Automated cherry pick of #660 #658

### DIFF
--- a/hack/update-reference-docs.sh
+++ b/hack/update-reference-docs.sh
@@ -76,7 +76,7 @@ rm -rf ${OUTPUT_DIR}
 cp -r ${BRODOC_VEN} ${REFERENCE_ROOT}/.
 cp ${REFERENCE_ROOT}/manifest.json ${BRODOC_DIR}/.
 rm -rf ${BRODOC_DIR}/documents/* && mkdir -p ${BRODOC_DIR}/documents && cp -r ${REFERENCE_ROOT}/includes/* ${BRODOC_DIR}/documents/
-cd ${BRODOC_DIR} && npm update && npm install && node brodoc.js && cd ../.
+cd ${BRODOC_DIR} && npm install && node brodoc.js && cd ../.
 mkdir -p ${OUTPUT_DIR} && cp -r ${BRODOC_DIR}/{*.js,*.html,*.css,node_modules} ${OUTPUT_DIR}/
 find ${OUTPUT_DIR}/node_modules -iname "*.html" -o -iname "*.rst" -type f -delete
 rm -rf ${OUTPUT_DIR}/node_modules/.bin

--- a/packer/amazon/configure_latest_kernel.sh
+++ b/packer/amazon/configure_latest_kernel.sh
@@ -11,3 +11,7 @@ rpm -ivh http://www.elrepo.org/elrepo-release-7.0-2.el7.elrepo.noarch.rpm
 
 # enable repo and install latest kernel
 yum --enablerepo=elrepo-kernel install -y kernel-ml
+
+# update grub to use latest kernel
+grub2-set-default 0
+grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/pkg/tarmak/kubectl/kubectl.go
+++ b/pkg/tarmak/kubectl/kubectl.go
@@ -344,9 +344,8 @@ func (k *Kubectl) setupConfig(c *api.Config, publicAPIEndpoint bool) (*api.Confi
 	}
 
 	// check if certificates are set
-	if !publicAPIEndpoint &&
-		(len(authInfo.ClientCertificateData) == 0 || len(authInfo.ClientKeyData) == 0 ||
-			len(cluster.CertificateAuthorityData) == 0) {
+	if len(authInfo.ClientCertificateData) == 0 || len(authInfo.ClientKeyData) == 0 ||
+		len(cluster.CertificateAuthorityData) == 0 {
 
 		if err := k.tarmak.Terraform().Prepare(k.tarmak.Environment().Hub()); err != nil {
 			return nil, nil, fmt.Errorf("failed to prepare terraform: %s", err)


### PR DESCRIPTION
Cherry pick of #660 #658 on release-0.5.

#660: Fix error when running kube commands with public API
#658: Fix latest kernel packer image

```release-note
Fix bug with kubectl/kubeconfig and public apiserver
```