### PR TITLE
Fix bug where we give false errors on instance availability

### DIFF
--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -642,9 +642,7 @@ func (a *Amazon) verifyInstanceType(instanceType string, svc EC2) error {
 	if err != nil {
 		return fmt.Errorf("error reaching aws to verify instance type %s: %v", instanceType, err)
 	}
-
-	fmt.Printf("Response: %v \n", response)
-
+	
 	if len(response.ReservedInstancesOfferings) < 1 {
 		result = multierror.Append(result, fmt.Errorf("type %s is not available in the %s region", instanceType, a.Region()))
 	}

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -590,7 +590,7 @@ func (a *Amazon) verifyInstanceTypes() error {
 			return err
 		}
 
-		if err := a.verifyInstanceType(instanceType, instance.Zones(), svc); err != nil {
+		if err := a.verifyInstanceType(instanceType, svc); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -598,7 +598,7 @@ func (a *Amazon) verifyInstanceTypes() error {
 	return result
 }
 
-func (a *Amazon) verifyInstanceType(instanceType string, zones []string, svc EC2) error {
+func (a *Amazon) verifyInstanceType(instanceType string, svc EC2) error {
 	var result error
 
 	//Request offering, filter by given instance type
@@ -642,6 +642,8 @@ func (a *Amazon) verifyInstanceType(instanceType string, zones []string, svc EC2
 	if err != nil {
 		return fmt.Errorf("error reaching aws to verify instance type %s: %v", instanceType, err)
 	}
+
+	fmt.Printf("Response: %v \n", response)
 
 	if len(response.ReservedInstancesOfferings) < 1 {
 		result = multierror.Append(result, fmt.Errorf("type %s is not available in the %s region", instanceType, a.Region()))

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -642,7 +642,6 @@ func (a *Amazon) verifyInstanceType(instanceType string, svc EC2) error {
 	if err != nil {
 		return fmt.Errorf("error reaching aws to verify instance type %s: %v", instanceType, err)
 	}
-	
 	if len(response.ReservedInstancesOfferings) < 1 {
 		result = multierror.Append(result, fmt.Errorf("type %s is not available in the %s region", instanceType, a.Region()))
 	}

--- a/pkg/tarmak/provider/amazon/amazon_test.go
+++ b/pkg/tarmak/provider/amazon/amazon_test.go
@@ -179,7 +179,7 @@ func TestAmazon_verifyAvailabilityZonesFalseGiven(t *testing.T) {
 	}
 }
 
-func TestAmazon_verifyInstanceTypeNoneGiven(t *testing.T) {
+func TestAmazon_verifyInstanceType(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -204,44 +204,13 @@ func TestAmazon_verifyInstanceTypeNoneGiven(t *testing.T) {
 
 	a.fakeEC2.EXPECT().DescribeReservedInstancesOfferings(gomock.Any()).Return(responce, nil)
 
-	err = a.verifyInstanceType("atype", []string{}, svc)
+	err = a.verifyInstanceType("atype", svc)
 	if err != nil {
 		t.Errorf("unexpected err:%v", err)
 	}
 }
 
-func TestAmazon_verifyInstanceTypeZonesGiven(t *testing.T) {
-	a := newFakeAmazon(t)
-	defer a.ctrl.Finish()
-
-	svc, err := a.EC2()
-	if err != nil {
-		t.Errorf("unexpected err:%v", err)
-	}
-
-	responce := &ec2.DescribeReservedInstancesOfferingsOutput{
-		ReservedInstancesOfferings: []*ec2.ReservedInstancesOffering{
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1a"),
-			},
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1b"),
-			},
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1c"),
-			},
-		},
-	}
-
-	a.fakeEC2.EXPECT().DescribeReservedInstancesOfferings(gomock.Any()).Return(responce, nil)
-
-	err = a.verifyInstanceType("atype", []string{"test-east-1a", "test-east-1b", "test-east-1c"}, svc)
-	if err != nil {
-		t.Errorf("unexpected err:%v", err)
-	}
-}
-
-func TestAmazon_verifyInstanceTypeZonesGivenWrong(t *testing.T) {
+func TestAmazon_verifyInstanceTypeNotAllZones(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -258,21 +227,18 @@ func TestAmazon_verifyInstanceTypeZonesGivenWrong(t *testing.T) {
 			&ec2.ReservedInstancesOffering{
 				AvailabilityZone: aws.String("test-east-1b"),
 			},
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1c"),
-			},
 		},
 	}
 
 	a.fakeEC2.EXPECT().DescribeReservedInstancesOfferings(gomock.Any()).Return(responce, nil)
 
-	err = a.verifyInstanceType("atype", []string{"test-east-1a", "test-east-1b", "test-east-1c"}, svc)
-	if err == nil {
-		t.Errorf("expected an error but got none.")
+	err = a.verifyInstanceType("atype", svc)
+	if err != nil {
+		t.Errorf("unexpected err:%v", err)
 	}
 }
 
-func TestAmazon_verifyInstanceTypeZonesOneOne(t *testing.T) {
+func TestAmazon_verifyInstanceTypeZonesOne(t *testing.T) {
 	a := newFakeAmazon(t)
 	defer a.ctrl.Finish()
 
@@ -291,61 +257,8 @@ func TestAmazon_verifyInstanceTypeZonesOneOne(t *testing.T) {
 
 	a.fakeEC2.EXPECT().DescribeReservedInstancesOfferings(gomock.Any()).Return(responce, nil)
 
-	err = a.verifyInstanceType("atype", []string{"test-east-1a"}, svc)
+	err = a.verifyInstanceType("atype", svc)
 	if err != nil {
 		t.Errorf("unexpected err:%v", err)
-	}
-}
-
-func TestAmazon_verifyInstanceTypeZonesOneMany(t *testing.T) {
-	a := newFakeAmazon(t)
-	defer a.ctrl.Finish()
-
-	svc, err := a.EC2()
-	if err != nil {
-		t.Errorf("unexpected err:%v", err)
-	}
-
-	responce := &ec2.DescribeReservedInstancesOfferingsOutput{
-		ReservedInstancesOfferings: []*ec2.ReservedInstancesOffering{
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1a"),
-			},
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1b"),
-			},
-		},
-	}
-
-	a.fakeEC2.EXPECT().DescribeReservedInstancesOfferings(gomock.Any()).Return(responce, nil)
-
-	err = a.verifyInstanceType("atype", []string{"test-east-1a"}, svc)
-	if err != nil {
-		t.Errorf("unexpected err:%v", err)
-	}
-}
-
-func TestAmazon_verifyInstanceTypeZonesNotAllAvailable(t *testing.T) {
-	a := newFakeAmazon(t)
-	defer a.ctrl.Finish()
-
-	svc, err := a.EC2()
-	if err != nil {
-		t.Errorf("unexpected err:%v", err)
-	}
-
-	responce := &ec2.DescribeReservedInstancesOfferingsOutput{
-		ReservedInstancesOfferings: []*ec2.ReservedInstancesOffering{
-			&ec2.ReservedInstancesOffering{
-				AvailabilityZone: aws.String("test-east-1a"),
-			},
-		},
-	}
-
-	a.fakeEC2.EXPECT().DescribeReservedInstancesOfferings(gomock.Any()).Return(responce, nil)
-
-	err = a.verifyInstanceType("atype", []string{"test-east-1a", "test-east-1b"}, svc)
-	if err == nil {
-		t.Errorf("expected error but got none")
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This fixes a bug where we give an error with Tarmak that an instance is not available while it is.
Becuase AWS doesn't provide an API endpoint to check instance availability, we have to use a hacky way to get it. That is why we use the reserved instance offering API.
Tarmak used to check every AZ, but this is not needed for the on-demand instances and region is enough. Now we only check if we get items back from AWS and continue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #642

**Special notes for your reviewer**:
This is also what Kops does, they only check for the whole region, not the individual AZs

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix bug where we give false errors on instance availability
```
