### PR TITLE
Ensure volumes are correctly mounted for vault instances

### DIFF
--- a/puppet/hieradata/role/vault.yaml
+++ b/puppet/hieradata/role/vault.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
 - airworthy
+- tarmak::vault
 - consul
 - vault_server

--- a/puppet/modules/consul/manifests/service.pp
+++ b/puppet/modules/consul/manifests/service.pp
@@ -6,13 +6,13 @@ class consul::service(
   String $backup_bucket_prefix = $consul::backup_bucket_prefix,
   String $backup_schedule = $consul::backup_schedule,
   Array[String] $_systemd_wants = $consul::systemd_wants,
-  Array[String] $_systemd_requires = $consul::systemd_requires,
   Array[String] $_systemd_before = $consul::systemd_before,
   Integer $consul_bootstrap_expect = $consul::_consul_bootstrap_expect
 )
 {
 
-  $_systemd_after = ['network.target'] + $consul::systemd_after
+  $_systemd_after = ['network.target', 'var-lib-consul.mount'] + $consul::systemd_after
+  $_systemd_requires = ['var-lib-consul.mount'] + $consul::systemd_requires
 
   $service_name = 'consul'
   $backup_service_name = 'consul-backup'

--- a/puppet/modules/consul/manifests/service.pp
+++ b/puppet/modules/consul/manifests/service.pp
@@ -11,8 +11,13 @@ class consul::service(
 )
 {
 
-  $_systemd_after = ['network.target', 'var-lib-consul.mount'] + $consul::systemd_after
-  $_systemd_requires = ['var-lib-consul.mount'] + $consul::systemd_requires
+  if $consul::cloud_provider == 'aws' {
+    $_systemd_after = ['network.target', 'var-lib-consul.mount'] + $consul::systemd_after
+    $_systemd_requires = ['var-lib-consul.mount'] + $consul::systemd_requires
+  } else {
+    $_systemd_after = ['network.target'] + $consul::systemd_after
+    $_systemd_requires = $consul::systemd_requires
+  }
 
   $service_name = 'consul'
   $backup_service_name = 'consul-backup'

--- a/puppet/modules/tarmak/manifests/vault.pp
+++ b/puppet/modules/tarmak/manifests/vault.pp
@@ -6,7 +6,7 @@ class tarmak::vault (
 
   include ::vault_server
 
-  if $vault_server::cloud_provider == 'aws' {
+  if $vault_server::cloud_provider == 'aws' and $::vault_server::volume_id {
     $disks = aws_ebs::disks()
     case $disks.length {
       0: {$ebs_device = ''; $is_not_attached = true}

--- a/puppet/modules/tarmak/manifests/vault.pp
+++ b/puppet/modules/tarmak/manifests/vault.pp
@@ -1,18 +1,12 @@
 class tarmak::vault (
-  String $volume_id = '',
   String $data_dir = '/var/lib/consul',
   String $dest_dir = '/opt/bin',
   String $systemd_dir = '/etc/systemd/system',
-  Enum['aws', ''] $cloud_provider = '',
 ){
 
-  if $cloud_provider == '' and defined('$::cloud_provider') {
-    $_cloud_provider = $::cloud_provider
-  } else {
-    $_cloud_provider = $cloud_provider
-  }
+  include ::vault_server
 
-  if $_cloud_provider == 'aws' {
+  if $vault_server::cloud_provider == 'aws' {
     $disks = aws_ebs::disks()
     case $disks.length {
       0: {$ebs_device = ''; $is_not_attached = true}
@@ -25,7 +19,7 @@ class tarmak::vault (
       systemd_dir => $systemd_dir,
     }
     aws_ebs::mount{'vault':
-      volume_id       => $volume_id,
+      volume_id       => $::vault_server::volume_id,
       device          => "/dev/${ebs_device}",
       dest_path       => $data_dir,
       is_not_attached => $is_not_attached,

--- a/puppet/modules/tarmak/spec/classes/vault_spec.rb
+++ b/puppet/modules/tarmak/spec/classes/vault_spec.rb
@@ -4,7 +4,7 @@ describe 'tarmak::vault' do
   context 'without params' do
     let(:pre_condition) {[
       """
-        class{'vault_server': cloud_provider => 'aws'}
+        class{'vault_server': cloud_provider => 'aws', volume_id => 'vol-1'}
       """
     ]}
 

--- a/puppet/modules/tarmak/spec/classes/vault_spec.rb
+++ b/puppet/modules/tarmak/spec/classes/vault_spec.rb
@@ -1,15 +1,13 @@
 require 'spec_helper'
 
 describe 'tarmak::vault' do
-  let(:pre_condition) do
-    """
-      class{'tarmak::vault':
-        cloud_provider => 'aws',
-      }
-    """
-  end
-
   context 'without params' do
+    let(:pre_condition) {[
+      """
+        class{'vault_server': cloud_provider => 'aws'}
+      """
+    ]}
+
     it do
       is_expected.to compile
       is_expected.to contain_file('/etc/systemd/system/attach-ebs-volume-vault.service').with(

--- a/puppet/modules/tarmak/spec/spec_helper.rb
+++ b/puppet/modules/tarmak/spec/spec_helper.rb
@@ -5,6 +5,7 @@ RSpec.configure do |config|
     :path => '/bin:/sbin:/usr/bin:/usr/sbin:/opt/bin',
     :ipaddress => '10.10.10.10',
     :osfamily => 'RedHat',
+    :consul_master_token => '',
     :disks => {
       'xvda' => {
         'size' => '16.00 GiB',

--- a/puppet/modules/vault_server/manifests/init.pp
+++ b/puppet/modules/vault_server/manifests/init.pp
@@ -17,6 +17,7 @@ class vault_server (
   String $lib_dir = $vault_server::params::lib_dir,
   String $download_dir = $vault_server::params::download_dir,
   String $systemd_dir = $vault_server::params::systemd_dir,
+  String $volume_id = '',
 ) inherits ::vault_server::params {
 
   # paths

--- a/puppet/modules/vault_server/manifests/init.pp
+++ b/puppet/modules/vault_server/manifests/init.pp
@@ -17,7 +17,7 @@ class vault_server (
   String $lib_dir = $vault_server::params::lib_dir,
   String $download_dir = $vault_server::params::download_dir,
   String $systemd_dir = $vault_server::params::systemd_dir,
-  String $volume_id = '',
+  Optional[String] $volume_id = undef,
 ) inherits ::vault_server::params {
 
   # paths

--- a/terraform/amazon/modules/vault/templates/vault_role_policy.json
+++ b/terraform/amazon/modules/vault/templates/vault_role_policy.json
@@ -20,7 +20,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:DescribeInstances"
+        "ec2:DescribeInstances",
+        "ec2:DescribeVolumes"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
Fixes the puppet to actually invoke the volume attachment for vault instances and assigns DescribeVolumes policy

```release-note
NONE
```

fixes #697 