### PR TITLE
Remove VPC endpoints from being created in existing VPC

### DIFF
--- a/docs/existing-vpc.rst
+++ b/docs/existing-vpc.rst
@@ -117,3 +117,8 @@ following annotations to your clusters network configuration (located in
 includes hub clusters.
 
 Now you can run ``tarmak cluster apply`` and continue as normal.
+
+.. warning::
+  Deploying Tarmak into an existing VPC will not automatically create VPC
+  endpoints for AWS services. It is strongly recommended that at least an S3 VPC
+  endpoint is present for your deployed cluster.

--- a/terraform/amazon/modules/network-existing-vpc/route53.tf
+++ b/terraform/amazon/modules/network-existing-vpc/route53.tf
@@ -5,7 +5,7 @@ resource "aws_route53_zone" "private" {
   comment       = "Hosted zone for private kubernetes in ${var.environment}"
 
   vpc {
-    vpc_id = "${aws_vpc.main.0.id}"
+    vpc_id = "${var.vpc_id}"
   }
 
   tags {

--- a/terraform/amazon/modules/network-existing-vpc/vpc_endpoints.tf
+++ b/terraform/amazon/modules/network-existing-vpc/vpc_endpoints.tf
@@ -1,5 +1,0 @@
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id          = "${var.vpc_id}"
-  service_name    = "com.amazonaws.${var.region}.s3"
-  route_table_ids = ["${distinct(data.aws_route_table.private.*.id)}"]
-}


### PR DESCRIPTION
fixes #706 

This removes this VPC endpoint from being created, along with a warning in the docs that it is strongly recommended that one exists. 

```release-note
S3 VPC endpoint is no longer created in deployments into an existing VPC
```
