### PR TITLE
Stop warning about failed bastion conn and forget

### DIFF
--- a/pkg/tarmak/ssh/ssh.go
+++ b/pkg/tarmak/ssh/ssh.go
@@ -332,7 +332,9 @@ func (s *SSH) bastionClient() (*ssh.Client, error) {
 				return s.bastionClientConn, nil
 			}
 		}
+
 		s.log.Warnf("current connection to bastion failed: %s", err)
+		s.bastionClientConn = nil
 	}
 
 	conf, err := s.config()


### PR DESCRIPTION
/assign @simonswine 

If the bastion client connection has failed we should forget it to prevent keep trying it and warning.


```release-note
NONE
```
