### PR TITLE
Fix heapster vertical pod autoscaler race condition

### DIFF
--- a/puppet/modules/kubernetes_addons/templates/heapster-deployment.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/heapster-deployment.yaml.erb
@@ -44,13 +44,6 @@ spec:
 <%- if @sink -%>
           - --sink=<%= @sink %>
 <%- end -%>
-        resources:
-          limits:
-            cpu: <%= @cpu %>
-            memory: <%= @mem %>
-          requests:
-            cpu: <%= @cpu %>
-            memory: <%= @mem %>
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This was race conditions since the introduction of kube-addon-manager

```release-notes
NONE
```