### PR TITLE
Set additional IAM policies correctly for all roles

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -761,7 +761,7 @@ func (c *Cluster) Variables() map[string]interface{} {
 		output[fmt.Sprintf("%s_max_instance_count", instancePool.TFName())] = instancePool.Config().MaxCount
 		output[fmt.Sprintf("%s_root_volume_size", instancePool.TFName())] = instancePool.RootVolume().Size()
 		output[fmt.Sprintf("%s_root_volume_type", instancePool.TFName())] = instancePool.RootVolume().Type()
-		output[fmt.Sprintf("%s_iam_additional_policy_arns", instancePool.TFName())] = instancePool.Config().Amazon.AdditionalIAMPolicies
+		output[fmt.Sprintf("%s_iam_additional_policy_arns", instancePool.TFName())] = instancePool.AmazonAdditionalIAMPolicies()
 	}
 
 	// set network cidr

--- a/pkg/tarmak/instance_pool/instance_pool.go
+++ b/pkg/tarmak/instance_pool/instance_pool.go
@@ -169,7 +169,7 @@ func (n *InstancePool) SpotPrice() string {
 	return n.conf.SpotPrice
 }
 
-func (n *InstancePool) AmazonAdditionalIAMPolicies() string {
+func (n *InstancePool) AmazonAdditionalIAMPolicies() []string {
 	policies := []string{}
 
 	// add cluster wide policies
@@ -184,10 +184,14 @@ func (n *InstancePool) AmazonAdditionalIAMPolicies() string {
 
 	// TODO: check for duplicates here
 
+	return policies
+}
+
+func (n *InstancePool) AmazonAdditionalIAMPoliciesString() string {
+	policies := n.AmazonAdditionalIAMPolicies()
 	for pos, _ := range policies {
 		policies[pos] = fmt.Sprintf(`"%s"`, policies[pos])
 	}
-
 	return fmt.Sprintf("[%s]", strings.Join(policies, ","))
 }
 

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -261,6 +261,7 @@ type Vault interface {
 }
 
 type InstancePool interface {
+	AmazonAdditionalIAMPolicies() []string
 	Config() *clusterv1alpha1.InstancePool
 	TFName() string
 	Name() string

--- a/terraform/amazon/templates/instance_pools/instance_pool_variables.tf.template
+++ b/terraform/amazon/templates/instance_pools/instance_pool_variables.tf.template
@@ -25,7 +25,7 @@ variable "{{.TFName}}_spot_price" {
 }
 
 variable "{{.TFName}}_iam_additional_policy_arns" {
-  default = {{.AmazonAdditionalIAMPolicies}}
+  default = {{.AmazonAdditionalIAMPoliciesString}}
 }
 
 {{ $instancePool := . -}}


### PR DESCRIPTION
Non-kubernetes instance did not receive those parameters correctly. This
PR makes sure they are set correctly in the terraform vars file.

Signed-off-by: Christian Simon <simon@swine.de>

```release-note
Fixes additional IAM policies correctly for non kubernetes roles
```
