### PR TITLE
Improve documentation on Elasticsearch index config

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -31,6 +31,7 @@ ecdsa
 Elasticsearch
 env
 etcd
+fluentbit
 Gi
 gid
 github

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -425,6 +425,22 @@ Both of those outputs can then be used in the tarmak configuration:
       additionalIAMPolicies:
       - ${elasticsearch_shipping_policy_arn}
 
+Configuring Index Templates
++++++++++++++++++++++++++++
+
+Fluentbit will publish into a new index everyday.  To optimise all of those
+indices for our logging purpose, it is beneficial to adapt some settings
+through index templates. We suggest at least considering raising the field
+limit from the default of 1000.  Also depending on the size of the
+Elasticsearch installation the number of shards and replicas should be adapted.
+This example here contains suggested settings for a single node setup:
+
+.. literalinclude:: user-guide/aws-elasticsearch/settings.json
+
+.. code-block:: yaml
+
+  curl -v -XPOST 'localhost:9200/_template/logstash' -H 'Content-Type: application/json' -d @settings.json
+
 EBS Encryption
 ~~~~~~~~~~~~~~
 

--- a/docs/user-guide/aws-elasticsearch/settings.json
+++ b/docs/user-guide/aws-elasticsearch/settings.json
@@ -1,0 +1,14 @@
+{
+  "index_patterns": [
+    "logstash-*"
+  ],
+  "settings": {
+    "number_of_shards": 10,
+    "number_of_replicas": 0,
+    "mapping": {
+      "total_fields": {
+        "limit": "10000"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This will raise the number of fields allowed in JSON document.

Signed-off-by: Christian Simon <simon@swine.de>

```release-note
NONE
```
/assign @JoshVanL 