### PR TITLE
Don't default to os.Stdin for stdin in SSH execute sessions

### DIFF
--- a/pkg/tarmak/ssh/ssh.go
+++ b/pkg/tarmak/ssh/ssh.go
@@ -247,11 +247,10 @@ func (s *SSH) Execute(host string, cmd []string, stdin io.Reader, stdout, stderr
 		sess.Stdout = stdout
 	}
 
-	if stdin == nil {
-		sess.Stdin = os.Stdin
-	} else {
-		sess.Stdin = stdin
-	}
+	// We don't want to default to os.Stdin here since it breaks Stdin in
+	// non-obvious ways elsewhere. If os.Stdin is required here, it should be
+	// passed in
+	sess.Stdin = stdin
 
 	err = sess.Start(strings.Join(cmd, " "))
 	if err != nil {


### PR DESCRIPTION
Query input was failing, for example when asking whether to delete ebs volumes.
This only happened during or after terraform was run.
Stdin was unresponsive and always failed.
This was due to defaulting to os.Stdin for SSH execute sessions.


```release-note
NONE
```

/assign @simonswine 
fixes #729 