### PR TITLE
Automated cherry pick of #680 #726

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ test::tarmak::golang:
   stage: test
   tags:
   - docker
-  image: golang:1.10.4
+  image: golang:1.11.4
   script:
   - rm -rf /go/src/github.com/jetstack
   - mkdir -p /go/src/github.com/jetstack
@@ -47,7 +47,7 @@ release::tarmak::golang:
   stage: release
   tags:
   - docker
-  image: golang:1.10.4
+  image: golang:1.11.4
   only:
   - tags
   script:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
 PACKAGE_NAME ?= github.com/jetstack/tarmak
 CONTAINER_DIR := /go/src/$(PACKAGE_NAME)
-GO_VERSION := 1.10.4
+GO_VERSION := 1.11.4
 
 BINDIR ?= $(CURDIR)/bin
 PATH   := $(BINDIR):$(PATH)

--- a/packer/amazon/configure_for_tarmak.sh
+++ b/packer/amazon/configure_for_tarmak.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-centos_release=7.5.1804
+centos_release=7.6.1810
 
 # hardcode centos release
 cat > /etc/yum.repos.d/CentOS-Base.repo <<EOF

--- a/pkg/packer/image.go
+++ b/pkg/packer/image.go
@@ -43,7 +43,7 @@ func (i *image) userVariables() map[string]string {
 	return map[string]string{
 		tarmakv1alpha1.ImageTagEnvironment:   i.environment,
 		tarmakv1alpha1.ImageTagBaseImageName: i.imageName,
-		"region": i.tarmak.Provider().Region(),
+		"region":                             i.tarmak.Provider().Region(),
 	}
 }
 

--- a/pkg/tarmak/provider/amazon/tf_remote_state.go
+++ b/pkg/tarmak/provider/amazon/tf_remote_state.go
@@ -344,7 +344,7 @@ func (a *Amazon) initRemoteStateBucketEncryption() error {
 	}
 
 	_, err = svc.PutBucketEncryption(&s3.PutBucketEncryptionInput{
-		Bucket: aws.String(a.RemoteStateName()),
+		Bucket:                            aws.String(a.RemoteStateName()),
 		ServerSideEncryptionConfiguration: encConf,
 	})
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #680 #726 on release-0.5.

#680: Upgrade to go version 1.11.4
#726: Upgrade to Centos 7.6.1810

```release-note
Upgrade to Centos 7.6.1810
```