### PR TITLE
Update clusterrole for kube-state-metrics

### DIFF
--- a/puppet/modules/prometheus/templates/kube-state-metrics-deployment.yaml.erb
+++ b/puppet/modules/prometheus/templates/kube-state-metrics-deployment.yaml.erb
@@ -99,6 +99,8 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
+  - configmaps
+  - secrets
   - nodes
   - pods
   - services
@@ -106,10 +108,9 @@ rules:
   - replicationcontrollers
   - limitranges
   - persistentvolumeclaims
+  - persistentvolumes
   - namespaces
   - endpoints
-  - persistentvolumes
-  - horizontalpodautoscalers
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:


### PR DESCRIPTION
Signed-off-by: Mattias Gees <mattias.gees@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fix for errors in logs

```
E0221 10:13:53.230160       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "configmaps" in API group "" at the cluster scope
E0221 10:13:54.238317       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "secrets" in API group "" at the cluster scope
E0221 10:13:54.239928       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "configmaps" in API group "" at the cluster scope
E0221 10:13:55.239963       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "secrets" in API group "" at the cluster scope
E0221 10:13:55.241302       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "configmaps" in API group "" at the cluster scope
E0221 10:13:56.241796       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "secrets" in API group "" at the cluster scope
E0221 10:13:56.242690       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "configmaps" in API group "" at the cluster scope
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix RBAC for kube-state-metrics
```
