### PR TITLE
Increases inotify limits on Kubernetes instances

### DIFF
--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -44,6 +44,8 @@ class kubernetes (
     'TLS_RSA_WITH_AES_256_GCM_SHA384',
     'TLS_RSA_WITH_AES_128_GCM_SHA256',
   ],
+  Integer $max_user_instances = 8192,
+  Integer $max_user_watches = 524288,
 ) inherits ::kubernetes::params
 {
 
@@ -185,5 +187,4 @@ class kubernetes (
     mode    => '0750',
     require => User[$user],
   }
-
 }

--- a/puppet/modules/kubernetes/manifests/install.pp
+++ b/puppet/modules/kubernetes/manifests/install.pp
@@ -1,8 +1,5 @@
 # download and install hyperkube
-class kubernetes::install (
-  Integer $max_user_instances = $::kubernetes::max_user_instances,
-  Integer $max_user_watches = $::kubernetes::max_user_watches,
-){
+class kubernetes::install {
   include kubernetes
 
   $hyperkube_path = "${::kubernetes::_dest_dir}/hyperkube"
@@ -21,19 +18,5 @@ class kubernetes::install (
     mode   => '0755',
     owner  => 'root',
     group  => 'root',
-  }
-
-  exec {'sysctl-system':
-    command     => 'sysctl --system',
-    refreshonly => true,
-    path        => ['/usr/bin/', '/bin', '/usr/sbin'],
-  }
-
-  file{"${::kubernetes::params::sysctl_dir}/fs.conf":
-    ensure  => file,
-    mode    => '0640',
-    owner   => 'root',
-    content => template('kubernetes/fs.conf.erb'),
-    notify  => Exec['sysctl-system'],
   }
 }

--- a/puppet/modules/kubernetes/manifests/install.pp
+++ b/puppet/modules/kubernetes/manifests/install.pp
@@ -1,5 +1,8 @@
 # download and install hyperkube
-class kubernetes::install {
+class kubernetes::install (
+  Integer $max_user_instances = $::kubernetes::max_user_instances,
+  Integer $max_user_watches = $::kubernetes::max_user_watches,
+){
   include kubernetes
 
   $hyperkube_path = "${::kubernetes::_dest_dir}/hyperkube"
@@ -18,5 +21,19 @@ class kubernetes::install {
     mode   => '0755',
     owner  => 'root',
     group  => 'root',
+  }
+
+  exec {'sysctl-system':
+    command     => 'sysctl --system',
+    refreshonly => true,
+    path        => ['/usr/bin/', '/bin', '/usr/sbin'],
+  }
+
+  file{"${::kubernetes::params::sysctl_dir}/fs.conf":
+    ensure  => file,
+    mode    => '0640',
+    owner   => 'root',
+    content => template('kubernetes/fs.conf.erb'),
+    notify  => Exec['sysctl-system'],
   }
 }

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -186,7 +186,7 @@ class kubernetes::kubelet(
   exec {'sysctl-system':
     command     => 'sysctl --system',
     refreshonly => true,
-    path        => ['/usr/bin/', '/bin', '/usr/sbin'],
+    path        => $::kubernetes::path,
   }
 
   file{$::kubernetes::params::sysctl_dir:

--- a/puppet/modules/kubernetes/manifests/params.pp
+++ b/puppet/modules/kubernetes/manifests/params.pp
@@ -9,6 +9,7 @@ class kubernetes::params {
   $download_dir = '/tmp'
   $systemd_dir = '/etc/systemd/system'
   $download_url = 'https://storage.googleapis.com/kubernetes-release/release/v#VERSION#/bin/linux/amd64/hyperkube'
+  $sysctl_dir = '/etc/sysctl.d'
   $log_level = '1'
   $uid = 873
   $gid = 873

--- a/puppet/modules/kubernetes/templates/fs.conf.erb
+++ b/puppet/modules/kubernetes/templates/fs.conf.erb
@@ -1,0 +1,6 @@
+# https://github.com/kubernetes/kops/blob/af4df08b694e2a1f8814a7b3649060477be67c86/nodeup/pkg/model/sysctls.go
+# Max number of inotify instances and watches for a user
+# Since dockerd runs as a single user, the default instances value of 128 per user is too low
+# e.g. uses of inotify: nginx ingress controller, kubectl logs -f
+fs.inotify.max_user_instances = <%= @max_user_instances %>
+fs.inotify.max_user_watches = <%= @max_user_watches %>


### PR DESCRIPTION
Increase inotify watch limits to Kubernetes instances.
max_user_instances = 8192,
max_user_watches = 524288,

```release-note
Increase inotify watch limits on Kubelet instances
```

/assign @simonswine 
