### PR TITLE
Revert "Upgrade UPX to 3.95"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,11 @@ $(BINDIR)/npm: $(BINDIR)/node
 # upx binary packer, only supported on Linux
 $(BINDIR)/upx:
 ifeq ($(UNAME_S),Linux)
-	curl -sL -o $@.tar.xz https://github.com/upx/upx/releases/download/v3.95/upx-3.95-amd64_linux.tar.xz
-	echo "b5d6856b89dd696138ad8c7245a8f0dae4b76f41b5a31c7c43a21bc72c479c4e  $@.tar.xz" | $(SHASUM)
+	# Do not upgrade to 3.95 as it produces wrong binaries for darwin
+	curl -sL -o $@.tar.xz https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz
+	echo "e1fc0d55c88865ef758c7e4fabbc439e4b5693b9328d219e0b9b3604186abe20  $@.tar.xz" | $(SHASUM)
 	which xz || ( apt-get update && apt-get -y install xz-utils)
-	cd $(BINDIR) && tar xvf $(shell basename $@).tar.xz upx-3.95-amd64_linux/upx --strip-components=1
+	cd $(BINDIR) && tar xvf $(shell basename $@).tar.xz upx-3.94-amd64_linux/upx --strip-components=1
 	rm $@.tar.xz
 else
 	echo -e "#/bin/sh\nexit 0" > $@


### PR DESCRIPTION
This reverts commit 01d018860da337e730e9ca4b0defc9b9f3ee5498.

Signed-off-by: Christian Simon <simon@swine.de>

```release-note
Down grade upx to 3.94 to build working Darwin binaries during releases
```
