### PR TITLE
Ensure known hosts path is the same as ssh_config

### DIFF
--- a/pkg/tarmak/cluster/cluster.go
+++ b/pkg/tarmak/cluster/cluster.go
@@ -731,9 +731,6 @@ func (c *Cluster) ConfigPath() string {
 }
 
 func (c *Cluster) SSHConfigPath() string {
-	if c.Type() == clusterv1alpha1.ClusterTypeClusterMulti {
-		return filepath.Join(c.Environment().Tarmak().ConfigPath(), c.Environment().HubName(), "ssh_config")
-	}
 	return filepath.Join(c.ConfigPath(), "ssh_config")
 }
 

--- a/pkg/tarmak/ssh/ssh.go
+++ b/pkg/tarmak/ssh/ssh.go
@@ -70,15 +70,14 @@ func (s *SSH) WriteConfig(c interfaces.Cluster) error {
 		return err
 	}
 
-	knownHostsPath := s.tarmak.Cluster().SSHHostKeysPath()
+	knownHostsPath := c.SSHHostKeysPath()
 
+	// open file for appending
 	knownHostsFile, err := os.OpenFile(
-		knownHostsPath,
-		os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-		0600,
-	)
+		knownHostsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+		0600)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open known hosts file: %s", err)
 	}
 	defer knownHostsFile.Close()
 

--- a/pkg/tarmak/tarmak.go
+++ b/pkg/tarmak/tarmak.go
@@ -178,6 +178,7 @@ func (t *Tarmak) writeSSHConfigForClusterHosts() error {
 		if errCluster != nil {
 			return fmt.Errorf("failed to retrieve current cluster name: %s", errCluster)
 		}
+
 		return fmt.Errorf("failed to write ssh config for current cluster '%s': %v", clusterName, err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures the create ssh known hosts path shares the same directory as the ssh_config.
This stop an error occurring where a  known_hosts_path was being written to a directory that did not yet exist.

 fixes #772 

```release-note
Ensure ssh_known_host file shares the same ssh_config directory.
```

/assign @simonswine 