### PR TITLE
Adds aws-iam-authenticator initialisation and instructions

### DIFF
--- a/docs/examples/aws-iam-authenticator.rst
+++ b/docs/examples/aws-iam-authenticator.rst
@@ -12,7 +12,7 @@ You can initialise the cluster to use this with the following configuration snip
     kubernetes:
       apiServer:
         amazon:
-          aws-iam-authenticator-init: true
+          awsIAMAuthenticatorInit: true
     ...
 
 You can configure the IAM authenticator server with the following config map and daemonset, 
@@ -21,116 +21,116 @@ including the ``-cluster`` suffix in a single cluster environment:
 
 .. code-block:: yaml
 
-	apiVersion: v1
-	kind: ConfigMap
-	metadata:
-	  namespace: kube-system
-	  name: aws-iam-authenticator
-	  labels:
-	    k8s-app: aws-iam-authenticator
-	data:
-	  config.yaml: |
-	    # a unique-per-cluster identifier to prevent replay attacks
-	    # (good choices are a random token or a domain name that will be unique to your cluster)
-	    clusterID: your-tarmak-cluster
-	    server:
-	      mapRoles:
-	      # statically map arn:aws:iam::<your account id>:role/KubernetesAdmin to a cluster admin
-	      - roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
-		username: kubernetes-admin
-		groups:
-		- system:masters
-	---
-	apiVersion: extensions/v1beta1
-	kind: DaemonSet
-	metadata:
-	  namespace: kube-system
-	  name: aws-iam-authenticator
-	  labels:
-	    k8s-app: aws-iam-authenticator
-	spec:
-	  updateStrategy:
-	    type: RollingUpdate
-	  template:
-	    metadata:
-	      annotations:
-		scheduler.alpha.kubernetes.io/critical-pod: ""
-	      labels:
-		k8s-app: aws-iam-authenticator
-	    spec:
-	      # run on the host network (don't depend on CNI)
-	      hostNetwork: true
-	      # run on each master node
-	      nodeSelector:
-		node-role.kubernetes.io/master: ""
-	      tolerations:
-	      - effect: NoSchedule
-		key: node-role.kubernetes.io/master
-	      - key: CriticalAddonsOnly
-		operator: Exists
-	      containers:
-	      - name: aws-iam-authenticator
-		image: gcr.io/heptio-images/authenticator:v0.3.0
-		args:
-		- server
-		- --config=/etc/aws-iam-authenticator/config.yaml
-		- --state-dir=/var/aws-iam-authenticator
-		- --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
-		- --kubeconfig-pregenerated=true
-		resources:
-		  requests:
-		    memory: 20Mi
-		    cpu: 10m
-		  limits:
-		    memory: 20Mi
-		    cpu: 100m
-		securityContext:
-		  privileged: true
-		volumeMounts:
-		- name: config
-		  mountPath: /etc/aws-iam-authenticator/
-		- name: state
-		  mountPath: /var/aws-iam-authenticator/
-	      securityContext:
-		fsGroup: 0
-		runAsUser: 0
-	      volumes:
-	      - name: config
-		configMap:
-		  name: aws-iam-authenticator
-	      - name: state
-		hostPath:
-		  path: /var/aws-iam-authenticator/
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      namespace: kube-system
+      name: aws-iam-authenticator
+      labels:
+        k8s-app: aws-iam-authenticator
+    data:
+      config.yaml: |
+        # a unique-per-cluster identifier to prevent replay attacks
+        # (good choices are a random token or a domain name that will be unique to your cluster)
+        clusterID: your-tarmak-cluster
+        server:
+          mapRoles:
+          # statically map arn:aws:iam::<your account id>:role/KubernetesAdmin to a cluster admin
+          - roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
+            username: kubernetes-admin
+            groups:
+            - system:masters
+    ---
+    apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      namespace: kube-system
+      name: aws-iam-authenticator
+      labels:
+        k8s-app: aws-iam-authenticator
+    spec:
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ""
+          labels:
+            k8s-app: aws-iam-authenticator
+        spec:
+          # run on the host network (don't depend on CNI)
+          hostNetwork: true
+          # run on each master node
+          nodeSelector:
+            node-role.kubernetes.io/master: ""
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - key: CriticalAddonsOnly
+            operator: Exists
+          containers:
+          - name: aws-iam-authenticator
+            image: gcr.io/heptio-images/authenticator:v0.3.0
+            args:
+            - server
+            - --config=/etc/aws-iam-authenticator/config.yaml
+            - --state-dir=/var/aws-iam-authenticator
+            - --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
+            - --kubeconfig-pregenerated=true
+            resources:
+              requests:
+                memory: 20Mi
+                cpu: 10m
+              limits:
+                memory: 20Mi
+                cpu: 100m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: config
+          mountPath: /etc/aws-iam-authenticator/
+        - name: state
+          mountPath: /var/aws-iam-authenticator/
+      securityContext:
+        fsGroup: 0
+        runAsUser: 0
+      volumes:
+      - name: config
+        configMap:
+          name: aws-iam-authenticator
+      - name: state
+        hostPath:
+          path: /var/aws-iam-authenticator/
 
 You can then authenticate to the cluster with e.g. the following, as long as aws-iam-authenticator is 
 downloaded and on your path:
 
-..code-block:: yaml
+.. code-block:: yaml
 
-	apiVersion: v1
-	clusters:
-	- cluster:
-	    certificate-authority-data: <snip - get these from ~/.tarmak/your-cluster/kubeconfig>
-	    server: https://api.your-cluster.somedomain.io ##see above
-	  name: your-cluster
-	contexts:
-	- context:
-	    cluster: your-cluster
-	    namespace: default
-	    user: your-cluster
-	  name: your-cluster
-	users:
-	- name: your-cluster
-	  user:
-	    exec:
-	      apiVersion: client.authentication.k8s.io/v1alpha1
-	      args:
-	      - token
-	      - -i
-	      - your-cluster ##change me
-	      - -r
-	      - arn:aws:iam::000000000000:role/KubernetesAdmin  ##change me
-	      command: aws-iam-authenticator-aws
-	      env:
-	      - name: AWS_PROFILE
-		value: your_profile ##change or remove me
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: <snip - get these from ~/.tarmak/your-cluster/kubeconfig>
+        server: https://api.your-cluster.somedomain.io ##see above
+      name: your-cluster
+    contexts:
+    - context:
+        cluster: your-cluster
+        namespace: default
+        user: your-cluster
+      name: your-cluster
+    users:
+    - name: your-cluster
+      user:
+        exec:
+          apiVersion: client.authentication.k8s.io/v1alpha1
+          args:
+          - token
+          - -i
+          - your-cluster ##change me
+          - -r
+          - arn:aws:iam::000000000000:role/KubernetesAdmin  ##change me
+          command: aws-iam-authenticator-aws
+          env:
+          - name: AWS_PROFILE
+            value: your_profile ##change or remove me

--- a/docs/examples/aws-iam-authenticator.rst
+++ b/docs/examples/aws-iam-authenticator.rst
@@ -1,0 +1,136 @@
+AWS IAM Authenticator
+---------------------
+
+`AWS IAM Authenticator <https://github.com/kubernetes-sigs/aws-iam-authenticator>`_ is a daemon that lets you authenticate to the 
+Kubernetes RBAC system via Amazon Web Services - Identity and Access Management users and roles
+
+You can initialise the cluster to use this with the following configuration snippet in tarmak.yaml:
+
+.. code-block:: yaml
+
+    ...
+    kubernetes:
+      apiServer:
+        amazon:
+          aws-iam-authenticator-init: true
+    ...
+
+You can configure the IAM authenticator server with the following config map and daemonset, 
+replacing ``000000000000`` with your AWS account ID and ``your-tarmak-cluster`` with your cluster name, 
+including the ``-cluster`` suffix in a single cluster environment:
+
+.. code-block:: yaml
+
+	apiVersion: v1
+	kind: ConfigMap
+	metadata:
+	  namespace: kube-system
+	  name: aws-iam-authenticator
+	  labels:
+	    k8s-app: aws-iam-authenticator
+	data:
+	  config.yaml: |
+	    # a unique-per-cluster identifier to prevent replay attacks
+	    # (good choices are a random token or a domain name that will be unique to your cluster)
+	    clusterID: your-tarmak-cluster
+	    server:
+	      mapRoles:
+	      # statically map arn:aws:iam::<your account id>:role/KubernetesAdmin to a cluster admin
+	      - roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
+		username: kubernetes-admin
+		groups:
+		- system:masters
+	---
+	apiVersion: extensions/v1beta1
+	kind: DaemonSet
+	metadata:
+	  namespace: kube-system
+	  name: aws-iam-authenticator
+	  labels:
+	    k8s-app: aws-iam-authenticator
+	spec:
+	  updateStrategy:
+	    type: RollingUpdate
+	  template:
+	    metadata:
+	      annotations:
+		scheduler.alpha.kubernetes.io/critical-pod: ""
+	      labels:
+		k8s-app: aws-iam-authenticator
+	    spec:
+	      # run on the host network (don't depend on CNI)
+	      hostNetwork: true
+	      # run on each master node
+	      nodeSelector:
+		node-role.kubernetes.io/master: ""
+	      tolerations:
+	      - effect: NoSchedule
+		key: node-role.kubernetes.io/master
+	      - key: CriticalAddonsOnly
+		operator: Exists
+	      containers:
+	      - name: aws-iam-authenticator
+		image: gcr.io/heptio-images/authenticator:v0.3.0
+		args:
+		- server
+		- --config=/etc/aws-iam-authenticator/config.yaml
+		- --state-dir=/var/aws-iam-authenticator
+		- --generate-kubeconfig=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
+		- --kubeconfig-pregenerated=true
+		resources:
+		  requests:
+		    memory: 20Mi
+		    cpu: 10m
+		  limits:
+		    memory: 20Mi
+		    cpu: 100m
+		securityContext:
+		  privileged: true
+		volumeMounts:
+		- name: config
+		  mountPath: /etc/aws-iam-authenticator/
+		- name: state
+		  mountPath: /var/aws-iam-authenticator/
+	      securityContext:
+		fsGroup: 0
+		runAsUser: 0
+	      volumes:
+	      - name: config
+		configMap:
+		  name: aws-iam-authenticator
+	      - name: state
+		hostPath:
+		  path: /var/aws-iam-authenticator/
+
+You can then authenticate to the cluster with e.g. the following, as long as aws-iam-authenticator is 
+downloaded and on your path:
+
+..code-block:: yaml
+
+	apiVersion: v1
+	clusters:
+	- cluster:
+	    certificate-authority-data: <snip - get these from ~/.tarmak/your-cluster/kubeconfig>
+	    server: https://api.your-cluster.somedomain.io ##see above
+	  name: your-cluster
+	contexts:
+	- context:
+	    cluster: your-cluster
+	    namespace: default
+	    user: your-cluster
+	  name: your-cluster
+	users:
+	- name: your-cluster
+	  user:
+	    exec:
+	      apiVersion: client.authentication.k8s.io/v1alpha1
+	      args:
+	      - token
+	      - -i
+	      - your-cluster ##change me
+	      - -r
+	      - arn:aws:iam::000000000000:role/KubernetesAdmin  ##change me
+	      command: aws-iam-authenticator-aws
+	      env:
+	      - name: AWS_PROFILE
+		value: your_profile ##change or remove me

--- a/docs/examples/aws-iam-authenticator.rst
+++ b/docs/examples/aws-iam-authenticator.rst
@@ -70,7 +70,7 @@ including the ``-cluster`` suffix in a single cluster environment:
             operator: Exists
           containers:
           - name: aws-iam-authenticator
-            image: gcr.io/heptio-images/authenticator:v0.3.0
+            image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.4.0-scratch
             args:
             - server
             - --config=/etc/aws-iam-authenticator/config.yaml

--- a/docs/generated/reference/output/api-docs.html
+++ b/docs/generated/reference/output/api-docs.html
@@ -922,6 +922,10 @@ Appears In:
 <td>AWS specifc options</td>
 </tr>
 <tr>
+<td><code>authTokenWebhookFile</code><br /> <em>string</em></td>
+<td></td>
+</tr>
+<tr>
 <td><code>disableAdmissionControllers</code><br /> <em>string array</em></td>
 <td></td>
 </tr>
@@ -975,6 +979,10 @@ Appears In:
 </tr>
 </thead>
 <tbody>
+<tr>
+<td><code>awsIAMAuthenticatorInit</code><br /> <em>boolean</em></td>
+<td></td>
+</tr>
 <tr>
 <td><code>internalELBAccessLogs</code><br /> <em><a href="#clusterkubernetesapiserveramazonaccesslogs-v1alpha1">ClusterKubernetesAPIServerAmazonAccessLogs</a></em></td>
 <td></td>

--- a/docs/generated/reference/output/api-docs.html
+++ b/docs/generated/reference/output/api-docs.html
@@ -919,7 +919,7 @@ Appears In:
 </tr>
 <tr>
 <td><code>amazon</code><br /> <em><a href="#clusterkubernetesapiserveramazon-v1alpha1">ClusterKubernetesAPIServerAmazon</a></em></td>
-<td>AWS specifc options</td>
+<td>AWS specific options</td>
 </tr>
 <tr>
 <td><code>authTokenWebhookFile</code><br /> <em>string</em></td>

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -6,6 +6,7 @@ amoungst
 ansible
 api
 apiserver
+Appscode
 attestor
 auth
 authenticator
@@ -137,5 +138,7 @@ uid
 unsealer
 username
 velero
+webhook
+Webhook
 wrt
 yaml

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -8,11 +8,15 @@ api
 apiserver
 attestor
 auth
+authenticator
+Authenticator
+authorisation
 authorization
 authz
 autoscale
 autoscaler
 autoscaling
+aws
 backend
 backends
 calico
@@ -24,6 +28,10 @@ Config
 configmap
 cryptographic
 ctrl
+customise
+customised
+customisation
+daemonset
 doesn
 EBS
 ec
@@ -31,6 +39,7 @@ ecdsa
 Elasticsearch
 env
 etcd
+favour
 fluentbit
 Gi
 gid
@@ -45,6 +54,9 @@ heptio
 hostname
 iam
 init
+initialise
+Initialise
+initialised
 initialize
 initializers
 io
@@ -57,6 +69,8 @@ kubeconfig
 kubectl
 kubelet
 kubernetes
+licence
+license
 lifecycle
 localhost
 login
@@ -66,6 +80,7 @@ macOS
 masterless
 millicores
 minio
+modelling
 multi
 nameservers
 namespace
@@ -75,6 +90,9 @@ nistp
 offline
 oneshot
 ons
+optimise
+optimised
+optimisation
 overprovisioning
 pki
 plugable
@@ -85,6 +103,10 @@ postgresql
 preempted
 prepended
 prometheus
+realise
+realised
+recognise
+recognised
 refactoring
 ReplicaSet
 rolename
@@ -92,11 +114,14 @@ runtime
 setup
 sha
 stateful
+standardised
 stdin
 subcommand
 subdomain
 subtree
 subtrees
+summarises
+synchronised
 systemd
 tarmak
 templating
@@ -105,6 +130,7 @@ testability
 Todo
 toolkit
 ttl
+tunnelling
 typha
 ubuntu
 uid

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -658,6 +658,21 @@ This can be used together with `Secure public endpoints <user-guide.html#secure-
     apiServer:
       public: true
 
+Authenticator Token Webhook file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can configure an authentication token webhook for the apiserver - this is the path to the file
+containing said configuration. There is a *default* value for this if using the aws-iam-authenticator, 
+but if you are customising this component, or using an alternative webhook authentication system (e.g.
+Appscode Guard) you can set / override it here as appropriate. The file must exist for the apiserver
+to start up.
+
+.. code-block:: yaml
+
+  kubernetes:
+    apiServer:
+      authTokenWebhookFile: /etc/kubernetes/shiny-new-authenticator/kubeconfig.yaml
+
 Secure public endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -458,6 +458,24 @@ The following `tarmak.yaml` snippet shows how to enable encrypted EBS.
         ebsEncrypted: true
     ...
 
+IAM Authentication
+~~~~~~~~~~~~~~~~~~
+
+Tarmak supports authentication using aws-iam-authenticator. You can enable this using the following
+snippet, although this doesn't deploy the authenticator to the cluster - this will need configuring
+for your environment using the instructions `here <https://github.com/kubernetes-sigs/aws-iam-authenticator>`_.
+Effectively, the snippet below performs steps 2 and 3 of these instructions for you.
+
+.. code-block:: yaml
+
+    kubernetes:
+      apiServer:
+        amazon:
+          aws-iam-authenticator-init: true
+    ...
+
+See the examples section for yaml files to configure the authenticator daemon set, config map and kubeconfig.
+
 OIDC Authentication
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -463,7 +463,7 @@ IAM Authentication
 
 Tarmak supports authentication using aws-iam-authenticator. You can enable this using the following
 snippet, although this doesn't deploy the authenticator to the cluster - this will need configuring
-for your environment using the instructions `here <https://github.com/kubernetes-sigs/aws-iam-authenticator>`_.
+for your environment using the instructions on `github <https://github.com/kubernetes-sigs/aws-iam-authenticator>`_.
 Effectively, the snippet below performs steps 2 and 3 of these instructions for you.
 
 .. code-block:: yaml
@@ -471,7 +471,7 @@ Effectively, the snippet below performs steps 2 and 3 of these instructions for 
     kubernetes:
       apiServer:
         amazon:
-          aws-iam-authenticator-init: true
+          awsIAMAuthenticatorInit: true
     ...
 
 See the examples section for yaml files to configure the authenticator daemon set, config map and kubeconfig.

--- a/docs/vault-setup-config.rst
+++ b/docs/vault-setup-config.rst
@@ -45,7 +45,7 @@ Init Tokens
 Tokens are used as the main authentication method in Vault and provide a
 mapping to one or more policies. On first boot, each instance generates their
 own unique token via a given token - the init token. These init-tokens are role
-dependant meaning the same init-token is shared with instances only with the
+dependent meaning the same init-token is shared with instances only with the
 same role. Once generated, the init token is erased by all instances in favour
 of their own new unique token making the init token no longer accessible on any
 instance. Unlike the init-tokens, generated tokens are short lived and so need
@@ -64,7 +64,7 @@ requirements of the policy - if successful, returns a signed certificate.
 Instances can only obtain certificates from CSRs because of the permissions
 that its unique token provides. Upon receiving, the instance will store the
 signed certificate locally to be shared with its relevant services and start or
-restart all services which are dependant.
+restart all services which are dependent.
 
 Expiration of Tokens and Certificates
 -------------------------------------

--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -155,7 +155,7 @@ type ClusterKubernetesAPIServer struct {
 	// AWS specifc options
 	Amazon *ClusterKubernetesAPIServerAmazon `json:"amazon,omitempty"`
 
-        AuthTokenWebhookFile string `json:"authTokenWebhookFile"`
+	AuthTokenWebhookFile string `json:"authTokenWebhookFile"`
 
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
@@ -196,9 +196,9 @@ type ClusterKubernetesAPIServerOIDC struct {
 }
 
 type ClusterKubernetesAPIServerAmazon struct {
-	PublicELBAccessLogs   *ClusterKubernetesAPIServerAmazonAccessLogs `json:"publicELBAccessLogs,omitempty"`
-	InternalELBAccessLogs *ClusterKubernetesAPIServerAmazonAccessLogs `json:"internalELBAccessLogs,omitempty"`
-        AwsIamAuthenticatorInit bool `json:"awsIAMAuthenticatorInit,omitempty"`
+	PublicELBAccessLogs     *ClusterKubernetesAPIServerAmazonAccessLogs `json:"publicELBAccessLogs,omitempty"`
+	InternalELBAccessLogs   *ClusterKubernetesAPIServerAmazonAccessLogs `json:"internalELBAccessLogs,omitempty"`
+	AwsIamAuthenticatorInit bool                                        `json:"awsIAMAuthenticatorInit,omitempty"`
 }
 
 type ClusterKubernetesAPIServerAmazonAccessLogs struct {

--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -155,6 +155,8 @@ type ClusterKubernetesAPIServer struct {
 	// AWS specifc options
 	Amazon *ClusterKubernetesAPIServerAmazon `json:"amazon,omitempty"`
 
+        AuthTokenWebhookFile string `json:"authTokenWebhookFile"`
+
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 
@@ -196,6 +198,7 @@ type ClusterKubernetesAPIServerOIDC struct {
 type ClusterKubernetesAPIServerAmazon struct {
 	PublicELBAccessLogs   *ClusterKubernetesAPIServerAmazonAccessLogs `json:"publicELBAccessLogs,omitempty"`
 	InternalELBAccessLogs *ClusterKubernetesAPIServerAmazonAccessLogs `json:"internalELBAccessLogs,omitempty"`
+        AwsIamAuthenticatorInit bool `json:"awsIAMAuthenticatorInit,omitempty"`
 }
 
 type ClusterKubernetesAPIServerAmazonAccessLogs struct {

--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -198,7 +198,7 @@ type ClusterKubernetesAPIServerOIDC struct {
 type ClusterKubernetesAPIServerAmazon struct {
 	PublicELBAccessLogs     *ClusterKubernetesAPIServerAmazonAccessLogs `json:"publicELBAccessLogs,omitempty"`
 	InternalELBAccessLogs   *ClusterKubernetesAPIServerAmazonAccessLogs `json:"internalELBAccessLogs,omitempty"`
-	AwsIamAuthenticatorInit bool                                        `json:"awsIAMAuthenticatorInit,omitempty"`
+	AwsIAMAuthenticatorInit bool                                        `json:"awsIAMAuthenticatorInit,omitempty"`
 }
 
 type ClusterKubernetesAPIServerAmazonAccessLogs struct {

--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -152,10 +152,10 @@ type ClusterKubernetesAPIServer struct {
 	// OIDC
 	OIDC *ClusterKubernetesAPIServerOIDC `json:"oidc,omitempty"`
 
-	// AWS specifc options
+	// AWS specific options
 	Amazon *ClusterKubernetesAPIServerAmazon `json:"amazon,omitempty"`
 
-	AuthTokenWebhookFile string `json:"authTokenWebhookFile"`
+	AuthTokenWebhookFile string `json:"authTokenWebhookFile,omitempty"`
 
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -165,13 +165,13 @@ func kubernetesClusterConfig(conf *clusterv1alpha1.ClusterKubernetes, hieraData 
 		}
 	}
 
-        if conf.APIServer != nil && conf.APIServer.AuthTokenWebhookFile != "" {
+	if conf.APIServer != nil && conf.APIServer.AuthTokenWebhookFile != "" {
 		hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::auth_token_webhook_file: "%s"`, conf.APIServer.AuthTokenWebhookFile))
 	}
 
-        if conf.APIServer != nil && conf.APIServer.Amazon != nil && conf.APIServer.Amazon.AwsIamAuthenticatorInit {
-                hieraData.variables = append(hieraData.variables, "kubernetes::apiserver::aws_iam_authenticator_init: true")
-        }
+	if conf.APIServer != nil && conf.APIServer.Amazon != nil && conf.APIServer.Amazon.AwsIamAuthenticatorInit {
+		hieraData.variables = append(hieraData.variables, "kubernetes::apiserver::aws_iam_authenticator_init: true")
+	}
 
 	if conf.PodSecurityPolicy != nil {
 		if conf.PodSecurityPolicy.Enabled {

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -169,7 +169,7 @@ func kubernetesClusterConfig(conf *clusterv1alpha1.ClusterKubernetes, hieraData 
 		hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::auth_token_webhook_file: "%s"`, conf.APIServer.AuthTokenWebhookFile))
 	}
 
-	if conf.APIServer != nil && conf.APIServer.Amazon != nil && conf.APIServer.Amazon.AwsIamAuthenticatorInit {
+	if conf.APIServer != nil && conf.APIServer.Amazon != nil && conf.APIServer.Amazon.AwsIAMAuthenticatorInit {
 		hieraData.variables = append(hieraData.variables, "kubernetes::apiserver::aws_iam_authenticator_init: true")
 	}
 

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -165,6 +165,14 @@ func kubernetesClusterConfig(conf *clusterv1alpha1.ClusterKubernetes, hieraData 
 		}
 	}
 
+        if conf.APIServer != nil && conf.APIServer.AuthTokenWebhookFile != "" {
+		hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::apiserver::auth_token_webhook_file: "%s"`, conf.APIServer.AuthTokenWebhookFile))
+	}
+
+        if conf.APIServer != nil && conf.APIServer.Amazon != nil && conf.APIServer.Amazon.AwsIamAuthenticatorInit {
+                hieraData.variables = append(hieraData.variables, "kubernetes::apiserver::aws_iam_authenticator_init: true")
+        }
+
 	if conf.PodSecurityPolicy != nil {
 		if conf.PodSecurityPolicy.Enabled {
 			hieraData.variables = append(hieraData.variables, fmt.Sprintf(`tarmak::kubernetes_pod_security_policy: true`))

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -66,6 +66,11 @@ class kubernetes::apiserver(
     $_systemd_after = ['network.target'] + $systemd_after
     $_systemd_requires = $systemd_requires
     $_auth_token_webhook_file = $auth_token_webhook_file
+    class{'kubernetes::aws_iam_authenticator_init':
+      file_ensure             => 'absent',
+      service_enable          => false,
+      auth_token_webhook_file => '',
+    }
   }
   $_systemd_before = $systemd_before
 

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -3,6 +3,7 @@ class kubernetes::apiserver(
   $allow_privileged = true,
   Optional[Boolean] $audit_enabled = undef,
   Optional[Boolean] $aws_iam_authenticator_init = false,
+  String $aws_iam_authenticator_image = 'gcr.io/heptio-images/authenticator@sha256:8699a69cbd7274810a63cfb67b7053166897831c734011c62ce0aee32d66b3b8',
   String $audit_log_directory = '/var/log/kubernetes',
   Integer $audit_log_maxbackup = 1,
   Integer $audit_log_maxsize = 100,

--- a/puppet/modules/kubernetes/manifests/aws_iam_authenticator_init.pp
+++ b/puppet/modules/kubernetes/manifests/aws_iam_authenticator_init.pp
@@ -4,6 +4,8 @@ class kubernetes::aws_iam_authenticator_init(
   Array[String] $systemd_requires = [],
   Array[String] $systemd_after = [],
   Array[String] $systemd_before = [],
+  Enum['file','absent'] $file_ensure = 'file',
+  Boolean $service_enable = true,
 ){
   require ::kubernetes
 
@@ -15,7 +17,7 @@ class kubernetes::aws_iam_authenticator_init(
   $_systemd_before = $systemd_before
 
   file{"${::kubernetes::systemd_dir}/${service_name}.service":
-    ensure  => file,
+    ensure  => $file_ensure,
     mode    => '0644',
     owner   => 'root',
     group   => 'root',
@@ -27,6 +29,6 @@ class kubernetes::aws_iam_authenticator_init(
     refreshonly => true,
   }
   -> service{ "${service_name}.service":
-    enable  => true,
+    enable  => $service_enable,
   }
 }

--- a/puppet/modules/kubernetes/manifests/aws_iam_authenticator_init.pp
+++ b/puppet/modules/kubernetes/manifests/aws_iam_authenticator_init.pp
@@ -1,0 +1,32 @@
+class kubernetes::aws_iam_authenticator_init(
+  String $auth_token_webhook_file,
+  Array[String] $systemd_wants = [],
+  Array[String] $systemd_requires = [],
+  Array[String] $systemd_after = [],
+  Array[String] $systemd_before = [],
+){
+  require ::kubernetes
+
+  $service_name = 'aws-iam-authenticator-init'
+
+  $_systemd_wants = $systemd_wants
+  $_systemd_after = $systemd_after
+  $_systemd_requires = $systemd_after
+  $_systemd_before = $systemd_before
+
+  file{"${::kubernetes::systemd_dir}/${service_name}.service":
+    ensure  => file,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    content => template("kubernetes/${service_name}.service.erb"),
+  }
+  ~> exec { "${service_name}-daemon-reload":
+    command     => 'systemctl daemon-reload',
+    path        => $::kubernetes::path,
+    refreshonly => true,
+  }
+  -> service{ "${service_name}.service":
+    enable  => true,
+  }
+}

--- a/puppet/modules/kubernetes/manifests/aws_iam_authenticator_init.pp
+++ b/puppet/modules/kubernetes/manifests/aws_iam_authenticator_init.pp
@@ -9,6 +9,8 @@ class kubernetes::aws_iam_authenticator_init(
 ){
   require ::kubernetes
 
+  $aia_path = "${::kubernetes::bin_dir}/aws-iam-authenticator-${kubernetes::aia_version}"
+
   $service_name = 'aws-iam-authenticator-init'
 
   $_systemd_wants = $systemd_wants
@@ -16,19 +18,49 @@ class kubernetes::aws_iam_authenticator_init(
   $_systemd_requires = $systemd_after
   $_systemd_before = $systemd_before
 
-  file{"${::kubernetes::systemd_dir}/${service_name}.service":
-    ensure  => $file_ensure,
-    mode    => '0644',
-    owner   => 'root',
-    group   => 'root',
-    content => template("kubernetes/${service_name}.service.erb"),
+  file { $::kubernetes::aia_bin_dir:
+      ensure => directory,
+      mode   => '0755',
+  }
+  -> file { $aia_path:
+      ensure => directory,
+      mode   => '0755',
+  }
+  -> exec {"aia-${kubernetes::aia_version}-download":
+      command => "curl -sL ${::kubernetes::aia_download_url} -o ${aia_path}/aws-iam-authenticator",
+      creates => "${aia_path}/aws-iam-authenticator",
+      path    => ['/usr/bin', '/bin'],
+  }
+  -> file {"${aia_path}/aws-iam-authenticator":
+      ensure => 'file',
+      mode   => '0755',
+      owner  => 'root',
+      group  => 'root',
+  }
+  -> file { "${::kubernetes::aia_bin_dir}/aws-iam-authenticator":
+      ensure => 'link',
+      mode   => '0755',
+      owner  => 'root',
+      group  => 'root',
+      target => "${aia_path}/aws-iam-authenticator",
+  }
+  -> file{'/var/aws-iam-authenticator':
+      ensure => directory,
+      mode   => '0755',
+  }
+  -> file{"${::kubernetes::systemd_dir}/${service_name}.service":
+      ensure  => $file_ensure,
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      content => template("kubernetes/${service_name}.service.erb"),
   }
   ~> exec { "${service_name}-daemon-reload":
-    command     => 'systemctl daemon-reload',
-    path        => $::kubernetes::path,
-    refreshonly => true,
+      command     => 'systemctl daemon-reload',
+      path        => $::kubernetes::path,
+      refreshonly => true,
   }
   -> service{ "${service_name}.service":
-    enable  => $service_enable,
+      enable  => $service_enable,
   }
 }

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -1,7 +1,9 @@
 # Class: kubernetes
 class kubernetes (
   $version = $::kubernetes::params::version,
+  $aia_version = $::kubernetes::params::aws_authenticator_version,
   $bin_dir = $::kubernetes::params::bin_dir,
+  $aia_bin_dir = '/opt/aws_authenticator',
   $download_dir = $::kubernetes::params::download_dir,
   $dest_dir = $::kubernetes::params::dest_dir,
   $config_dir = $::kubernetes::params::config_dir,
@@ -17,6 +19,7 @@ class kubernetes (
   $ssl_dir = undef,
   $source = undef,
   Enum['aws', ''] $cloud_provider = '',
+  $storage_encrypted = undef,
   $cluster_name = undef,
   $dns_root = undef,
   $cluster_dns = undef,
@@ -115,6 +118,13 @@ class kubernetes (
     'G'
   )
   $_dest_dir = "${dest_dir}/kubernetes-${version}"
+
+  $aia_download_url = regsubst(
+    $::kubernetes::params::aws_authenticator_download_url,
+    '#VERSION#',
+    $aia_version,
+    'G'
+  )
 
   if $ssl_dir == undef {
     $_ssl_dir = "${config_dir}/ssl"

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -17,7 +17,6 @@ class kubernetes (
   $ssl_dir = undef,
   $source = undef,
   Enum['aws', ''] $cloud_provider = '',
-  $aws_iam_authenticator_image = 'gcr.io/heptio-images/authenticator@sha256:8699a69cbd7274810a63cfb67b7053166897831c734011c62ce0aee32d66b3b8',
   $cluster_name = undef,
   $dns_root = undef,
   $cluster_dns = undef,

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -17,6 +17,7 @@ class kubernetes (
   $ssl_dir = undef,
   $source = undef,
   Enum['aws', ''] $cloud_provider = '',
+  $aws_iam_authenticator_image = 'gcr.io/heptio-images/authenticator@sha256:8699a69cbd7274810a63cfb67b7053166897831c734011c62ce0aee32d66b3b8',
   $cluster_name = undef,
   $dns_root = undef,
   $cluster_dns = undef,

--- a/puppet/modules/kubernetes/manifests/params.pp
+++ b/puppet/modules/kubernetes/manifests/params.pp
@@ -9,6 +9,8 @@ class kubernetes::params {
   $download_dir = '/tmp'
   $systemd_dir = '/etc/systemd/system'
   $download_url = 'https://storage.googleapis.com/kubernetes-release/release/v#VERSION#/bin/linux/amd64/hyperkube'
+  $aws_authenticator_download_url = 'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v#VERSION#/aws-iam-authenticator_#VERSION#_linux_amd64'
+  $aws_authenticator_version = '0.4.0'
   $sysctl_dir = '/etc/sysctl.d'
   $log_level = '1'
   $uid = 873

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -51,7 +51,10 @@ describe 'kubernetes::apiserver' do
 
   context 'iam authenticator' do
     context 'default' do
-      it { should_not contain_file(service_file).with_content(%r{aws-iam-authenticator-init.service}) }
+      it do
+        should contain_class('kubernetes::aws_iam_authenticator_init').with('file_ensure' => 'absent')
+        should_not contain_file(service_file).with_content(%r{aws-iam-authenticator-init.service})
+      end
     end
 
     context 'iam authenticator enabled' do
@@ -61,7 +64,7 @@ describe 'kubernetes::apiserver' do
         """
       ]}
       it { should contain_file(service_file).with_content(/#{Regexp.escape('Requires=')}.*#{Regexp.escape('aws-iam-authenticator-init.service')}/) }
-      it { should contain_class('kubernetes::aws_iam_authenticator_init') }
+      it { should contain_class('kubernetes::aws_iam_authenticator_init').with('file_ensure' => 'file') }
       it { should contain_file(service_file).with_content(/#{Regexp.escape('--authentication-token-webhook-config-file=/etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml')}/) }
     end
   end

--- a/puppet/modules/kubernetes/spec/classes/aws_iam_authenticator_init_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/aws_iam_authenticator_init_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'kubernetes::aws_iam_authenticator_init' do
+  context 'auth token webhook file' do
+    let(:pre_condition) {[
+      """
+      class{'kubernetes::aws_iam_authenticator_init': auth_token_webhook_file => '/foo/bar/baz'}
+      """
+    ]}
+    it { should contain_file('/etc/systemd/system/aws-iam-authenticator-init.service').with_content(/#{Regexp.escape('/foo/bar/baz')}/)
+}
+  end
+end

--- a/puppet/modules/kubernetes/spec/classes/aws_iam_authenticator_init_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/aws_iam_authenticator_init_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe 'kubernetes::aws_iam_authenticator_init' do
+  context 'disabled' do
+    let(:pre_condition) {[
+      """
+      class{'kubernetes::aws_iam_authenticator_init':
+        auth_token_webhook_file => '',
+        file_ensure             => 'absent',
+      }
+      """
+    ]}
+    it { should contain_file('/etc/systemd/system/aws-iam-authenticator-init.service').with('ensure' => 'absent')}
+  end
   context 'auth token webhook file' do
     let(:pre_condition) {[
       """

--- a/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
+++ b/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
@@ -2,20 +2,16 @@
 Description=Initialise heptio authenticator (AWS IAM authenticator)
 Documentation=https://github.com/kubernetes-sigs/aws-iam-authenticator
 After=network.target
-After=docker.service
-Requires=docker.service
 Before=kube-apiserver.service
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 [Service]
 Type=oneshot
-ExecStartPre=/bin/docker run \
-  -u 0 -w /config \
-  -v /var/aws-iam-authenticator/:/config:Z \
-  <%= scope['kubernetes::apiserver::aws_iam_authenticator_image'] %> \
+WorkingDirectory=/var/aws-iam-authenticator
+ExecStartPre=<%= scope['kubernetes::aia_bin_dir'] %>/aws-iam-authenticator \
   init -i <%= scope['kubernetes::cluster_name'] %>
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/aws-iam-authenticator
 ExecStart=/bin/cp \
-  /var/aws-iam-authenticator/heptio-authenticator-aws.kubeconfig \
+  /var/aws-iam-authenticator/aws-iam-authenticator.kubeconfig \
   <%= @auth_token_webhook_file %>
 
 [Install]

--- a/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
+++ b/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
@@ -5,9 +5,9 @@ After=network.target
 After=docker.service
 Requires=docker.service
 Before=kube-apiserver.service
-Type=oneshot
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 [Service]
+Type=oneshot
 ExecStartPre=/bin/docker run \
   -u 0 -w /config \
   -v /var/aws-iam-authenticator/:/config:Z \

--- a/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
+++ b/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
@@ -1,0 +1,21 @@
+[Unit]
+Description=Initialise heptio authenticator (AWS IAM authenticator)
+Documentation=https://github.com/kubernetes-sigs/aws-iam-authenticator
+After=network.target
+After=docker.service
+Requires=docker.service
+Before=kube-apiserver.service
+<%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
+[Service]
+ExecStartPre=/bin/docker run \
+  -u 0 -w /config \
+  -v /var/aws-iam-authenticator/:/config:Z \
+  <%= scope['kubernetes::aws_iam_authenticator_image'] %> \
+  init -i <%= scope['kubernetes::cluster_name'] %>
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/aws-iam-authenticator
+ExecStart=/bin/cp \
+  /var/aws-iam-authenticator/heptio-authenticator-aws.kubeconfig \
+  <%= @auth_token_webhook_file %>
+
+[Install]
+WantedBy=multi-user.target

--- a/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
+++ b/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
@@ -5,6 +5,7 @@ After=network.target
 After=docker.service
 Requires=docker.service
 Before=kube-apiserver.service
+Type=oneshot
 <%= scope.function_template(['kubernetes/_systemd_unit.erb']) %>
 [Service]
 ExecStartPre=/bin/docker run \

--- a/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
+++ b/puppet/modules/kubernetes/templates/aws-iam-authenticator-init.service.erb
@@ -10,7 +10,7 @@ Before=kube-apiserver.service
 ExecStartPre=/bin/docker run \
   -u 0 -w /config \
   -v /var/aws-iam-authenticator/:/config:Z \
-  <%= scope['kubernetes::aws_iam_authenticator_image'] %> \
+  <%= scope['kubernetes::apiserver::aws_iam_authenticator_image'] %> \
   init -i <%= scope['kubernetes::cluster_name'] %>
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/aws-iam-authenticator
 ExecStart=/bin/cp \

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -140,6 +140,9 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @oidc_username_prefix -%>
   "--oidc-username-prefix=<%= @oidc_username_prefix %>" \
 <% end -%>
+<% if @_auth_token_webhook_file -%>
+  "--authentication-token-webhook-config-file=<%= @_auth_token_webhook_file %>" \
+<% end -%>
   --profiling=false \
 <% if @post_1_10 -%>
  "--tls-min-version=<%= @tls_min_version %>" \


### PR DESCRIPTION
Signed-off-by: Sean Turner <sean@secops.ltd>

**Creates a systemd unit for pre-creating the iam-authenticator configuration, applies this if configured to do so, and sets it to occur before the apiserver starts**:

```release-note
Adds puppet classes, tests, tarmak configuration options, and some documentation for initialising the AWS IAM Authenticator (via systemd) for use with the Kubernetes apiserver(s) - note this doesn't install aws-iam-authenticator to the resulting cluster.
```
