### PR TITLE
Adds update deploy permissions for metrics-server-nanny

### DIFF
--- a/puppet/modules/kubernetes_addons/templates/metrics-server-rbac.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/metrics-server-rbac.yaml.erb
@@ -78,8 +78,9 @@ rules:
   - deployments
   verbs:
   - get
-  - list
-  - watch
+  - update
+  resourceNames:
+  -  metrics-server
 ---
 <% if @version_before_1_8 -%>
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/puppet/modules/kubernetes_addons/templates/metrics-server.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/metrics-server.yaml.erb
@@ -36,7 +36,7 @@ metadata:
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   selector:
     matchLabels:

--- a/puppet/modules/kubernetes_addons/templates/metrics-server.yaml.erb
+++ b/puppet/modules/kubernetes_addons/templates/metrics-server.yaml.erb
@@ -36,7 +36,7 @@ metadata:
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
@@ -93,13 +93,6 @@ spec:
         - containerPort: 443
           name: https
           protocol: TCP
-        resources:
-          limits:
-            cpu: <%= @cpu %>
-            memory: <%= @mem %>
-          requests:
-            cpu: <%= @cpu %>
-            memory: <%= @mem %>
 <% unless @version_before_1_8 -%>
         volumeMounts:
         - name: tmp-dir


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

**What this PR does / why we need it**:
Adds update permissions to metrics-server-nanny so that it is able to change the metrics-server deployment.

```release-note
Adds deployment update permissions to metrics-server-nanny container
```

/assign @simonswine 
