### PR TITLE
Remove initializers apiserver admission plugin > 1.14

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -55,6 +55,7 @@ class kubernetes::apiserver(
   $tls_min_version = $::kubernetes::tls_min_version
   $tls_cipher_suites = $::kubernetes::tls_cipher_suites
 
+  $post_1_14 = versioncmp($::kubernetes::version, '1.14.0') >= 0
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
   $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
   $post_1_9 = versioncmp($::kubernetes::version, '1.9.0') >= 0
@@ -74,7 +75,9 @@ class kubernetes::apiserver(
   # Admission controllers cf. https://kubernetes.io/docs/admin/admission-controllers/
   if $admission_control == undef {
     $_admission_control = delete_undef_values([
-      $post_1_8 ? { true => 'Initializers', default => undef },
+      # The initializers admission plugin has been removed in 1.14 onward
+      # https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md
+      ($post_1_8 and !$post_1_14) ? { true => 'Initializers', default => undef },
       'NamespaceLifecycle',
       'LimitRanger',
       'ServiceAccount',

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -72,6 +72,24 @@ describe 'kubernetes::apiserver' do
       ]}
       it { should contain_file(service_file).with_content(/#{Regexp.escape('--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota')}/)}
     end
+
+    context 'default 1.13' do
+      let(:pre_condition) {[
+        """
+        class{'kubernetes': version => '1.13.0'}
+        """
+      ]}
+      it { should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodSecurityPolicy,NodeRestriction')}/)}
+    end
+
+    context 'default 1.14' do
+      let(:pre_condition) {[
+        """
+        class{'kubernetes': version => '1.14.0'}
+        """
+      ]}
+      it { should contain_file(service_file).with_content(/#{Regexp.escape('--enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodSecurityPolicy,NodeRestriction')}/)}
+    end
   end
 
   context 'storage backend' do


### PR DESCRIPTION
As per it's removal https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md


```release-note
Remove Initializers apiserver admission plugin for versions >= 1.14 
```
/assign @simonswine 