### PR TITLE
Increases vault max_lease_ttl to 5 years

### DIFF
--- a/puppet/modules/vault_server/templates/vault.hcl.erb
+++ b/puppet/modules/vault_server/templates/vault.hcl.erb
@@ -13,7 +13,7 @@ listener "tcp" {
 }
 
 default_lease_ttl = "168h"
-max_lease_ttl = "720h"
+max_lease_ttl = "43800h"
 disable_mlock = false
 
 cluster_name = "vault-<%= @environment %>"


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

/assign @simonswine 

```release-note
Increase vault's max_lease_ttl to 5 years
```
