### PR TITLE
fix typo in route53 file for dnsNameservers-zoneNameservers mismatch

### DIFF
--- a/pkg/tarmak/provider/amazon/route53.go
+++ b/pkg/tarmak/provider/amazon/route53.go
@@ -133,7 +133,7 @@ func (a *Amazon) verifyPublicZone() error {
 	sort.Strings(zoneNameservers)
 
 	if !reflect.DeepEqual(dnsNameservers, zoneNameservers) {
-		return fmt.Errorf("public root dns namesevers %v and zone nameservers %v mismatch", dnsNameservers, zoneNameservers)
+		return fmt.Errorf("public root dns nameservers %v and zone nameservers %v mismatch", dnsNameservers, zoneNameservers)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It fixes a typo in the code when an error condition becomes true

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
