### PR TITLE
Enable support for bound service account token

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -29,6 +29,7 @@ class kubernetes::apiserver(
   $ca_file = undef,
   $cert_file = undef,
   $key_file = undef,
+  String $service_account_issuer ='kubernetes.default.svc',
   Optional[String] $oidc_client_id = undef,
   Optional[String] $oidc_groups_claim = undef,
   Optional[String] $oidc_groups_prefix = undef,
@@ -56,6 +57,7 @@ class kubernetes::apiserver(
   $tls_cipher_suites = $::kubernetes::tls_cipher_suites
 
   $post_1_14 = versioncmp($::kubernetes::version, '1.14.0') >= 0
+  $post_1_12 = versioncmp($::kubernetes::version, '1.12.0') >= 0
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
   $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
   $post_1_9 = versioncmp($::kubernetes::version, '1.9.0') >= 0

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -323,6 +323,31 @@ describe 'kubernetes::apiserver' do
     end
   end
 
+  context 'bound service token flags' do
+    context 'with kubernetes 1.12+' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.12.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+        """
+      ]}
+      it do
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+      end
+    end
+    context 'with kubernetes before 1.12' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.11.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+        """
+      ]}
+      it do
+        should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=')}/)
+      end
+    end
+  end
+
   context 'feature gates' do
     context 'without given feature gates and not enabled pod priority' do
       let(:params) { {'feature_gates' => {}}}

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -92,6 +92,10 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <%- if scope['kubernetes::_service_account_key_file'] -%>
   --service-account-key-file=<%= scope['kubernetes::_service_account_key_file'] %> \
   --service-account-lookup \
+<% if @post_1_12 -%>
+ "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
+ "--service-account-issuer=<%= @service_account_issuer %>" \
+<% end -%>
 <% end -%>
 <% if @_feature_gates && @_feature_gates.length > 0 -%>
   --feature-gates=<% g = @_feature_gates.to_a.collect{|k| k.join('=')}.join(',') -%><%= g %> \

--- a/puppet/modules/tarmak/manifests/master.pp
+++ b/puppet/modules/tarmak/manifests/master.pp
@@ -141,6 +141,7 @@ class tarmak::master(
       proxy_client_cert_file       => $proxy_client_cert_file ,
       proxy_client_key_file        => $proxy_client_key_file,
       encryption_config_file       => $encryption_config_file,
+      service_account_issuer       => "https://${::tarmak::kubernetes_api_prefix}.${::tarmak::cluster_name}.${::tarmak::dns_root}",
   }
 
   class { 'kubernetes::controller_manager':


### PR DESCRIPTION
Allows to use beta feature for requesting scoped tokens from the API. Beta from 1.12+. It is enabled in GKE (not in kubeadm)

```release-note
Enable support for bound service account token
```
