### PR TITLE
Enable support for bound service account tokens fix

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -30,6 +30,7 @@ class kubernetes::apiserver(
   $cert_file = undef,
   $key_file = undef,
   String $service_account_issuer ='kubernetes.default.svc',
+  Optional[Array[String]] $service_account_api_audiences = undef,
   Optional[String] $oidc_client_id = undef,
   Optional[String] $oidc_groups_claim = undef,
   Optional[String] $oidc_groups_prefix = undef,
@@ -72,6 +73,12 @@ class kubernetes::apiserver(
     $_audit_enabled = $post_1_8
   } else {
     $_audit_enabled = $audit_enabled
+  }
+
+  if $service_account_api_audiences == undef {
+    $_service_account_api_audiences = [$service_account_issuer]
+  } else {
+    $_service_account_api_audiences = $service_account_api_audiences
   }
 
   # Admission controllers cf. https://kubernetes.io/docs/admin/admission-controllers/

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -58,6 +58,7 @@ class kubernetes::apiserver(
   $tls_cipher_suites = $::kubernetes::tls_cipher_suites
 
   $post_1_14 = versioncmp($::kubernetes::version, '1.14.0') >= 0
+  $post_1_13 = versioncmp($::kubernetes::version, '1.13.0') >= 0
   $post_1_12 = versioncmp($::kubernetes::version, '1.12.0') >= 0
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
   $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -29,6 +29,7 @@ class kubernetes::apiserver(
   $ca_file = undef,
   $cert_file = undef,
   $key_file = undef,
+  String $service_account_issuer ='kubernetes.default.svc',
   Optional[String] $oidc_client_id = undef,
   Optional[String] $oidc_groups_claim = undef,
   Optional[String] $oidc_groups_prefix = undef,
@@ -56,6 +57,7 @@ class kubernetes::apiserver(
   $tls_cipher_suites = $::kubernetes::tls_cipher_suites
 
   $post_1_14 = versioncmp($::kubernetes::version, '1.14.0') >= 0
+  $post_1_12 = versioncmp($::kubernetes::version, '1.12.0') >= 0
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
   $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0
   $post_1_9 = versioncmp($::kubernetes::version, '1.9.0') >= 0

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -333,6 +333,20 @@ describe 'kubernetes::apiserver' do
       it do
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc')}/)
+      end
+    end
+    context 'with kubernetes 1.12+ with custom audiences' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.12.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+            class{'kubernetes::apiserver': service_account_api_audiences => ['kubernetes.default.svc', 'my.custom.aud.svc']}
+        """
+      ]}
+      it do
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc,my.custom.aud.svc')}/)
       end
     end
     context 'with kubernetes before 1.12' do
@@ -344,6 +358,7 @@ describe 'kubernetes::apiserver' do
       it do
         should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
         should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=')}/)
+        should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=')}/)
       end
     end
   end

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -323,6 +323,31 @@ describe 'kubernetes::apiserver' do
     end
   end
 
+  context 'bound service token flags' do
+    context 'with kubernetes 1.12+' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.12.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+        """
+      ]}
+      it do
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+      end
+    end
+    context 'with kubernetes before 1.12' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.11.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+        """
+      ]}
+      it do
+        should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=')}/)
+      end
+    end
+  end
+
   context 'feature gates' do
     context 'without given feature gates and not enabled pod priority' do
       let(:params) { {'feature_gates' => {}}}

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -336,7 +336,7 @@ describe 'kubernetes::apiserver' do
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc')}/)
       end
     end
-    context 'with kubernetes 1.12+ with custom audiences' do
+    context 'with kubernetes 1.12+ and less then 1.13+ with custom audiences' do
       let(:pre_condition) {[
         """
             class{'kubernetes': version => '1.12.0', service_account_key_file => '/etc/kubernetes/sa.key'}
@@ -347,6 +347,19 @@ describe 'kubernetes::apiserver' do
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc,my.custom.aud.svc')}/)
+      end
+    end
+    context 'with kubernetes 1.13+ with custom audiences' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.13.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+            class{'kubernetes::apiserver': service_account_api_audiences => ['kubernetes.default.svc', 'my.custom.aud.svc']}
+        """
+      ]}
+      it do
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--api-audiences=kubernetes.default.svc,my.custom.aud.svc')}/)
       end
     end
     context 'with kubernetes before 1.12' do

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -95,7 +95,11 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @post_1_12 -%>
  "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
  "--service-account-issuer=<%= @service_account_issuer %>" \
+<% if !@post_1_13 -%>
   --service-account-api-audiences=<%= @_service_account_api_audiences.join(',') %> \
+<% else -%>
+  --api-audiences=<%= @_service_account_api_audiences.join(',') %> \
+<% end -%>
 <% end -%>
 <% end -%>
 <% if @_feature_gates && @_feature_gates.length > 0 -%>

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -95,6 +95,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @post_1_12 -%>
  "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
  "--service-account-issuer=<%= @service_account_issuer %>" \
+  --service-account-api-audiences=<%= @_service_account_api_audiences.join(',') %> \
 <% end -%>
 <% end -%>
 <% if @_feature_gates && @_feature_gates.length > 0 -%>

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -95,10 +95,10 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @post_1_12 -%>
  "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
  "--service-account-issuer=<%= @service_account_issuer %>" \
-<% if !@post_1_13 -%>
-  --service-account-api-audiences=<%= @_service_account_api_audiences.join(',') %> \
-<% else -%>
+<% if @post_1_13 -%>
   --api-audiences=<%= @_service_account_api_audiences.join(',') %> \
+<% else -%>
+  --service-account-api-audiences=<%= @_service_account_api_audiences.join(',') %> \
 <% end -%>
 <% end -%>
 <% end -%>

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -92,6 +92,10 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <%- if scope['kubernetes::_service_account_key_file'] -%>
   --service-account-key-file=<%= scope['kubernetes::_service_account_key_file'] %> \
   --service-account-lookup \
+<% if @post_1_12 -%>
+ "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
+ "--service-account-issuer=<%= @service_account_issuer %>" \
+<% end -%>
 <% end -%>
 <% if @_feature_gates && @_feature_gates.length > 0 -%>
   --feature-gates=<% g = @_feature_gates.to_a.collect{|k| k.join('=')}.join(',') -%><%= g %> \

--- a/puppet/modules/tarmak/manifests/master.pp
+++ b/puppet/modules/tarmak/manifests/master.pp
@@ -141,6 +141,7 @@ class tarmak::master(
       proxy_client_cert_file       => $proxy_client_cert_file ,
       proxy_client_key_file        => $proxy_client_key_file,
       encryption_config_file       => $encryption_config_file,
+      service_account_issuer       => "https://${::tarmak::kubernetes_api_prefix}.${::tarmak::cluster_name}.${::tarmak::dns_root}",
   }
 
   class { 'kubernetes::controller_manager':


### PR DESCRIPTION
/assign @simonswine
We use `--service-account-api-audiences` for 1.12.x and `--api-audiences` for 1.13.

```release-note
Enables bound service account tokens for Kubernetes 1.12+
```
