### PR TITLE
Automated cherry pick of #828

### DIFF
--- a/terraform/amazon/modules/vault/tls.tf
+++ b/terraform/amazon/modules/vault/tls.tf
@@ -65,6 +65,9 @@ resource "tls_locally_signed_cert" "vault" {
   # 1 year
   validity_period_hours = 8766
 
+  # mark the certificate for renewal 30 days before expiry
+  early_renewal_hours = 720
+
   allowed_uses = [
     "key_encipherment",
     "digital_signature",


### PR DESCRIPTION
Cherry pick of #828 on release-0.6.

#828: Mark the vault certificates to be renewed 30 days before